### PR TITLE
Make `ReplayableVideoAsset.replay` asynchronous

### DIFF
--- a/src/components/ReplayableVideoAsset.vue
+++ b/src/components/ReplayableVideoAsset.vue
@@ -19,6 +19,7 @@
     />
     <a
       class="replay-button"
+      href="#"
       :class="{ visible: this.showsReplayButton }"
       @click.prevent="replay"
     >
@@ -58,13 +59,13 @@ export default {
     };
   },
   methods: {
-    replay() {
+    async replay() {
       const videoPlayer = this.$refs.asset.$el;
       if (videoPlayer) {
         this.showsReplayButton = false;
         // Start video playback from the beginning.
         videoPlayer.currentTime = 0;
-        videoPlayer.play();
+        await videoPlayer.play();
       }
     },
     onVideoEnd() {

--- a/tests/unit/components/ReplayableVideoAsset.spec.js
+++ b/tests/unit/components/ReplayableVideoAsset.spec.js
@@ -30,7 +30,7 @@ describe('ReplayableVideoAsset', () => {
     },
   });
 
-  const playMock = jest.fn();
+  const playMock = jest.fn().mockResolvedValue(undefined);
 
   beforeAll(() => {
     window.matchMedia = () => ({ matches: false });
@@ -69,11 +69,12 @@ describe('ReplayableVideoAsset', () => {
     expect(replayButton.classes('visible')).toBe(false);
   });
 
-  it('plays the video if replay button is clicked', () => {
+  it('plays the video if replay button is clicked', async () => {
     const wrapper = mountWithProps();
 
     expect(playMock).toHaveBeenCalledTimes(0);
     wrapper.find('.replay-button').trigger('click');
+    await playMock;
     expect(playMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/components/ReplayableVideoAsset.spec.js
+++ b/tests/unit/components/ReplayableVideoAsset.spec.js
@@ -12,6 +12,7 @@ import { shallowMount } from '@vue/test-utils';
 import ReplayableVideoAsset from 'docc-render/components/ReplayableVideoAsset.vue';
 import VideoAsset from 'docc-render/components/VideoAsset.vue';
 import InlineReplayIcon from 'theme/components/Icons/InlineReplayIcon.vue';
+import { flushPromises } from '../../../test-utils';
 
 const variants = [{ traits: ['dark', '1x'], url: 'https://www.example.com/myvideo.mp4' }];
 
@@ -74,7 +75,7 @@ describe('ReplayableVideoAsset', () => {
 
     expect(playMock).toHaveBeenCalledTimes(0);
     wrapper.find('.replay-button').trigger('click');
-    await playMock;
+    await flushPromises();
     expect(playMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 78842177

## Summary

Since `HTMLMediaElement.play()` returns a `Promise` (in recent browsers)[1][1], the method calling it should ideally be an asynchronous function to avoid any potential race conditions.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play

## Testing

Steps:
1. Checkout this branch and use `npm run build` to build this version of DocC-Render.
2. Configure `DOCC_HTML_DIR=/path/to/built/dist` and use DocC to compile a documentation catalog that has tutorials with video content in its sections.
3. Ensure that after section videos play, they can always be replayed using the "Replay" link.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests (updated)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
