### PR TITLE
Force the Y scrollbar to always appear to prevent jumping issues in Safari

### DIFF
--- a/src/utils/scroll-lock.js
+++ b/src/utils/scroll-lock.js
@@ -10,6 +10,7 @@
 
 let isLocked = false;
 let initialClientY = -1;
+let scrolledClientY = 0;
 
 const isIosDevice = () => window.navigator
   && window.navigator.platform
@@ -43,7 +44,16 @@ const isTargetElementTotallyScrolled = targetElement => (
  * A simple locking, that works for the majority of browsers
  */
 function simpleLock() {
-  document.body.style.overflow = 'hidden';
+  // save scrolled Y position when locking
+  scrolledClientY = document.body.getBoundingClientRect().top;
+  // force the Y scrollbar to always appear to prevent jumping issues
+  document.body.style.overflow = 'hidden scroll';
+  // add scrolled Y position to body top before changing the position property
+  document.body.style.top = `${scrolledClientY}px`;
+  // limit the vertical height by fixing the position
+  document.body.style.position = 'fixed';
+  // force body to expand to its whole width
+  document.body.style.width = '100%';
 }
 
 /**
@@ -138,6 +148,9 @@ export default {
     } else {
       // remove all inline styles
       document.body.style.cssText = '';
+
+      // restore scrolled Y position after resetting the position property
+      window.scrollTo(0, Math.abs(scrolledClientY));
     }
     isLocked = false;
   },


### PR DESCRIPTION
Bug/issue #78781490, if applicable: 

## Summary

When a user opens the navbar in Safari while having scrollbars macOS conf as “Always”, the scrollbar in the right side disappears—because we locked the scrolling.

Safari doesn't include scrollbars in media query width—the rest of the browsers do—so when scrollbars disappears the media query is triggered and it closes the navbar creating this jumpy bug.

I fixed this bug by forcing the Y scrollbar to always appear but limiting the vertical height at the same time, fixing the position so scrolling won't happen when it's locked, only an empty scrollbar will be visible.

| Before      | After |
| ----------- | ----------- |
| ![before](https://user-images.githubusercontent.com/8567677/138262219-ba73a740-0904-46a1-ae2e-1226dcaadc3c.gif) | ![after](https://user-images.githubusercontent.com/8567677/138262318-64564158-df1d-49eb-a6d6-035e22c13915.gif) |

## Dependencies

NA

## Testing

Use the provided fixture folder:

[manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/7388297/manual-fixtures.zip)

Steps:
1. Open "System Preferences" -> "General" -> "Show scroll bars" and click on "Always"
2. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures/ npm run serve`
3. Open Safari and go to http://localhost:8080/documentation/framework/sloth
3. Go to responsive Design Mode and set the width to 1024px
4. Assert that when clicking the navbar chevron there isn't a jumpy bug

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary