### PR TITLE
Allow `shell` language for syntax highlighting.

### DIFF
--- a/src/utils/syntax-highlight.js
+++ b/src/utils/syntax-highlight.js
@@ -29,6 +29,7 @@ const Languages = {
   python: ['py', 'gyp', 'ipython'],
   ruby: ['rb', 'gemspec', 'podspec', 'thor', 'irb'],
   scss: [],
+  shell: ['console', 'shellsession'],
   swift: [],
   xml: ['html', 'xhtml', 'rss', 'atom', 'xjb', 'xsd', 'xsl', 'plist', 'wsf', 'svg'],
 };
@@ -78,7 +79,7 @@ async function importHighlightFileForLanguage(language) {
         languageFile = await import(
           /* webpackChunkName: "highlight-js-[request]" */
           // eslint-disable-next-line max-len
-          /* webpackInclude: /\/(bash|c|s?css|cpp|diff|http|java|llvm|perl|php|python|ruby|xml|javascript|json|markdown|objectivec|swift)\.js$/ */
+          /* webpackInclude: /\/(bash|c|s?css|cpp|diff|http|java|llvm|perl|php|python|ruby|xml|javascript|json|markdown|objectivec|shell|swift)\.js$/ */
           `highlight.js/lib/languages/${file}`
         );
       }


### PR DESCRIPTION
Bug/issue #, if applicable: 83398865

## Summary

Adds support for syntax highlighting code listings using the `"shell"` language as implemented by highlight.js.

## Testing

Steps:
1. Create an example shell code listing like the one listed below in a documentation bundle. (Use a fenced code block with `shell` as the language).
2. Build this branch with `npm run build` and note that `dist/js` contains a new file for the "shell" language.
3. Run `DOCC_HTML_DIR=/path/to/swift-docc-render/dist docc preview /path/to/bundle.docc`.
4. Verify that the listing is now highlighted (the `%` prompt in this example should now have color).

```shell
% cd blah/
% ls
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] ~~Added tests~~ (config only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
