### PR TITLE
Fix quiz button width, when navigating from tutorial to docs and back

### DIFF
--- a/src/components/Tutorial/Assessments/Quiz.vue
+++ b/src/components/Tutorial/Assessments/Quiz.vue
@@ -189,13 +189,13 @@ export default {
 .controls {
   text-align: center;
   margin-bottom: 40px;
-}
 
-.button-cta {
-  margin: 0.5rem;
-  margin-top: 0;
-  padding: 0.3rem 3rem;
-  min-width: 8rem;
+  .button-cta {
+    margin: 0.5rem;
+    margin-top: 0;
+    padding: 0.3rem 3rem;
+    min-width: 8rem;
+  }
 }
 
 // hide the checkbox


### PR DESCRIPTION
Bug/issue #, if applicable: 82666933

## Summary

Fixes a small CSS specificity issue, where styles from the docs are overwriting the ones from Tutorials/Quiz.vue, for the ButtonLink component.

## Dependencies

NA

## Testing

You can use the bundle attached:

[public.zip](https://github.com/apple/swift-docc-render/files/7453563/public.zip)

Steps:
1. run `VUE_APP_DEV_SERVER_PROXY=path/to/unzipped/bundle npm run serve`
2. go to http://localhost:8080/tutorials/slothcreator/creating-custom-sloths
3. Assert buttons are big
4. Click on the `Sloth` link in the header of the page
5. Go back
6. Assert the buttons are still big.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - no need, css only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
