### PR TITLE
Change `Frameworks` to `Technologies` to support documenting more product types

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -51,12 +51,12 @@
             :swiftPath="swiftPath"
           />
           <Availability v-if="platforms" :platforms="platforms" />
-          <FrameworkList v-if="modules" :frameworks="modules" />
-          <FrameworkList
-            v-if="extendsFramework"
-            class="extends-framework"
+          <TechnologyList v-if="modules" :technologies="modules" />
+          <TechnologyList
+            v-if="extendsTechnology"
+            class="extends-technology"
             title="Extends"
-            :frameworks="[{ name: extendsFramework }]"
+            :technologies="[{ name: extendsTechnology }]"
           />
           <OnThisPageNav v-if="onThisPageSections.length > 1" :sections="onThisPageSections" />
         </Summary>
@@ -104,7 +104,7 @@ import ContentNode from './DocumentationTopic/ContentNode.vue';
 import CallToActionButton from './CallToActionButton.vue';
 import DefaultImplementations from './DocumentationTopic/DefaultImplementations.vue';
 import Description from './DocumentationTopic/Description.vue';
-import FrameworkList from './DocumentationTopic/Summary/FrameworkList.vue';
+import TechnologyList from './DocumentationTopic/Summary/TechnologyList.vue';
 import OnThisPageNav from './DocumentationTopic/Summary/OnThisPageNav.vue';
 import PrimaryContent from './DocumentationTopic/PrimaryContent.vue';
 import Relationships from './DocumentationTopic/Relationships.vue';
@@ -141,7 +141,7 @@ export default {
     DefaultImplementations,
     Description,
     DownloadButton: CallToActionButton,
-    FrameworkList,
+    TechnologyList,
     LanguageSwitcher,
     Nav: DocumentationNav,
     OnThisPageNav,
@@ -239,7 +239,7 @@ export default {
       type: Array,
       default: () => ([]),
     },
-    extendsFramework: {
+    extendsTechnology: {
       type: String,
     },
     tags: {

--- a/src/components/DocumentationTopic/Summary/TechnologyList.vue
+++ b/src/components/DocumentationTopic/Summary/TechnologyList.vue
@@ -10,16 +10,16 @@
 
 <template>
   <Section
-    class="frameworks"
+    class="technologies"
     role="complementary"
     :aria-label="computedTitle"
   >
     <Title>{{ computedTitle }}</Title>
     <List>
-      <Item v-for="framework in frameworks" :key="framework.name">
-        <WordBreak class="name">{{ framework.name }}</WordBreak>
+      <Item v-for="technology in technologies" :key="technology.name">
+        <WordBreak class="name">{{ technology.name }}</WordBreak>
         <WordBreak
-          v-for="module in (framework.relatedModules || [])"
+          v-for="module in (technology.relatedModules || [])"
           class="name"
           :key="module"
         >{{ module }}
@@ -38,7 +38,7 @@ import Section from './Section.vue';
 import Title from './Title.vue';
 
 export default {
-  name: 'FrameworkList',
+  name: 'TechnologyList',
   components: {
     Item: ListItem,
     List,
@@ -47,17 +47,23 @@ export default {
     WordBreak,
   },
   props: {
-    frameworks: {
+    technologies: {
       type: Array,
       required: true,
     },
     title: {
       type: String,
-      default: 'Framework',
+      required: false,
     },
   },
   computed: {
-    computedTitle: ({ title, frameworks }) => `${title}${pluralize(frameworks)}`,
+    computedTitle: ({ title, defaultTitle }) => title || defaultTitle,
+    defaultTitle: ({ technologies }) => pluralize({
+      en: {
+        one: 'Technology',
+        other: 'Technologies',
+      },
+    }, technologies.length),
   },
 };
 </script>

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -40,10 +40,83 @@ export function escapeHtml(str) {
   return str.replace(HTML_UNSAFE_RE, sanitize);
 }
 
-// Add the correct grammatical number (singular or plural)
-// to a noun depending on the number of items of an array
-export function pluralize(array) {
-  return array.length === 1 ? '' : 's';
+export const PluralCategory = {
+  zero: 'zero',
+  one: 'one',
+  two: 'two',
+  few: 'few',
+  many: 'many',
+  other: 'other',
+};
+
+export const PluralRuleType = {
+  cardinal: 'cardinal',
+  ordinal: 'ordinal',
+};
+
+// Returns the "pluralized" version of some provided text based on an integer
+// count and the user's resolved locale.
+//
+// Choices _must_ be provided for the en locale since that will be used as a
+// fallback in the scenario where no choices are provided or available for the
+// resolved locale of a given user.
+//
+// @param {Object} choices An object keyed by locales. Each value should itself
+//   be an object with keys for each plural category supported by the locale
+//   with the value representing the string to return.
+//
+// Examples:
+//
+//   const choices = {
+//     en: {
+//       one: 'day',
+//       other: 'days',
+//     },
+//     sl: {
+//       one: 'ura',
+//       two: 'uri',
+//       few: 'ure',
+//       other: 'ur',
+//     },
+//   };
+//
+//   // en
+//   pluralize(choices, 2); // 'days'
+//   pluralize({ en: { one: 'Technology, other: 'Technologies' } }, 1) // 'Technology'
+//   pluralize({}, 1) // throws error
+//
+//   // sl
+//   pluralize(choices, 2); // 'uri'
+//   pluralize({ sl }, 2); // throws error
+//   pluralize({ en }, 2); // 'days'
+export function pluralize(choices, count) {
+  const { cardinal } = PluralRuleType;
+  const { one, other } = PluralCategory;
+
+  const defaultLocale = 'en';
+  const defaultCategory = count === 1 ? one : other;
+
+  // at minimum, there should at least be a "one" and "other" choice for the
+  // "en" locale for use as fallback text in the case that a choice for the
+  // user's resolved locale category is not provided/available
+  if (!choices[defaultLocale] || !choices[defaultLocale][defaultCategory]) {
+    throw new Error(`No default choices provided to pluralize using default locale ${defaultLocale}`);
+  }
+
+  let locale = defaultLocale;
+  let category = defaultCategory;
+  if (('Intl' in window) && ('PluralRules' in window.Intl)) {
+    const preferredLocales = navigator.languages ? navigator.languages : [navigator.language];
+    const pluralRules = new Intl.PluralRules(preferredLocales, { type: cardinal });
+    const resolvedCategory = pluralRules.select(count);
+    const resolvedLocale = pluralRules.resolvedOptions().locale;
+    if (choices[resolvedLocale] && choices[resolvedLocale][resolvedCategory]) {
+      locale = resolvedLocale;
+      category = resolvedCategory;
+    }
+  }
+
+  return choices[locale][category];
 }
 
 // Escape URL hash fragments for use in CSS selectors, which is needed to

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -83,7 +83,7 @@ export default {
           url: identifier,
         },
         metadata: {
-          extends: extendsFramework,
+          extends: extendsTechnology,
           conformance,
           modules,
           platforms,
@@ -124,7 +124,7 @@ export default {
         seeAlsoSections,
         variantOverrides,
         variants,
-        extendsFramework,
+        extendsTechnology,
         tags: tags.slice(0, 1), // make sure we only show the first tag
       };
     },

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -23,7 +23,7 @@ const {
   Aside,
   Description,
   DownloadButton,
-  FrameworkList,
+  TechnologyList,
   LanguageSwitcher,
   Nav,
   OnThisPageNav,
@@ -352,13 +352,13 @@ describe('DocumentationTopic', () => {
       expect(list.props('platforms')).toEqual(platforms);
     });
 
-    it('renders a `FrameworkList` with frameworks data', () => {
+    it('renders a `TechnologyList` with technologies data', () => {
       const modules = ['FooKit', 'BarKit'];
       wrapper.setProps({ modules });
 
-      const list = summary.find(FrameworkList);
+      const list = summary.find(TechnologyList);
       expect(list.exists()).toBe(true);
-      expect(list.props('frameworks')).toEqual(modules);
+      expect(list.props('technologies')).toEqual(modules);
     });
 
     it('renders an `OnThisPageNav` with more than 1 section', () => {
@@ -392,18 +392,18 @@ describe('DocumentationTopic', () => {
       });
     });
 
-    it('renders an `FrameworkList` component in the sidebar', () => {
-      expect(wrapper.find('.extends-framework').exists()).toBe(false);
-      const extendsFramework = 'FooFramework';
+    it('renders an `TechnologyList` component in the sidebar', () => {
+      expect(wrapper.find('.extends-technology').exists()).toBe(false);
+      const extendsTechnology = 'FooTechnology';
 
       wrapper.setProps({
-        extendsFramework,
+        extendsTechnology,
       });
 
-      const frameworkList = wrapper.find('.extends-framework');
-      expect(frameworkList.exists()).toBe(true);
-      expect(frameworkList.props()).toEqual({
-        frameworks: [{ name: extendsFramework }],
+      const technologyList = wrapper.find('.extends-technology');
+      expect(technologyList.exists()).toBe(true);
+      expect(technologyList.props()).toEqual({
+        technologies: [{ name: extendsTechnology }],
         title: 'Extends',
       });
     });

--- a/tests/unit/components/DocumentationTopic/Summary/TechnologyList.spec.js
+++ b/tests/unit/components/DocumentationTopic/Summary/TechnologyList.spec.js
@@ -9,7 +9,7 @@
 */
 
 import { shallowMount } from '@vue/test-utils';
-import FrameworkList from 'docc-render/components/DocumentationTopic/Summary/FrameworkList.vue';
+import TechnologyList from 'docc-render/components/DocumentationTopic/Summary/TechnologyList.vue';
 
 const {
   Item,
@@ -17,72 +17,70 @@ const {
   Section,
   Title,
   WordBreak,
-} = FrameworkList.components;
+} = TechnologyList.components;
 
-describe('FrameworkList', () => {
+describe('TechnologyList', () => {
   let wrapper;
 
   const propsData = {
-    frameworks: [
+    technologies: [
       { name: 'FooKit' },
       { name: 'BarKit' },
     ],
   };
 
   beforeEach(() => {
-    wrapper = shallowMount(FrameworkList, { propsData });
+    wrapper = shallowMount(TechnologyList, { propsData });
   });
 
   it('renders a `Section', () => {
-    expect(wrapper.is('.frameworks')).toBe(true);
+    expect(wrapper.is('.technologies')).toBe(true);
 
     const section = wrapper.find(Section);
     expect(section.exists()).toBe(true);
-    expect(section.classes('frameworks')).toBe(true);
-    expect(section.attributes('aria-label')).toBe('Frameworks');
+    expect(section.classes('technologies')).toBe(true);
+    expect(section.attributes('aria-label')).toBe('Technologies');
     expect(section.attributes('role')).toBe('complementary');
   });
 
   it('renders a `Title`', () => {
     const title = wrapper.find(Title);
     expect(title.exists()).toBe(true);
-    expect(title.text()).toBe('Frameworks');
+    expect(title.text()).toBe('Technologies');
   });
 
   it('allows overriding the title via a prop', () => {
-    wrapper.setProps({
-      title: 'Foobar',
-    });
+    wrapper.setProps({ title: 'Foobars' });
     const title = wrapper.find(Title);
     expect(title.exists()).toBe(true);
     expect(title.text()).toBe('Foobars');
     expect(wrapper.find(Section).attributes('aria-label')).toBe('Foobars');
   });
 
-  it('renders a `List` with an `Item/WordBreak` for each framework', () => {
+  it('renders a `List` with an `Item/WordBreak` for each technology', () => {
     const list = wrapper.find(List);
     expect(list.exists()).toBe(true);
 
     const items = list.findAll(Item);
-    expect(items.length).toBe(propsData.frameworks.length);
+    expect(items.length).toBe(propsData.technologies.length);
 
-    propsData.frameworks.forEach((framework, i) => {
+    propsData.technologies.forEach((technology, i) => {
       const wbreak = items.at(i).find(WordBreak);
       expect(wbreak.exists()).toBe(true);
-      expect(wbreak.text()).toBe(framework.name);
+      expect(wbreak.text()).toBe(technology.name);
     });
   });
 
-  it('uses the singular "Framework" title with only a single framework', () => {
-    wrapper.setProps({ frameworks: [propsData.frameworks[0]] });
-    expect(wrapper.find(Section).attributes('aria-label')).toBe('Framework');
-    expect(wrapper.find(Title).text()).toBe('Framework');
+  it('uses the singular "Technology" title with only a single technology', () => {
+    wrapper.setProps({ technologies: [propsData.technologies[0]] });
+    expect(wrapper.find(Section).attributes('aria-label')).toBe('Technology');
+    expect(wrapper.find(Title).text()).toBe('Technology');
   });
 
   it('renders multiple names of any related modules', () => {
     wrapper.setProps({
-      frameworks: [
-        propsData.frameworks[0],
+      technologies: [
+        propsData.technologies[0],
         {
           name: 'BarKit',
           relatedModules: ['BazKit', 'QuxKit'],

--- a/tests/unit/utils/strings.spec.js
+++ b/tests/unit/utils/strings.spec.js
@@ -63,14 +63,76 @@ describe('escapeHtml', () => {
 });
 
 describe('pluralize', () => {
-  it('return `s` if value is plural', () => {
-    expect(pluralize(['A', 'B'])).toBe('s');
+  it('throws an error when en-US one/other choices are not provided', () => {
+    expect(() => pluralize({}, 1)).toThrow();
+    expect(() => pluralize({}, 0)).toThrow();
+    expect(() => pluralize({}, 42)).toThrow();
+    expect(() => pluralize({ en: 'foo' }, 42)).toThrow();
+    expect(() => pluralize({ sl: { one: 'a', other: 'b' } })).toThrow();
+    expect(() => pluralize({ en: { one: 'foo' } }, 42)).toThrow();
   });
-  it('return `s` if value is 0', () => {
-    expect(pluralize([])).toBe('s');
+
+  describe('en', () => {
+    const one = 'day';
+    const other = 'days';
+    const choices = { en: { one, other } };
+
+    it('returns the "one" choice for a count of 1', () => {
+      expect(pluralize(choices, 1)).toBe(one);
+    });
+
+    it('returns the "other" choice for integers that are not 1', () => {
+      expect(pluralize(choices, 0)).toBe(other);
+      expect(pluralize(choices, 2)).toBe(other);
+      expect(pluralize(choices, 42)).toBe(other);
+    });
   });
-  it('return an empty string if value is singular', () => {
-    expect(pluralize(['A'])).toBe('');
+
+  describe('with other locales', () => {
+    let languages;
+
+    const en = {
+      one: 'day',
+      other: 'days',
+    };
+    const sl = {
+      one: 'ura',
+      two: 'uri',
+      few: 'ure',
+      other: 'ur',
+    };
+    const choices = { en, sl };
+
+    beforeEach(() => {
+      languages = navigator.languages;
+      // stub `navigator.languages` to simulate a runtime with an alternate locale
+      // eslint-disable-next-line
+      navigator.__defineGetter__('languages', () => ['sl']);
+    });
+
+    afterEach(() => {
+      // restore original value of `navigator.languages`
+      // eslint-disable-next-line
+      navigator.__defineGetter__('languages', () => languages);
+    });
+
+    it('uses translated text for the appropriate locale and plural rule', () => {
+      expect(pluralize(choices, 1)).toBe(sl.one);
+      expect(pluralize(choices, 2)).toBe(sl.two);
+      expect(pluralize(choices, 3)).toBe(sl.few);
+      expect(pluralize(choices, 4)).toBe(sl.few);
+      expect(pluralize(choices, 5)).toBe(sl.other);
+      expect(pluralize(choices, 0)).toBe(sl.other);
+    });
+
+    it('falls back to "en" if the appropriate translation is not provided', () => {
+      expect(pluralize({ en }, 1)).toBe(en.one);
+      expect(pluralize({ en }, 2)).toBe(en.other);
+      expect(pluralize({ en }, 3)).toBe(en.other);
+      expect(pluralize({ en }, 4)).toBe(en.other);
+      expect(pluralize({ en }, 5)).toBe(en.other);
+      expect(pluralize({ en }, 0)).toBe(en.other);
+    });
   });
 });
 


### PR DESCRIPTION
* __Rationale:__ Changing the wording of the side bar from `Frameworks` to `Technologies` to improve the presentation of non-framework documentation. As a result of this change, we also updated the `pluralize` function to be more generic and ready for localized translation in the future. 
* __Risk:__ Low.
* __Risk Detail:__ There is mostly just a plain text change.
* __Reward:__ High
* __Reward Details:__ This supports the work landed in `Swift-Docc` and has been discussed on the Swift Forums [here]( and has been discussed on the Swift Forums [here](https://forums.swift.org/t/improve-presentation-of-non-framework-documentation-sr-15434/53388). ). 
* __Original PR:__ #28 
* __Issue:__ rdar://83451964
* __Code Reviewed By:__ @mportiz08 
* __Testing Details:__ Unit tests were added and updated for the new wording and the new `pluralize` method.