### PR TITLE
use ordered list start index when rendering

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -236,7 +236,11 @@ function renderNode(createElement, references) {
         node.text
       ));
     case BlockType.orderedList:
-      return createElement('ol', {}, (
+      return createElement('ol', {
+        attrs: {
+          start: node.start,
+        },
+      }, (
         renderListItems(node.items)
       ));
     case BlockType.paragraph:

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -205,6 +205,51 @@ describe('ContentNode', () => {
 
       const list = wrapper.find('.content ol');
       expect(list.exists()).toBe(true);
+      expect(list.attributes('start')).toBeUndefined();
+
+      const items = list.findAll('li');
+      expect(items.length).toBe(2);
+      expect(items.at(0).find('p').text()).toBe('foo');
+      expect(items.at(1).find('p').text()).toBe('bar');
+    });
+
+    it('renders an <ol> with <li> items and a custom start index', () => {
+      const wrapper = mountWithItem({
+        type: 'orderedList',
+        start: 2,
+        items: [
+          {
+            content: [
+              {
+                type: 'paragraph',
+                inlineContent: [
+                  {
+                    type: 'text',
+                    text: 'foo',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            content: [
+              {
+                type: 'paragraph',
+                inlineContent: [
+                  {
+                    type: 'text',
+                    text: 'bar',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      const list = wrapper.find('.content ol');
+      expect(list.exists()).toBe(true);
+      expect(list.attributes('start')).toBe('2');
 
       const items = list.findAll('li');
       expect(items.length).toBe(2);


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://73847907

## Summary

While cmark-gfm saves the starting index of an ordered list, swift-markdown and Swift-DocC currently discards this information. This PR is part of a set that preserves the starting index when rendering documentation.

## Dependencies

* https://github.com/apple/swift-markdown/pull/22
* https://github.com/apple/swift-docc/pull/53

## Testing

Build this branch, then follow the testing instructions on https://github.com/apple/swift-docc/pull/53.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ n/a ] Updated documentation if necessary
