### PR TITLE
Increment render node version for variantOverrides

### DIFF
--- a/src/utils/schema-version-check.js
+++ b/src/utils/schema-version-check.js
@@ -10,7 +10,7 @@
 
 export const CURRENT_SUPPORTED_SCHEMA = {
   major: 0,
-  minor: 1,
+  minor: 2,
   patch: 0,
 };
 

--- a/src/utils/schema-version-check.js
+++ b/src/utils/schema-version-check.js
@@ -14,11 +14,11 @@ export const CURRENT_SUPPORTED_SCHEMA = {
   patch: 0,
 };
 
-function combineVersions({ major, minor, patch }) {
+export function combineVersions({ major, minor, patch }) {
   return [major, minor, patch].join('.');
 }
 
-const CURRENT_SCHEMA_STRING = combineVersions(CURRENT_SUPPORTED_SCHEMA);
+export const CURRENT_SCHEMA_STRING = combineVersions(CURRENT_SUPPORTED_SCHEMA);
 
 function constructMinorVersionMessage(current) {
   return `[Swift-DocC-Render] The render node version for this page has a higher minor version (${current}) than Swift-DocC-Render supports (${CURRENT_SCHEMA_STRING}). Compatibility is not guaranteed.`;

--- a/tests/unit/utils/schema-version-check.spec.js
+++ b/tests/unit/utils/schema-version-check.spec.js
@@ -8,7 +8,7 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import emitWarningForSchemaVersionMismatch, { CURRENT_SUPPORTED_SCHEMA } from 'docc-render/utils/schema-version-check';
+import emitWarningForSchemaVersionMismatch, { CURRENT_SUPPORTED_SCHEMA, combineVersions, CURRENT_SCHEMA_STRING } from 'docc-render/utils/schema-version-check';
 
 const warnSpy = jest.spyOn(console, 'warn').mockReturnValue('');
 
@@ -23,33 +23,36 @@ describe('schema-version-check', () => {
   });
 
   it('emits a warning if the major version is higher than the supported', () => {
-    emitWarningForSchemaVersionMismatch({
+    const newVersion = {
       ...CURRENT_SUPPORTED_SCHEMA,
       major: CURRENT_SUPPORTED_SCHEMA.major + 1,
-    });
+    };
+    emitWarningForSchemaVersionMismatch(newVersion);
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy)
-      .toHaveBeenCalledWith('[Swift-DocC-Render] The render node version for this page (1.1.0) has a different major version component than Swift-DocC-Render supports (0.1.0). Compatibility is not guaranteed.');
+      .toHaveBeenCalledWith(`[Swift-DocC-Render] The render node version for this page (${combineVersions(newVersion)}) has a different major version component than Swift-DocC-Render supports (${CURRENT_SCHEMA_STRING}). Compatibility is not guaranteed.`);
   });
 
   it('emits a warning if the major version is lower than the supported', () => {
-    emitWarningForSchemaVersionMismatch({
+    const newVersion = {
       ...CURRENT_SUPPORTED_SCHEMA,
       major: CURRENT_SUPPORTED_SCHEMA.major - 1,
-    });
+    };
+    emitWarningForSchemaVersionMismatch(newVersion);
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy)
-      .toHaveBeenCalledWith('[Swift-DocC-Render] The render node version for this page (-1.1.0) has a different major version component than Swift-DocC-Render supports (0.1.0). Compatibility is not guaranteed.');
+      .toHaveBeenCalledWith(`[Swift-DocC-Render] The render node version for this page (${combineVersions(newVersion)}) has a different major version component than Swift-DocC-Render supports (${CURRENT_SCHEMA_STRING}). Compatibility is not guaranteed.`);
   });
 
   it('emits a warning if the minor version is higher than the supported', () => {
-    emitWarningForSchemaVersionMismatch({
+    const newVersion = {
       ...CURRENT_SUPPORTED_SCHEMA,
       minor: CURRENT_SUPPORTED_SCHEMA.minor + 1,
-    });
+    };
+    emitWarningForSchemaVersionMismatch(newVersion);
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy)
-      .toHaveBeenCalledWith('[Swift-DocC-Render] The render node version for this page has a higher minor version (0.2.0) than Swift-DocC-Render supports (0.1.0). Compatibility is not guaranteed.');
+      .toHaveBeenCalledWith(`[Swift-DocC-Render] The render node version for this page has a higher minor version (${combineVersions(newVersion)}) than Swift-DocC-Render supports (${CURRENT_SCHEMA_STRING}). Compatibility is not guaranteed.`);
   });
 
   it('does not emit a warning, if the minor version is lower than the supported', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Increments the minor value of the render node schema to 0.2.0 to account
for addition of the top-level `variantOverrides` property introduced in https://github.com/apple/swift-docc/pull/11.

## Dependencies

This is related to https://github.com/apple/swift-docc/pull/43.

## Testing

N/A

## Checklist

- ~[ ] Added tests~ N/A
- [x] Ran the `npm test` script and it succeeded
- [x] Updated documentation if necessary
