### PR TITLE
Update URL in declaration to support external links

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/TypeIdentifierLink.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/TypeIdentifierLink.vue
@@ -10,7 +10,7 @@
 
 <script>
 // This component renders token text as a link to a given type.
-import { buildUrl } from 'docc-render/utils/url-helper';
+import Reference from 'docc-render/components/ContentNode/Reference.vue';
 
 export default {
   name: 'TypeIdentifierLink',
@@ -24,22 +24,25 @@ export default {
   render(createElement) {
     const klass = 'type-identifier-link';
     const reference = this.references[this.identifier];
-    return reference && reference.url ? (
-      // resolved reference, use anchor tag
-      createElement('router-link', {
+    // internal and external link
+    if (reference && reference.url) {
+      return createElement(Reference, {
         class: klass,
-        props: { to: buildUrl(reference.url, this.$route.query) },
+        props: {
+          url: reference.url,
+          kind: reference.kind,
+          role: reference.role,
+        },
       }, (
         this.$slots.default
-      ))
-    ) : (
-      // unresolved link, use span tag
-      createElement('span', {
-        class: klass,
-      }, (
-        this.$slots.default
-      ))
-    );
+      ));
+    }
+    // unresolved link, use span tag
+    return createElement('span', {
+      class: klass,
+    }, (
+      this.$slots.default
+    ));
   },
   props: {
     identifier: {

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/TypeIdentifierLink.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/TypeIdentifierLink.spec.js
@@ -8,12 +8,10 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import {
-  shallowMount,
-  RouterLinkStub,
-} from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import TypeIdentifierLink
   from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationToken/TypeIdentifierLink.vue';
+import Reference from 'docc-render/components/ContentNode/Reference.vue';
 
 describe('TypeIdentifierLink', () => {
   const foo = {
@@ -30,14 +28,9 @@ describe('TypeIdentifierLink', () => {
     default: foo.title,
   };
 
-  const stubs = {
-    'router-link': RouterLinkStub,
-  };
-
   const defaultOpts = {
     propsData,
     slots,
-    stubs,
     mocks: {
       $route: {
         query: {},
@@ -62,10 +55,10 @@ describe('TypeIdentifierLink', () => {
     });
 
     expect(wrapper.is('.type-identifier-link')).toBe(true);
-    const link = wrapper.find(RouterLinkStub);
+    const link = wrapper.find(Reference);
     expect(link.exists()).toBe(true);
     expect(link.classes('type-identifier-link')).toBe(true);
-    expect(link.props('to')).toBe(foo.url);
+    expect(link.props('url')).toBe(foo.url);
     expect(link.text()).toBe(foo.title);
   });
 });


### PR DESCRIPTION
Update URL in declaration to support external links

Bug/issue #, if applicable: rdar://82575979

## Summary
In the Declaration Section of the documentation, we used to only be able to render internal, relative URLs and neglected the case where the Reference could be external. 
Before the fix, `swift-docc-render` would append the external URL as if it's a relative URL. 
With this PR, I updated the implementation in `/DeclarationToken/TypeIdentifierLink.vue` so this edge case is now supported. I updated the unit test with new expected behavior as well.

## Testing
1. Download the fixture:
[fixture.zip](https://github.com/apple/swift-docc-render/files/7508547/fixture.zip)
2. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/fixture/ npm run serve`
3. Open Safari and go to: http://localhost:8080/documentation/test
4. Check that in the declaration section, there should be a link for "bool".
5. Clicking on that links should take you to https://www.swift.org/documentation/docc/, instead of http://localhost:8080/documentation/https:/www.swift.org/documentation/docc/


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA