### PR TITLE
Delete spacing between nav scrollbar and screen edge

### DIFF
--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -517,7 +517,7 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   }
 
   @include breakpoint(small, $scope: nav) {
-    padding: 0 $nav-padding-small;
+    padding: 0 0 0 $nav-padding-small;
   }
 
   @include nav-in-breakpoint {
@@ -586,6 +586,7 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   display: flex;
   align-items: center;
   max-height: $nav-height-small;
+  padding-right: $nav-padding-small;
 
   @include nav-in-breakpoint {
     grid-area: actions;


### PR DESCRIPTION
Bug/issue #83836696, if applicable: 

## Summary

Delete spacing between nav scrollbar and screen edge

### Before
<img width="464" alt="Screenshot 2021-12-10 at 4 13 36 PM" src="https://user-images.githubusercontent.com/8567677/145600193-68a185ef-d3f8-4d8e-8ca5-085e2f83715d.png">

### After
<img width="464" alt="Screenshot 2021-12-10 at 4 10 09 PM" src="https://user-images.githubusercontent.com/8567677/145600264-5e7a42ee-3f9e-4037-9c19-75f944a5159a.png">

## Dependencies

NA

## Testing

Use the provided fixture folder:
[manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/7513457/manual-fixtures.zip)

Steps:
1. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures/ npm run serve`
2. Set scrollbars macOS conf to “Always”
3. Open Safari on desktop
4. Go to http://localhost:8080/tutorials/slothcreator/creating-custom-sloths
5. Go to responsive Design Mode and set a mobile resolution
6. Open the nav and assert that there is no space between the nav scrollbar and the screen edge

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests (Not needed)
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
