### PR TITLE
Adds extra space to the right of scrollable code-listings

### DIFF
--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -174,6 +174,7 @@ code {
 
 .code-line-container {
   flex-shrink: 0;
+  padding-right: 14px;
 }
 
 .code-listing,

--- a/src/components/ContentNode/CollapsibleCodeListing.vue
+++ b/src/components/ContentNode/CollapsibleCodeListing.vue
@@ -71,6 +71,7 @@ code {
   display: flex;
   border-left: 4px solid transparent;
   counter-increment: linenumbers;
+  padding-right: 14px;
 }
 
 .code-number {

--- a/src/components/DocumentationTopic/ContentNode.vue
+++ b/src/components/DocumentationTopic/ContentNode.vue
@@ -45,6 +45,8 @@ $docs-code-listing-border-width: 1px !default;
 
     pre {
       padding: $code-block-style-elements-padding;
+      // setting it to 0 prevents browsers from adding extra right spacing, when having scrollbar
+      padding-right: 0;
 
       > code {
         @include font-styles(documentation-code-listing);


### PR DESCRIPTION
Bug/issue #, if applicable: 76070767

## Summary

Adds a space to the scrollable code-listings, both on mobile and desktop. This fixes issues with code-listings flush to the right of the screen, when they are scrolled to the end.


## Dependencies

NA

## Testing

Use the added fixture - [public.zip](https://github.com/apple/swift-docc-render/files/7499081/public.zip)
 
Steps:
1. Go to `/tutorials/slothcreator/creating-custom-sloths` from the uploaded JSON
2. Make sure the code-listings have enough space on the right when they are scrollable horizontally. 
3. Go to `/documentation/framework/sloth`
4. Make sure all codelistings have enough space when scrolled.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests - css only, no need
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
