### PR TITLE
Prevent ruled lines from showing up in Split View mode on Tutorials pages

### DIFF
--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -144,7 +144,11 @@ export default {
 
 .highlighted {
   background: var(--line-highlight, var(--color-code-line-highlight));
-  box-shadow: inset 4px 0 0 0 var(--color-code-line-highlight-border);
+  border-left: $highlighted-border-width solid var(--color-code-line-highlight-border);
+
+  .code-number {
+    padding-left: $code-number-padding-left - $highlighted-border-width;
+  }
 }
 
 pre {

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -33,7 +33,9 @@ $topic-link-icon-spacing: 0.5em;
 // Code Block Style Elements
 $code-block-style-elements-padding: 8px 14px !default;
 $code-listing-with-numbers-padding: 14px 0;
-$code-number-padding: 0 1rem 0 8px;
+$code-number-padding-left: 8px;
+$code-number-padding: 0 1rem 0 $code-number-padding-left;
+$highlighted-border-width: 4px;
 
 // Declaration components
 $code-source-spacing: 0.588rem;


### PR DESCRIPTION
Bug/issue #78336370, if applicable: 

## Summary

Prevent ruled lines from showing up in Split View mode on Tutorials pages

<img width="1049" alt="2b12ac80-304a-11ec-919f-50cc1640e2f4" src="https://user-images.githubusercontent.com/8567677/137941588-02b6d4f2-508c-4c32-983b-4a27af475601.png">

## Dependencies

NA

## Testing

Use the provided fixture folder:

[manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/7374590/manual-fixtures.zip)

Steps:
1. Open the Simulator app and set the Split View mode (as in the screenshot of the Summary) in an iPad 8
2. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures/ npm run serve`
3. Go to http://localhost:8080/tutorials/slothcreator/creating-custom-sloths
4. Assert that rules lines are not shown

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests (Not needed)
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
