### PR TITLE
VO should provide feedback after user answers a question in Tutorials' quiz

### DIFF
--- a/src/components/Tutorial/Assessments.vue
+++ b/src/components/Tutorial/Assessments.vue
@@ -36,12 +36,12 @@
         </div>
         <div v-else class="success">
           <slot name="success">
-          <p>{{ successMessage }}</p>
+            <p>{{ SuccessMessage }}</p>
           </slot>
         </div>
         <div aria-live="assertive" class="visuallyhidden">
           <slot name="success" v-if="completed">
-            {{ successMessage }}
+            {{ SuccessMessage }}
           </slot>
         </div>
       </MainColumn>
@@ -58,10 +58,11 @@ import AssessmentsProgress from './AssessmentsProgress.vue';
 import Quiz from './Assessments/Quiz.vue';
 
 const additionalScrollOffset = 12;
-const successMessage = 'Great job, you\'ve answered all the questions for this tutorial.';
+const SuccessMessage = 'Great job, you\'ve answered all the questions for this tutorial.';
 
 export default {
   name: 'Assessments',
+  constants: { SuccessMessage },
   components: {
     LinkableSection: LinkableElement,
     Quiz,
@@ -117,7 +118,7 @@ export default {
     return {
       activeIndex: 0,
       completed: false,
-      successMessage,
+      SuccessMessage,
     };
   },
   computed: {

--- a/src/components/Tutorial/Assessments.vue
+++ b/src/components/Tutorial/Assessments.vue
@@ -35,9 +35,14 @@
           />
         </div>
         <div v-else class="success">
-           <slot name="success">
-            <p>Great job, you've answered all the questions for this tutorial.</p>
-           </slot>
+          <slot name="success">
+          <p>{{ successMessage }}</p>
+          </slot>
+        </div>
+        <div aria-live="assertive" class="visuallyhidden">
+          <slot name="success" v-if="completed">
+            {{ successMessage }}
+          </slot>
         </div>
       </MainColumn>
     </Row>
@@ -53,6 +58,7 @@ import AssessmentsProgress from './AssessmentsProgress.vue';
 import Quiz from './Assessments/Quiz.vue';
 
 const additionalScrollOffset = 12;
+const successMessage = 'Great job, you\'ve answered all the questions for this tutorial.';
 
 export default {
   name: 'Assessments',
@@ -111,6 +117,7 @@ export default {
     return {
       activeIndex: 0,
       completed: false,
+      successMessage,
     };
   },
   computed: {

--- a/src/components/Tutorial/Assessments/Quiz.vue
+++ b/src/components/Tutorial/Assessments/Quiz.vue
@@ -13,22 +13,22 @@
     <ContentNode class="title" :content="title" />
     <ContentNode class="question-content" v-if="content" :content="content" />
     <div class="choices">
-    <label
-      v-for="(choice, index) in choices"
-      :key="index"
-      :class="choiceClasses[index]"
-      >
-        <component :is="getIconComponent(index)" class="choice-icon" />
-        <input type="radio" :value="index" v-model="selectedIndex" name="assessment">
-        <ContentNode class="question" :content="choice.content" />
-        <template v-if="userChoices[index].checked">
-          <ContentNode class="answer" :content="choice.justification" />
-          <p class="answer" v-if="choice.reaction">{{ choice.reaction }}</p>
-          <div aria-live="assertive" class="visuallyhidden">
-          {{ choice.isCorrect ? "Correct Answer" : "Incorrect Answer" }}
-          </div>
-        </template>
-    </label>
+      <label
+        v-for="(choice, index) in choices"
+        :key="index"
+        :class="choiceClasses[index]"
+        >
+          <component :is="getIconComponent(index)" class="choice-icon" />
+          <input type="radio" :value="index" v-model="selectedIndex" name="assessment">
+          <ContentNode class="question" :content="choice.content" />
+          <template v-if="userChoices[index].checked">
+            <ContentNode class="answer" :content="choice.justification" />
+            <p class="answer" v-if="choice.reaction">{{ choice.reaction }}</p>
+          </template>
+      </label>
+      <div aria-live="assertive" class="visuallyhidden">
+        {{ ariaLiveText }}
+      </div>
     </div>
     <div class="controls">
       <ButtonLink
@@ -91,6 +91,7 @@ export default {
     return {
       userChoices: this.choices.map(() => ({ checked: false })),
       selectedIndex: null,
+      checkedIndex: null,
     };
   },
   computed: {
@@ -113,6 +114,11 @@ export default {
         this.userChoices[correctChoice].checked
       ));
     },
+    ariaLiveText: ({ checkedIndex, choices }) => {
+      if (checkedIndex === null) return '';
+      const { isCorrect } = choices[checkedIndex];
+      return `Answer number ${checkedIndex + 1} is ${isCorrect ? 'correct' : 'incorrect'}`;
+    },
   },
   methods: {
     getIconComponent(index) {
@@ -124,6 +130,7 @@ export default {
     },
     submit() {
       this.$set(this.userChoices, this.selectedIndex, { checked: true });
+      this.checkedIndex = this.selectedIndex;
       this.$emit('submit');
     },
     advance() {

--- a/tests/unit/components/Tutorial/Assessments.spec.js
+++ b/tests/unit/components/Tutorial/Assessments.spec.js
@@ -12,6 +12,7 @@ import { shallowMount } from '@vue/test-utils';
 import Assessments from 'docc-render/components/Tutorial/Assessments.vue';
 
 const { LinkableSection } = Assessments.components;
+const { SuccessMessage } = Assessments.constants;
 
 // Stub scrolling APIs not implemented in Jest.
 window.HTMLElement.prototype.scrollIntoView = () => {};
@@ -276,9 +277,7 @@ describe('success slot for completed assessment', () => {
 
     const message = success.find('p');
     expect(message.exists()).toBe(true);
-    expect(message.text()).toBe(
-      'Great job, you\'ve answered all the questions for this tutorial.',
-    );
+    expect(message.text()).toBe(SuccessMessage);
   });
 
   it('renders a default "success" message on aria live element for AX', () => {
@@ -287,22 +286,19 @@ describe('success slot for completed assessment', () => {
     });
     const ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
     expect(ariaLive.exists()).toBe(true);
-    expect(ariaLive.text()).not.toBe(
-      'Great job, you\'ve answered all the questions for this tutorial.',
-    );
+    // assert that aria-live's slot is empty
+    expect(ariaLive.isEmpty()).toBe(true);
 
     wrapper.setData({ completed: true });
-
-    expect(ariaLive.text()).toBe(
-      'Great job, you\'ve answered all the questions for this tutorial.',
-    );
+    // assert that aria-live's slot has been updated
+    expect(ariaLive.text()).toBe(SuccessMessage);
   });
 
-  it('renders a "success" slot when provided', () => {
+  it('renders a "success" slot and slot message when provided', () => {
     const wrapper = shallowMount(Assessments, {
       ...options,
       slots: {
-        success: '<marquee>🍺</marquee>',
+        success: '<marquee>Success Slot</marquee>',
       },
     });
     wrapper.setData({ completed: true });
@@ -310,30 +306,14 @@ describe('success slot for completed assessment', () => {
     const success = wrapper.find('.success');
     expect(success.exists()).toBe(true);
     expect(success.contains('p')).toBe(false);
-    expect(success.text()).not.toBe(
-      'Great job, you\'ve answered all the questions for this tutorial.',
-    );
 
     const message = success.find('marquee');
     expect(message.exists()).toBe(true);
-    expect(message.text()).toBe('🍺');
-  });
-
-  it('renders a "success" slot message when provided on aria live element for AX', () => {
-    const wrapper = shallowMount(Assessments, {
-      ...options,
-      slots: {
-        success: '<marquee>🍺</marquee>',
-      },
-    });
-    wrapper.setData({ completed: true });
+    expect(message.text()).toBe('Success Slot');
 
     const ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
     expect(ariaLive.exists()).toBe(true);
-    expect(ariaLive.text()).not.toBe(
-      'Great job, you\'ve answered all the questions for this tutorial.',
-    );
-
-    expect(ariaLive.text()).toBe('🍺');
+    // Aria live is updated
+    expect(ariaLive.text()).toBe('Success Slot');
   });
 });

--- a/tests/unit/components/Tutorial/Assessments.spec.js
+++ b/tests/unit/components/Tutorial/Assessments.spec.js
@@ -281,6 +281,23 @@ describe('success slot for completed assessment', () => {
     );
   });
 
+  it('renders a default "success" message on aria live element for AX', () => {
+    const wrapper = shallowMount(Assessments, {
+      ...options,
+    });
+    const ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
+    expect(ariaLive.exists()).toBe(true);
+    expect(ariaLive.text()).not.toBe(
+      'Great job, you\'ve answered all the questions for this tutorial.',
+    );
+
+    wrapper.setData({ completed: true });
+
+    expect(ariaLive.text()).toBe(
+      'Great job, you\'ve answered all the questions for this tutorial.',
+    );
+  });
+
   it('renders a "success" slot when provided', () => {
     const wrapper = shallowMount(Assessments, {
       ...options,
@@ -300,5 +317,23 @@ describe('success slot for completed assessment', () => {
     const message = success.find('marquee');
     expect(message.exists()).toBe(true);
     expect(message.text()).toBe('🍺');
+  });
+
+  it('renders a "success" slot message when provided on aria live element for AX', () => {
+    const wrapper = shallowMount(Assessments, {
+      ...options,
+      slots: {
+        success: '<marquee>🍺</marquee>',
+      },
+    });
+    wrapper.setData({ completed: true });
+
+    const ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
+    expect(ariaLive.exists()).toBe(true);
+    expect(ariaLive.text()).not.toBe(
+      'Great job, you\'ve answered all the questions for this tutorial.',
+    );
+
+    expect(ariaLive.text()).toBe('🍺');
   });
 });

--- a/tests/unit/components/Tutorial/Assessments/Quiz.spec.js
+++ b/tests/unit/components/Tutorial/Assessments/Quiz.spec.js
@@ -198,20 +198,30 @@ describe('Quiz', () => {
       const choice = choices.at(0);
       choice.trigger('click');
       submit.trigger('click');
-
-      const indicator = choice.find('[aria-live="assertive"].visuallyhidden');
-      expect(indicator.exists()).toBe(true);
-      expect(indicator.text()).toBe('Correct Answer');
     });
 
     it('renders visually hidden indicator of incorrect choice', () => {
       const choice = choices.at(1);
       choice.trigger('click');
       submit.trigger('click');
+    });
 
-      const indicator = choice.find('[aria-live="assertive"].visuallyhidden');
-      expect(indicator.exists()).toBe(true);
-      expect(indicator.text()).toBe('Incorrect Answer');
+    it('updates the aria live text telling the user if the answer chosen is correct or incorrect', () => {
+      const ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
+      expect(ariaLive.exists()).toBe(true);
+      expect(ariaLive.text()).toBe('');
+
+      let choice = choices.at(1);
+      choice.trigger('click');
+      submit.trigger('click');
+
+      expect(ariaLive.text()).toBe('Answer number 2 is incorrect');
+
+      choice = choices.at(0);
+      choice.trigger('click');
+      submit.trigger('click');
+
+      expect(ariaLive.text()).toBe('Answer number 1 is correct');
     });
   });
 });

--- a/tests/unit/components/Tutorial/Assessments/Quiz.spec.js
+++ b/tests/unit/components/Tutorial/Assessments/Quiz.spec.js
@@ -194,18 +194,6 @@ describe('Quiz', () => {
       expect(choice.find('.choice-icon').html()).toContain('<resetcircleicon');
     });
 
-    it('renders visually hidden indicator of correct choice', () => {
-      const choice = choices.at(0);
-      choice.trigger('click');
-      submit.trigger('click');
-    });
-
-    it('renders visually hidden indicator of incorrect choice', () => {
-      const choice = choices.at(1);
-      choice.trigger('click');
-      submit.trigger('click');
-    });
-
     it('updates the aria live text telling the user if the answer chosen is correct or incorrect', () => {
       const ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
       expect(ariaLive.exists()).toBe(true);


### PR DESCRIPTION
Bug/issue #56352262, if applicable: 

## Summary

### Problem
When using VoiceOver at Check Your Understanding of a Tutorial, there is no clear feedback to let the reader know if a selected answer was right or wrong.

### Solution
aria-live needs to be a single HTML element and every time that it gets its text updated with new information the screen reader will read its content out loud.

## Dependencies

NA

## Testing

Use the provided fixture folder:
[manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/7722113/manual-fixtures.zip)

Steps:
1. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures/ npm run serve`
2. Go to http://localhost:8080/tutorials/slothcreator/creating-custom-sloths "Check Your Understanding" section
3. Open VoiceOver
4. Select an option and click the Submit button
5. Assert that every time you click the Submit button, VoiceOver reads if the answer is correct or incorrect.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
