### PR TITLE
[DO NOT MERGE] [Bug Fix] navigation dropdown bold issue(SR-15313)

### DIFF
--- a/src/components/Tutorial/NavigationBar/MobileDropdown.vue
+++ b/src/components/Tutorial/NavigationBar/MobileDropdown.vue
@@ -38,7 +38,9 @@
               >
                 {{ tutorialTitle }}
               </router-link>
-              <ul v-if="tutorialUrl === $route.path" class="section-list" role="listbox">
+              <ul v-if="tutorialUrl === $route.path.toLowerCase()"
+                  class="section-list"
+                  role="listbox">
                 <li
                   v-for="section in sections"
                   :key="section.title"

--- a/src/components/Tutorial/NavigationBar/PrimaryDropdown.vue
+++ b/src/components/Tutorial/NavigationBar/PrimaryDropdown.vue
@@ -52,14 +52,15 @@
                 <router-link
                   :to="urlWithParams"
                   custom
-                  #default="{ navigate, isActive }"
+                  #default="{ navigate }"
                 >
                   <li
-                    :class="{ [OptionClass]: true, [ActiveOptionClass]: isActive }"
+                    :class="{ [OptionClass]: true,
+                              [ActiveOptionClass]: urlWithParams === $route.path.toLowerCase()}"
                     role="option"
                     :value="title"
-                    :aria-selected="isActive"
-                    :aria-current="isActive ? 'tutorial': false"
+                    :aria-selected="urlWithParams === $route.path.toLowerCase()"
+                    :aria-current="urlWithParams === $route.path.toLowerCase() ? 'tutorial': false"
                     :tabindex="-1"
                     @click="setActive(navigate, closeDropdown, $event)"
                     @keydown.enter="setActive(navigate, closeDropdown, $event)"


### PR DESCRIPTION
Issue [SR-15313](https://bugs.swift.org/browse/SR-15313)
## Summary

- Primary tutorial navigation dropdown fails to bold the current tutorial when browser URL is not lowercased (SR-15313)
	- The "isActive" from router-link will be false since it tricks "/about" and "/abouT" are not active. And it seems hard for us to change the override the compare logic behind router-link to a case-insensitive one.
	- So I use the same method in `MobileDropdown.vue` to check "currentOption === ⌥.title" as isActive condition
```js
// vue-router version 3.5.3 /src/components/link.js line 79
classes[exactActiveClass] = isSameRoute(current, compareTarget, this.exactPath)
classes[activeClass] = this.exact || this.exactPath
  ? classes[exactActiveClass]
  : isIncludedRoute(current, compareTarget)
```
```js
// vue-router version 3.5.3 /src/utils/route.js line 119
export function isIncludedRoute (current: Route, target: Route): boolean {
  return (
    current.path.replace(trailingSlashRE, '/').indexOf(
      target.path.replace(trailingSlashRE, '/')
    ) === 0 &&
    (!target.hash || current.hash === target.hash) &&
    queryIncludes(current.query, target.query)
  )
}
```
- Mobile tutorial navigation dropdown fails to list its child when browser URL is not lowercased
	- Change the if check to `tutorialUrl === $route.path.toLowerCase()` to make sure the condition is true when navigating to an UPPER-CASE or Mix-case one.

## Testing

Navigating to: http://localhost:8000/tutorials/slothcreator/CREATING-CUSTOM-SLOTHS in the attached documentation catalog.(See the SR-15313's attachment) in normal mode and mobile mode(width less than some value will enter this mode) respectively.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Ran `npm test`, and it succeeded
`[Vue warn]: Error in render: "TypeError: Cannot read property 'toLowerCase' of undefined"`