### PR TITLE
Prevent custom `scrollBehavior` function to return undefined

### DIFF
--- a/src/utils/router-utils.js
+++ b/src/utils/router-utils.js
@@ -47,7 +47,7 @@ export async function scrollBehavior(to, from, savedPosition) {
   }
   if (areEquivalentLocations(to, from)) {
     // Do not change the scroll position if the location hasn't changed.
-    return undefined;
+    return false;
   }
   return { x: 0, y: 0 };
 }

--- a/tests/unit/utils/router-utils.spec.js
+++ b/tests/unit/utils/router-utils.spec.js
@@ -88,10 +88,10 @@ describe('router-utils', () => {
       });
     });
 
-    it('resolves as undefined if two urls are the same and have no `hash`', async () => {
+    it('resolves as false if two urls are the same and have no `hash`', async () => {
       const noHashUrl = createRoute('foo', {});
       const resolved = await scrollBehavior(noHashUrl, noHashUrl);
-      expect(resolved).toEqual(undefined);
+      expect(resolved).toEqual(false);
     });
 
     it('resolves with `{ x: 0, y: 0 }` if new url without hash', async () => {


### PR DESCRIPTION
Bug/issue #83137437, if applicable: 

## Summary

Vue Router 3.5.2 introduced [this commit](https://github.com/vuejs/vue-router/commit/4e0b3e03862bde23851c83c3e2fb647dfcf23efe#diff-665f767c626278dc1a3b196044efeb9f55ac990a3e5c51415ec73837bc142dabR169) where you can see that `behaviour`’s key is assigned to the `behaviour` property of `shouldScroll`.

`shouldScroll` is the result of calling `scrollBehavior` with different router params. We are overwriting the `scrollBehavior` function in Swift-DocC-Render and it should never return `undefined`.

## Dependencies

NA

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
