### PR TITLE
Vertical align local nav for tutorials and documentation pages

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -142,8 +142,7 @@ export default {
   @include font-styles(documentation-nav);
   // vertically align the items
   @include breakpoint-only-largenav() {
-    height: $nav-height-small;
-    padding-top: rem(4px);
+    padding-top: 0;
   }
 }
 

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -600,7 +600,6 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   display: flex;
   align-items: center;
   white-space: nowrap;
-  padding-top: rem(4px);
   box-sizing: border-box;
 
   @include breakpoint(small, $scope: nav) {

--- a/src/components/Tutorial/NavigationBar.vue
+++ b/src/components/Tutorial/NavigationBar.vue
@@ -227,6 +227,7 @@ export default {
 .nav /deep/ .nav-title {
   grid-column: 1;
   width: 90%;
+  padding-top: 0;
 }
 
 .primary-dropdown,


### PR DESCRIPTION
Bug/issue #76457548, if applicable: 

## Summary

Vertical align local nav for tutorials and documentation pages

### Documentation

| Before      | After |
| ----------- | ----------- |
| <img width="163" alt="b0850a80-4179-11ec-8523-5dc578f00073" src="https://user-images.githubusercontent.com/8567677/141131770-7eddb008-107d-498b-9133-773837a36bdb.png"> | <img width="163" alt="b975dc00-4179-11ec-9104-a8cebeea070a" src="https://user-images.githubusercontent.com/8567677/141131853-3e7f42cb-9d2b-4d93-beee-8fe7ab370b2f.png"> |

### Tutorials

| Before      | After |
| ----------- | ----------- |
| <img width="153" alt="ffcb3b00-4179-11ec-841f-9418f72340a7" src="https://user-images.githubusercontent.com/8567677/141132185-0b4d0406-4cb3-4158-bc5e-29165bbe4cc0.png"> | <img width="153" alt="078adf80-417a-11ec-8b36-dcb186f89fe9" src="https://user-images.githubusercontent.com/8567677/141132200-3ecae746-606a-4993-b99b-c65991431374.png"> |

## Dependencies

NA

## Testing

Use the provided fixture folder:
[manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/7513457/manual-fixtures.zip)

Steps:
1. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures/ npm run serve`
2. Go to http://localhost:8080/tutorials/slothcreator/creating-custom-sloths and http://localhost:8080/documentation/framework/sloth
3. Assert that local nav is vertically aligned in both cases

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests - Only CSS
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
