### PR TITLE
Avoid splitting characters in a way that leaves a single character by itself in Possible Values

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/PossibleValues.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/PossibleValues.vue
@@ -14,7 +14,7 @@
     <dl class="datalist">
       <template v-for="value in values">
         <dt class="param-name" :key="`${value.name}:name`">
-          <code>{{value.name}}</code>
+          <WordBreak tag="code">{{value.name}}</WordBreak>
         </dt>
         <dd v-if="value.content" class="value-content" :key="`${value.name}:content`">
           <ContentNode :content="value.content" />
@@ -27,10 +27,11 @@
 <script>
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
 import ContentNode from 'docc-render/components/ContentNode.vue';
+import WordBreak from '@/components/WordBreak.vue';
 
 export default {
   name: 'PossibleValues',
-  components: { ContentNode, OnThisPageSection },
+  components: { ContentNode, OnThisPageSection, WordBreak },
   props: {
     values: {
       type: Array,

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/PossibleValues.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/PossibleValues.spec.js
@@ -11,7 +11,7 @@
 import { shallowMount } from '@vue/test-utils';
 import PossibleValues from 'docc-render/components/DocumentationTopic/PrimaryContent/PossibleValues.vue';
 
-const { ContentNode } = PossibleValues.components;
+const { ContentNode, WordBreak } = PossibleValues.components;
 
 const propsData = {
   values: [
@@ -35,10 +35,15 @@ const propsData = {
   ],
 };
 describe('PossibleValues', () => {
-  it('renders the passed values', () => {
-    const wrapper = shallowMount(PossibleValues, {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowMount(PossibleValues, {
       propsData,
     });
+  });
+
+  it('renders the passed values', () => {
     const titles = wrapper.findAll('.param-name');
     expect(titles).toHaveLength(2);
     expect(titles.at(0).text()).toEqual('A');
@@ -49,5 +54,13 @@ describe('PossibleValues', () => {
     const contentNode = wrapper.find(ContentNode);
     expect(contentNode.exists()).toBe(true);
     expect(contentNode.props('content')).toBe(propsData.values[1].content);
+  });
+
+  it('renders <WordBreak> with a <code> tag', () => {
+    const wordBreaks = wrapper.findAll(WordBreak);
+    expect(wordBreaks).toHaveLength(2);
+    expect(wordBreaks.at(0).text()).toBe(propsData.values[0].name);
+    expect(wordBreaks.at(0).attributes('tag')).toBe('code');
+    expect(wordBreaks.at(1).text()).toBe(propsData.values[1].name);
   });
 });


### PR DESCRIPTION
Bug/issue #48833910, if applicable: 

## Summary

Avoid splitting characters in a way that leaves a single character by itself in Possible Values

### Before
<img width="342" alt="Screenshot 2021-12-14 at 4 26 11 PM" src="https://user-images.githubusercontent.com/8567677/146027980-13724dcb-ac4a-4d1d-a8f7-9e48654f35e3.png">

### After
<img width="342" alt="Screenshot 2021-12-14 at 4 25 49 PM" src="https://user-images.githubusercontent.com/8567677/146028012-7a87dbd6-e2b6-426e-a126-2683f2a47ea1.png">

## Dependencies

NA

## Testing

Use the provided fixture folder:
[manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/7712788/manual-fixtures.zip)

Steps:
1. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures/ npm run serve`
2. Go to http://localhost:8080/documentation/framework/sloth
5. Go to responsive Design Mode and set a mobile resolution
6. Assert that long Possible Values are not being split by characters

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
