### PR TITLE
Stop inserting word-breaks inside type names

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationToken.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationToken.vue
@@ -9,7 +9,6 @@
 -->
 
 <script>
-import WordBreak from 'docc-render/components/WordBreak.vue';
 import ChangedToken from './DeclarationToken/ChangedToken.vue';
 import RawText from './DeclarationToken/RawText.vue';
 import SyntaxToken from './DeclarationToken/SyntaxToken.vue';
@@ -46,9 +45,7 @@ export default {
     }
     case TokenKind.typeIdentifier: {
       const props = { identifier: this.identifier };
-      return createElement(TypeIdentifierLink, { props }, [
-        createElement(WordBreak, text),
-      ]);
+      return createElement(TypeIdentifierLink, { props }, text);
     }
     case TokenKind.added:
     case TokenKind.removed:

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken.spec.js
@@ -47,7 +47,7 @@ describe('DeclarationToken', () => {
     const link = wrapper.find(TypeIdentifierLink);
     expect(link.exists()).toBe(true);
     expect(link.props()).toEqual({ identifier: propsData.identifier });
-    expect(link.contains(WordBreak)).toBe(true);
+    expect(link.contains(WordBreak)).toBe(false);
     expect(link.text()).toBe(propsData.text);
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: [SR-15519](https://bugs.swift.org/browse/SR-15519) (doesn't resolve, but improves)

## Summary

Currently, type names in declarations are subject to line-breaking, resulting in suboptimal rendering such as:

```
func frob<Foo>(..., ..., ..., ..., ..., ...) -> where Foo : Bidirectional
  Collection
```

Or

```
func frob<Foo>(..., ..., ..., ..., ..., ...) -> where Foo : String
  Protocol
```

This PR removes word-breaking from type names, meaning the above now render as:

```
func frob<Foo>(..., ..., ..., ..., ..., ...) -> where Foo : 
  BidirectionalCollection

func frob<Foo>(..., ..., ..., ..., ..., ...) -> where Foo : 
  StringProtocol
```

This is still not optimal, and we should be smarter and use non-breaking spaces in certain elements (e.g. generic constraints) to discourage them from being split across multiple lines, but it's an improvement.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Updated tests
- [X] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary (no docs to update AFAICT)

I've tested it locally, and it has the desired effect.

Before:


![](https://bugs.swift.org/secure/attachment/18337/18337_image-2021-11-24-12-30-50-335.png)


After:

<img width="756" alt="image" src="https://user-images.githubusercontent.com/5254025/143246833-9d080e84-2c82-4de5-9949-8d4792214264.png">

