### PR TITLE
Add support to render `References` with human readable name in plain text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2117,17 +2117,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -2154,25 +2143,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
         "ssri": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -2180,28 +2150,6 @@
           "dev": true,
           "requires": {
             "minipass": "^3.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.5.0",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.5.0.tgz",
-          "integrity": "sha512-WXh+7AgFxGTgb5QAkQtFeUcHNIEq3PGVQ8WskY5ZiFbWBkOwcCPRs4w/2tVyTbh2q6TVRlO3xfvIukUtjsu62A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
           }
         },
         "wrap-ansi": {
@@ -15066,6 +15014,87 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.8.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.1.tgz",
+      "integrity": "sha512-V53TJbHmzjBhCG5OYI2JWy/aYDspz4oVHKxS43Iy212GjGIG1T3EsB3+GWXFm/1z5VwjdjLmdZUFYM70y77vtQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2117,6 +2117,17 @@
             "color-convert": "^2.0.1"
           }
         },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -2143,6 +2154,25 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
         "ssri": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -2150,6 +2180,28 @@
           "dev": true,
           "requires": {
             "minipass": "^3.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "vue-loader-v16": {
+          "version": "npm:vue-loader@16.5.0",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.5.0.tgz",
+          "integrity": "sha512-WXh+7AgFxGTgb5QAkQtFeUcHNIEq3PGVQ8WskY5ZiFbWBkOwcCPRs4w/2tVyTbh2q6TVRlO3xfvIukUtjsu62A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "hash-sum": "^2.0.0",
+            "loader-utils": "^2.0.0"
           }
         },
         "wrap-ansi": {
@@ -15014,87 +15066,6 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
-        }
-      }
-    },
-    "vue-loader-v16": {
-      "version": "npm:vue-loader@16.8.1",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.1.tgz",
-      "integrity": "sha512-V53TJbHmzjBhCG5OYI2JWy/aYDspz4oVHKxS43Iy212GjGIG1T3EsB3+GWXFm/1z5VwjdjLmdZUFYM70y77vtQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "hash-sum": "^2.0.0",
-        "loader-utils": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -314,6 +314,7 @@ function renderNode(createElement, references) {
           role: reference.role,
           isActive: node.isActive,
           ideTitle: reference.ideTitle,
+          titleStyle: reference.titleStyle,
         },
       }, (
         titleInlineContent ? renderChildren(titleInlineContent) : titlePlainText

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -313,7 +313,7 @@ function renderNode(createElement, references) {
           kind: reference.kind,
           role: reference.role,
           isActive: node.isActive,
-          ideTitile: reference.ideTitile,
+          ideTitle: reference.ideTitle,
         },
       }, (
         titleInlineContent ? renderChildren(titleInlineContent) : titlePlainText

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -313,6 +313,7 @@ function renderNode(createElement, references) {
           kind: reference.kind,
           role: reference.role,
           isActive: node.isActive,
+          ideTitile: reference.ideTitile,
         },
       }, (
         titleInlineContent ? renderChildren(titleInlineContent) : titlePlainText

--- a/src/components/ContentNode/Reference.vue
+++ b/src/components/ContentNode/Reference.vue
@@ -46,11 +46,14 @@ export default {
       return this.kind === 'symbol'
         && (this.role === TopicRole.symbol || this.role === TopicRole.dictionarySymbol);
     },
+    isDisplaySymbol({ isSymbolReference, titleStyle, ideTitle }) {
+      return ideTitle ? (isSymbolReference && titleStyle === 'symbol') : isSymbolReference;
+    },
     refComponent() {
       if (!this.isInternal) {
         return ReferenceExternal;
       }
-      if (this.isSymbolReference && !this.ideTitle) {
+      if (this.isDisplaySymbol) {
         return ReferenceInternalSymbol;
       }
       return ReferenceInternal;
@@ -81,6 +84,10 @@ export default {
       default: true,
     },
     ideTitle: {
+      type: String,
+      required: false,
+    },
+    titleStyle: {
       type: String,
       required: false,
     },

--- a/src/components/ContentNode/Reference.vue
+++ b/src/components/ContentNode/Reference.vue
@@ -47,13 +47,13 @@ export default {
         && (this.role === TopicRole.symbol || this.role === TopicRole.dictionarySymbol);
     },
     refComponent() {
-      if (this.isInternal) {
-        if (this.isSymbolReference) {
-          return this.ideTitle ? ReferenceInternal : ReferenceInternalSymbol;
-        }
-        return ReferenceInternal;
+      if (!this.isInternal) {
+        return ReferenceExternal;
       }
-      return ReferenceExternal;
+      if (this.isSymbolReference && !this.ideTitle) {
+        return ReferenceInternalSymbol;
+      }
+      return ReferenceInternal;
     },
     urlWithParams({ isInternal }) {
       return isInternal ? buildUrl(this.url, this.$route.query) : this.url;

--- a/src/components/ContentNode/Reference.vue
+++ b/src/components/ContentNode/Reference.vue
@@ -48,7 +48,10 @@ export default {
     },
     refComponent() {
       if (this.isInternal) {
-        return this.isSymbolReference ? ReferenceInternalSymbol : ReferenceInternal;
+        if (this.isSymbolReference) {
+          return this.ideTitle ? ReferenceInternal : ReferenceInternalSymbol;
+        }
+        return ReferenceInternal;
       }
       return ReferenceExternal;
     },
@@ -76,6 +79,10 @@ export default {
       type: Boolean,
       required: false,
       default: true,
+    },
+    ideTitle: {
+      type: String,
+      required: false,
     },
   },
 };

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -412,12 +412,14 @@ describe('ContentNode', () => {
         foobar: {
           title: 'FooBar',
           url: '/foo/bar',
+          ideTitle: 'IDETitle',
         },
       });
 
       const reference = wrapper.find('.content').find(Reference);
       expect(reference.exists()).toBe(true);
       expect(reference.props('url')).toBe('/foo/bar');
+      expect(reference.props('ideTitle')).toBe('IDETitle');
       expect(reference.isEmpty()).toBe(false);
       expect(reference.text()).toBe('FooBar');
     });

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -413,6 +413,7 @@ describe('ContentNode', () => {
           title: 'FooBar',
           url: '/foo/bar',
           ideTitle: 'IDETitle',
+          titleStyle: 'symbol',
         },
       });
 
@@ -420,6 +421,7 @@ describe('ContentNode', () => {
       expect(reference.exists()).toBe(true);
       expect(reference.props('url')).toBe('/foo/bar');
       expect(reference.props('ideTitle')).toBe('IDETitle');
+      expect(reference.props('titleStyle')).toBe('symbol');
       expect(reference.isEmpty()).toBe(false);
       expect(reference.text()).toBe('FooBar');
     });

--- a/tests/unit/components/ContentNode/Reference.spec.js
+++ b/tests/unit/components/ContentNode/Reference.spec.js
@@ -120,10 +120,29 @@ describe('Reference', () => {
         kind: 'symbol',
         role: TopicRole.dictionarySymbol,
         ideTitle: 'UIView',
+        titleStyle: 'title',
       },
       slots: { default: 'UIView' },
     });
     const ref = wrapper.find(ReferenceInternal);
+    expect(ref.exists()).toBe(true);
+    expect(ref.props('url')).toBe('/documentation/uikit/uiview');
+  });
+
+  it('renders a `ReferenceInternalSymbol` for external "dictionarySymbol" kind references with `symbol` title style', () => {
+    const wrapper = shallowMount(Reference, {
+      localVue,
+      router,
+      propsData: {
+        url: '/documentation/uikit/uiview',
+        kind: 'symbol',
+        role: TopicRole.dictionarySymbol,
+        ideTitle: 'UIView',
+        titleStyle: 'symbol',
+      },
+      slots: { default: 'UIView' },
+    });
+    const ref = wrapper.find(ReferenceInternalSymbol);
     expect(ref.exists()).toBe(true);
     expect(ref.props('url')).toBe('/documentation/uikit/uiview');
   });

--- a/tests/unit/components/ContentNode/Reference.spec.js
+++ b/tests/unit/components/ContentNode/Reference.spec.js
@@ -78,6 +78,23 @@ describe('Reference', () => {
     expect(ref.props('url')).toBe('/documentation/uikit/uiview');
   });
 
+  it('renders a `ReferenceInternal` for external "symbol" kind references with human readable name', () => {
+    const wrapper = shallowMount(Reference, {
+      localVue,
+      router,
+      propsData: {
+        url: '/documentation/uikit/uiview',
+        kind: 'symbol',
+        role: TopicRole.symbol,
+        ideTitle: 'UIView',
+      },
+      slots: { default: 'UIView' },
+    });
+    const ref = wrapper.find(ReferenceInternal);
+    expect(ref.exists()).toBe(true);
+    expect(ref.props('url')).toBe('/documentation/uikit/uiview');
+  });
+
   it('renders a `ReferenceInternalSymbol` for external "dictionarySymbol" kind references', () => {
     const wrapper = shallowMount(Reference, {
       localVue,
@@ -90,6 +107,23 @@ describe('Reference', () => {
       slots: { default: 'UIView' },
     });
     const ref = wrapper.find(ReferenceInternalSymbol);
+    expect(ref.exists()).toBe(true);
+    expect(ref.props('url')).toBe('/documentation/uikit/uiview');
+  });
+
+  it('renders a `ReferenceInternal` for external "dictionarySymbol" kind references with a human readable name', () => {
+    const wrapper = shallowMount(Reference, {
+      localVue,
+      router,
+      propsData: {
+        url: '/documentation/uikit/uiview',
+        kind: 'symbol',
+        role: TopicRole.dictionarySymbol,
+        ideTitle: 'UIView',
+      },
+      slots: { default: 'UIView' },
+    });
+    const ref = wrapper.find(ReferenceInternal);
     expect(ref.exists()).toBe(true);
     expect(ref.props('url')).toBe('/documentation/uikit/uiview');
   });


### PR DESCRIPTION
Bug/issue #, if applicable: 61211397

## Summary
In the `TopicsSection`, we check if the `reference` has a human readable name before rendering. So, if a symbol reference has a human readable name, its title will be rendered in plain text instead of CodeVoice.
We did not consider this scenario anywhere else. This PR adds support to render symbols with human readable names in plain text. I added `ideTitle` and `titleStyle` to the props of the `Reference` component, so it can determine if a symbol has a human readable name and if it should be rendered as text or CodeVoice. 

## Testing
Use the provided fixture folder:
[fixture.zip](https://github.com/apple/swift-docc-render/files/7621933/fixture.zip)

Steps:
1. Run VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures/ npm run serve
2. Go to http://localhost:8080/documentation/example
3. Check that the first example is rendered in plain text, and the following two are rendered in CodeVoice.
The first example, is a `reference` with a human readable name, thus it should be rendered in plain text.
The second example also has a human readable name, but its `titleStyle` says to render as a symbol. So this should be rendered in CodeVoice.
The third is just a sanity check for a regular symbol reference that doesn't have a human readable name. 

<img width="940" alt="Screen Shot 2021-11-29 at 2 57 16 PM" src="https://user-images.githubusercontent.com/87735557/143962744-fb7192ba-48f1-49cd-922f-b68d701c8771.png">

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary - NA
