### PR TITLE
Prevent custom-header from rendering, if header slot is used

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,8 +15,10 @@
   >
     <a href="#main" id="skip-nav">Skip Navigation</a>
     <InitialLoadingPlaceholder />
-    <custom-header v-if="hasCustomHeader" :data-color-scheme="preferredColorScheme" />
-    <slot name="header" :isTargetIDE="isTargetIDE" />
+    <slot name="header" :isTargetIDE="isTargetIDE">
+      <!-- Render the custom header by default, if there is no content in the `header` slot -->
+      <custom-header v-if="hasCustomHeader" :data-color-scheme="preferredColorScheme" />
+    </slot>
     <!-- The nav sticky anchor has to always be between the Header and the Content -->
     <div :id="baseNavStickyAnchorId" />
     <slot :isTargetIDE="isTargetIDE">

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -280,6 +280,16 @@ describe('App', () => {
         expect(header.exists()).toBe(true);
         expect(header.attributes('data-color-scheme')).toBeDefined();
       });
+
+      it('does not render a <custom-header>, if a header slot is passed', () => {
+        wrapper = createWrapper({
+          slots: {
+            header: '<div class="header">Header</div>',
+          },
+        });
+        const header = wrapper.find('custom-header-stub');
+        expect(header.exists()).toBe(false);
+      });
     });
 
     it('renders a <custom-footer> if one has been defined', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 82736354

## Summary

Stops the `<custom-header>` element from being rendered, if the `header` slot is used. This prevents the UI from rendering two header elements at once.

This may happen, when you have a theme that extends `swift-docc-render` with it's own header, and are previewing a doc bundle, that has a custom `header.html` file.

## Dependencies

NA

## Testing

Steps:
1. Create a Vue app that extends this branch of `swift-docc-render` as a theme.
2. Define a custom header that is rendered via the `header` slot of `docc-render/App.vue`
3. Run `npm run build` on your theme.
4. Using `swift-docc`, preview a bundle, that has a custom `header.html` file, while pointing to the just-built docc-render theme - `DOCC_HTML_DIR=/path/to/theme/dist docc preview`
4. Assert that the browser renders only your theme's header, and not the `custom-header` element from the docc bundle.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
