### PR TITLE
White runtime preview's image should be differentiated from white code background in Tutorials when dark mode

### DIFF
--- a/src/components/Tutorial/CodePreview.vue
+++ b/src/components/Tutorial/CodePreview.vue
@@ -204,6 +204,7 @@ $duration: 0.2s;
 .code-preview {
   position: sticky;
   @include overflow-y;
+  background-color: var(--background, var(--color-step-background));
 
   $height-ide: 100vh;
   height: calc(#{$height-ide} - #{$nav-height});
@@ -255,7 +256,6 @@ $duration: 0.2s;
   top: 0;
   right: 0;
   background: var(--color-runtime-preview-background);
-  box-shadow: 0px 0px 3px 0px var(--color-runtime-preview-shadow);
   border-radius: $border-radius;
   margin: $preview-margin;
   margin-left: 0;
@@ -267,6 +267,21 @@ $duration: 0.2s;
   @supports not (width: stretch) {
     display: flex;
     flex-direction: column;
+  }
+
+  &::before {
+    box-shadow: 0px 0px 3px 0px var(--color-runtime-preview-shadow);
+    border-radius: $border-radius;
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+
+    @include prefers-dark {
+      mix-blend-mode: difference;
+    }
   }
 }
 


### PR DESCRIPTION
Bug/issue #80957132, if applicable: 

## Summary

White runtime preview's image should be differentiated from white code background in Tutorials when dark mode.

When modalBackgroundColor computed property returns white in dark mode, the shadow of preview images cannot be noticed. To fix it I applied a mix blend mode CSS property to make the preview image's shadow always contrasted with whatever code background color it has.

### Before
<img width="1980" alt="Screenshot 2021-11-09 at 3 07 19 PM" src="https://user-images.githubusercontent.com/8567677/140938845-6863dc76-080d-481f-9d50-594315c48ccf.png">

### After
<img width="1980" alt="Screenshot 2021-11-09 at 3 06 51 PM" src="https://user-images.githubusercontent.com/8567677/140938873-666ed9a9-0581-4582-a89b-0188f0f9423a.png">


## Dependencies

NA

## Testing

Use the provided fixture folder:
[manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/7505297/manual-fixtures.zip)


Steps:
1. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures/ npm run serve`
2. Go to http://localhost:8080/tutorials/slothcreator/creating-custom-sloths
3. Change to dark mode
3. Add the custom property `--background: white;` locally in the browser
4. Assert that runtime preview's shadow is visible over the white code background

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary