### PR TITLE
Fix tutorial mobile code-listing background color contrast

### DIFF
--- a/src/components/Tutorial/MobileCodePreview.vue
+++ b/src/components/Tutorial/MobileCodePreview.vue
@@ -114,7 +114,7 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .mobile-code-preview {
-  background-color: var(--background, var(--color-code-background));
+  background-color: var(--background, var(--color-step-background));
   padding: $code-listing-with-numbers-padding;
 
   @include breakpoint(small) {


### PR DESCRIPTION
Bug/issue #, if applicable: 81556679

## Summary

Fixes the background color for mobile tutorial code previews to match the desktop color. Otherwise the background may not have enough contrast with highlighted lines.

## Dependencies

NA

## Testing

[manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/7410592/manual-fixtures.zip)


Steps:
1. Use the manual fixtures
1. Go to http://localhost:8080/tutorials/testbed/tutorial
2. Use a mobile device size
3. Assert the mobile preview code-listing background color is the same as the desktop preview color, and the contrast between highlighted line and background is the same.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - no need, css only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
