### PR TITLE
Fix bug preventing navigation to page after toggling language

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -154,13 +154,17 @@ export default {
     })).catch(next);
   },
   beforeRouteUpdate(to, from, next) {
-    if (to.query.language === Language.objectiveC.key.url && this.objcOverrides) {
+    if (to.path === from.path && to.query.language === Language.objectiveC.key.url
+      && this.objcOverrides) {
       this.topicDataObjc = apply(clone(this.topicData), this.objcOverrides);
       next();
     } else if (shouldFetchDataForRouteUpdate(to, from)) {
       fetchDataForRouteEnter(to, from, next).then((data) => {
         this.topicDataObjc = null;
         this.topicData = data;
+        if (to.query.language === Language.objectiveC.key.url && this.objcOverrides) {
+          this.topicDataObjc = apply(clone(this.topicData), this.objcOverrides);
+        }
         next();
       }).catch(next);
     } else {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -13,7 +13,7 @@
     <Topic
       v-if="topicData"
       v-bind="topicProps"
-      :key="topicProps.identifier + topicProps.interfaceLanguage"
+      :key="topicKey"
     />
   </CodeTheme>
 </template>
@@ -66,6 +66,10 @@ export default {
         this.topicDataDefault = data;
       },
     },
+    topicKey: ({ $route, topicProps }) => [
+      $route.path,
+      topicProps.interfaceLanguage,
+    ].join(),
     topicProps() {
       const {
         abstract,

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -130,6 +130,9 @@ export default {
     },
   },
   methods: {
+    applyObjcOverrides() {
+      this.topicDataObjc = apply(clone(this.topicData), this.objcOverrides);
+    },
     handleCodeColorsChange(codeColors) {
       CodeThemeStore.updateCodeColors(codeColors);
     },
@@ -152,22 +155,21 @@ export default {
     fetchDataForRouteEnter(to, from, next).then(data => next((vm) => {
       vm.topicData = data; // eslint-disable-line no-param-reassign
       if (to.query.language === Language.objectiveC.key.url && vm.objcOverrides) {
-        // eslint-disable-next-line no-param-reassign
-        vm.topicDataObjc = apply(clone(vm.topicData), vm.objcOverrides);
+        vm.applyObjcOverrides();
       }
     })).catch(next);
   },
   beforeRouteUpdate(to, from, next) {
     if (to.path === from.path && to.query.language === Language.objectiveC.key.url
       && this.objcOverrides) {
-      this.topicDataObjc = apply(clone(this.topicData), this.objcOverrides);
+      this.applyObjcOverrides();
       next();
     } else if (shouldFetchDataForRouteUpdate(to, from)) {
       fetchDataForRouteEnter(to, from, next).then((data) => {
         this.topicDataObjc = null;
         this.topicData = data;
         if (to.query.language === Language.objectiveC.key.url && this.objcOverrides) {
-          this.topicDataObjc = apply(clone(this.topicData), this.objcOverrides);
+          this.applyObjcOverrides();
         }
         next();
       }).catch(next);

--- a/src/views/Topic.vue
+++ b/src/views/Topic.vue
@@ -14,7 +14,7 @@
       v-if="topicData"
       v-bind="propsFor(topicData)"
       :is="componentFor(topicData)"
-      :key="topicData.identifier.url"
+      :key="topicKey"
       :hierarchy="hierarchy"
     />
   </div>
@@ -69,6 +69,10 @@ export default {
         technologyNavigation,
       };
     },
+    topicKey: ({ $route, topicData }) => [
+      $route.path,
+      topicData.identifier.interfaceLanguage,
+    ].join(),
   },
   beforeRouteEnter(to, from, next) {
     fetchDataForRouteEnter(to, from, next).then(data => next((vm) => {

--- a/src/views/TutorialsOverview.vue
+++ b/src/views/TutorialsOverview.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <Overview v-if="topicData" v-bind="overviewProps" />
+  <Overview v-if="topicData" v-bind="overviewProps" :key="topicKey" />
 </template>
 
 <script>
@@ -40,6 +40,10 @@ export default {
       references,
       sections,
     }),
+    topicKey: ({ $route, topicData }) => [
+      $route.path,
+      topicData.identifier.interfaceLanguage,
+    ].join(),
   },
   beforeRouteEnter(to, from, next) {
     fetchDataForRouteEnter(to, from, next).then(data => next((vm) => {

--- a/tests/unit/views/Topic.spec.js
+++ b/tests/unit/views/Topic.spec.js
@@ -73,6 +73,7 @@ describe('Topic', () => {
     wrapper.setData({
       topicData: {
         identifier: {
+          interfaceLanguage: 'swift',
           url: 'foo',
         },
       },
@@ -103,6 +104,7 @@ describe('Topic', () => {
     wrapper.setData({
       topicData: {
         identifier: {
+          interfaceLanguage: 'swift',
           url: 'foo',
         },
       },
@@ -146,6 +148,7 @@ describe('Topic', () => {
           ...props,
           kind: 'article',
           identifier: {
+            interfaceLanguage: 'swift',
             url: 'foo',
           },
         },
@@ -209,6 +212,7 @@ describe('Topic', () => {
           ...props,
           kind: 'project',
           identifier: {
+            interfaceLanguage: 'swift',
             url: 'foo',
           },
         },

--- a/tests/unit/views/TutorialsOverview.spec.js
+++ b/tests/unit/views/TutorialsOverview.spec.js
@@ -29,6 +29,10 @@ describe('TutorialsOverview', () => {
 
   it('renders an `Overview` with data', () => {
     const topicData = {
+      identifier: {
+        interfaceLanguage: 'swift',
+        url: '/tutorials/swiftui',
+      },
       metadata: {},
       references: {},
       sections: [],


### PR DESCRIPTION
Bug/issue #, if applicable: 85271020

## Summary

This fixes the following 2 issues with the logic for the new "variant overrides" support:

* Navigating to a _new_ page in Objective-C mode should still trigger a new request for data for the new page.
* Navigating to a _new_ page in Objective-C mode should apply a variant overrides patch (if available) after requesting its data.

These scenarios weren't accounted for because the majority of testing done previously was simply done by simulating toggling the language on the same page and didn't include example data for subsequent navigation.

## Testing

Steps:
1. Download/unzip [archive.zip](https://github.com/apple/swift-docc-render/files/7524143/archive.zip) 
2. Configure `VUE_APP_DEV_SERVER_PROXY=/path/to/unzipped/archive` and run `npm run serve`
3. Load http://localhost:8080/documentation/myframework
4. Toggle the language to "Objective-C" and click the "Topics" link to the `SimpleClass` symbol
5. Verify that the page for `SimpleClass` loads and is showing Objective-C content
6. Ensure that the workflows from https://github.com/apple/swift-docc-render/pull/10 still work as before

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
