### PR TITLE
Make relationship column spacing flush with other items

### DIFF
--- a/src/components/DocumentationTopic/RelationshipsList.vue
+++ b/src/components/DocumentationTopic/RelationshipsList.vue
@@ -125,13 +125,11 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-$bullet-margin: 0.5em;
-
 .relationships-list {
   list-style: none;
 
   &.column {
-    margin: 0 0 0 $bullet-margin;
+    margin: 0;
   }
 
   // The "inline" style displays items on a single line as a


### PR DESCRIPTION
Bug/issue #, if applicable: 71427784

## Summary

Removes the extra spacing of column relationships.

![image](https://user-images.githubusercontent.com/9863944/137516462-db72c09a-5935-4494-8651-5c4a00419c2c.png)


## Dependencies

NA

## Testing

Use the provided fixture folder.

[manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/7354481/manual-fixtures.zip)

Steps:
1. Point to a bundle that has RelationshipsList data in one of its symbols - `VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures npm run serve`.
1. Go to `http://localhost:8081/documentation/framework/sample`
1. Assert the ConformsTo section is aligned with the rest of the items.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests - no, css only~
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
