### PR TITLE
Update highlight.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7545,9 +7545,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-      "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.3.1.tgz",
+      "integrity": "sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw=="
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "core-js": "^3.8.2",
-    "highlight.js": "^11.0.0",
+    "highlight.js": "^11.3.1",
     "intersection-observer": "0.12.0",
     "portal-vue": "2.1.7",
     "webpack-theme-resolver-plugin": "3.0.0"


### PR DESCRIPTION
Bug/issue #, if applicable: 80600825

## Summary

Update the highlight.js dependency to its latest version (v11.3.1).

## Testing

Add the following example Swift code listing to some existing documentation.

```swift
actor Foo {
  nonisolated func bar() {}
}
```

Verify that the `nonisolated` keyword is highlighted with the same pink color as the `func` keyword when rendering that documentation with this branch of DocC-Render.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests, none needed
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
