### PR TITLE
Make "required" property inline with content, on all Rest type sections.

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/RestBody.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestBody.vue
@@ -155,4 +155,14 @@ export default {
 .part-name {
   font-weight: $font-weight-bold;
 }
+
+// The inline display is needed here to allow the optional "Required" text to
+// prefix the actual paragraph of any text.
+.content {
+  display: inline;
+
+  /deep/ p:first-child {
+    display: inline;
+  }
+}
 </style>

--- a/src/components/DocumentationTopic/PrimaryContent/RestParameters.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestParameters.vue
@@ -107,4 +107,14 @@ export default {
 .param-deprecated {
   margin-left: 0;
 }
+
+// The inline display is needed here to allow the optional "Required" text to
+// prefix the actual paragraph of any text.
+.content {
+  display: inline;
+
+  /deep/ p:first-child {
+    display: inline;
+  }
+}
 </style>


### PR DESCRIPTION
Bug/issue #, if applicable: 78800815

## Summary

Ensures that the `required `and `deprecated` visual properties are always inline with the content of various REST components.

![image](https://user-images.githubusercontent.com/9863944/140323669-bbdff070-7976-4046-901e-7a2ef8ef91fa.png)

## Dependencies

NA

## Testing

Use the provided fixtures

[rest-parameters.json.zip](https://github.com/apple/swift-docc-render/files/7475154/rest-parameters.json.zip)

1. RestParameters - Ensure `required` is inline - http://localhost:8080/documentation/framework/rest-parameters
2. RestBody - Ensure `required` is inline - http://localhost:8080/documentation/framework/rest-parameters

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests - no need, css only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
