### PR TITLE
Adjust `scrollBehavior` for smaller nav at small breakpoint

### DIFF
--- a/src/components/BreakpointEmitter.vue
+++ b/src/components/BreakpointEmitter.vue
@@ -9,44 +9,12 @@
 -->
 
 <script>
-import { BreakpointName } from 'docc-render/utils/breakpoints';
+import {
+  BreakpointAttributes,
+  BreakpointName,
+  BreakpointScopes,
+} from 'docc-render/utils/breakpoints';
 
-const BreakpointScopes = {
-  default: 'default',
-  nav: 'nav',
-};
-
-const BreakpointAttributes = {
-  [BreakpointScopes.default]: {
-    [BreakpointName.large]: {
-      minWidth: 1069,
-      contentWidth: 980,
-    },
-    [BreakpointName.medium]: {
-      minWidth: 736,
-      maxWidth: 1068,
-      contentWidth: 692,
-    },
-    [BreakpointName.small]: {
-      minWidth: 320,
-      maxWidth: 735,
-      contentWidth: 280,
-    },
-  },
-  [BreakpointScopes.nav]: {
-    [BreakpointName.large]: {
-      minWidth: 1024,
-    },
-    [BreakpointName.medium]: {
-      minWidth: 768,
-      maxWidth: 1023,
-    },
-    [BreakpointName.small]: {
-      minWidth: 320,
-      maxWidth: 767,
-    },
-  },
-};
 const maxQuery = maxWidth => (maxWidth ? `(max-width: ${maxWidth}px)` : '');
 const minQuery = minWidth => (minWidth ? `(min-width: ${minWidth}px)` : '');
 

--- a/src/constants/nav.js
+++ b/src/constants/nav.js
@@ -10,4 +10,5 @@
 
 // eslint-disable-next-line import/prefer-default-export
 export const baseNavHeight = 52;
+export const baseNavHeightSmallBreakpoint = 48;
 export const baseNavStickyAnchorId = 'nav-sticky-anchor';

--- a/src/utils/breakpoints.js
+++ b/src/utils/breakpoints.js
@@ -14,6 +14,43 @@ export const BreakpointName = {
   small: 'small',
 };
 
+export const BreakpointScopes = {
+  default: 'default',
+  nav: 'nav',
+};
+
+export const BreakpointAttributes = {
+  [BreakpointScopes.default]: {
+    [BreakpointName.large]: {
+      minWidth: 1069,
+      contentWidth: 980,
+    },
+    [BreakpointName.medium]: {
+      minWidth: 736,
+      maxWidth: 1068,
+      contentWidth: 692,
+    },
+    [BreakpointName.small]: {
+      minWidth: 320,
+      maxWidth: 735,
+      contentWidth: 280,
+    },
+  },
+  [BreakpointScopes.nav]: {
+    [BreakpointName.large]: {
+      minWidth: 1024,
+    },
+    [BreakpointName.medium]: {
+      minWidth: 768,
+      maxWidth: 1023,
+    },
+    [BreakpointName.small]: {
+      minWidth: 320,
+      maxWidth: 767,
+    },
+  },
+};
+
 const breakpointWeights = {
   [BreakpointName.small]: 0,
   [BreakpointName.medium]: 1,

--- a/src/utils/router-utils.js
+++ b/src/utils/router-utils.js
@@ -8,8 +8,12 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { baseNavHeight } from 'docc-render/constants/nav';
+import {
+  baseNavHeight,
+  baseNavHeightSmallBreakpoint,
+} from 'docc-render/constants/nav';
 import { documentationTopicName } from 'docc-render/constants/router';
+import { BreakpointAttributes } from 'docc-render/utils/breakpoints';
 import { waitFrames } from 'docc-render/utils/loading';
 import { cssEscapeTopicIdHash } from 'docc-render/utils/strings';
 import { areEquivalentLocations } from 'docc-render/utils/url-helper';
@@ -21,6 +25,16 @@ import { areEquivalentLocations } from 'docc-render/utils/url-helper';
 export function getCurrentLocation() {
   const { location } = window;
   return location.pathname + location.search + location.hash;
+}
+
+function getBaseNavOffset() {
+  const viewportWidth = Math.max(
+    document.documentElement.clientWidth || 0,
+    window.innerWidth || 0,
+  );
+  return viewportWidth < BreakpointAttributes.nav.small.maxWidth
+    ? baseNavHeightSmallBreakpoint
+    : baseNavHeight;
 }
 
 export async function scrollBehavior(to, from, savedPosition) {
@@ -37,10 +51,11 @@ export async function scrollBehavior(to, from, savedPosition) {
     const { name, query, hash } = to;
     const isDocumentation = name.includes(documentationTopicName);
     const hasNavBarOpen = !!query.changes;
+    const baseNavOffset = getBaseNavOffset();
     // if on docs and have API changes enabled
-    const apiChangesNavHeight = (isDocumentation && hasNavBarOpen) ? baseNavHeight : 0;
+    const apiChangesNavHeight = (isDocumentation && hasNavBarOpen) ? baseNavOffset : 0;
     // compensate for the nav sticky height.
-    const offset = baseNavHeight + apiChangesNavHeight;
+    const offset = baseNavOffset + apiChangesNavHeight;
 
     const y = process.env.VUE_APP_TARGET === 'ide' ? 0 : offset;
     return { selector: cssEscapeTopicIdHash(hash), offset: { x: 0, y } };

--- a/tests/unit/utils/router-utils.spec.js
+++ b/tests/unit/utils/router-utils.spec.js
@@ -8,7 +8,10 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { baseNavHeight } from 'docc-render/constants/nav';
+import {
+  baseNavHeight,
+  baseNavHeightSmallBreakpoint,
+} from 'docc-render/constants/nav';
 import { documentationTopicName } from 'docc-render/constants/router';
 import {
   scrollBehavior as originalScrollBehavior,
@@ -76,6 +79,20 @@ describe('router-utils', () => {
         selector: routeDocsNoChanges.hash,
         offset: { x: 0, y: baseNavHeight },
       });
+    });
+
+    it('resolves with a smaller nav height offset at small breakpoints', async () => {
+      const { innerWidth } = window;
+      window.innerWidth = 400;
+
+      const routeDocsNoChanges = createRoute(documentationTopicName, {}, 'bar');
+      const resolved = await scrollBehavior(routeDocsNoChanges, routeBar);
+      expect(resolved).toEqual({
+        selector: routeDocsNoChanges.hash,
+        offset: { x: 0, y: baseNavHeightSmallBreakpoint },
+      });
+
+      window.innerWidth = innerWidth;
     });
 
     it('resolves with a double nav height offset if passed `hash` and has API `changes`.', async () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 78199719

## Summary

This fixes an issue where the scroll position is off by 4 pixels when jumping to a part of the page using a fragment URL _only_ for devices/windows with small widths.

Since the base nav has a height of 48px instead of 52px only at the small breakpoint, this smaller value should be used as an offset when calculating the y scroll position value.

Here are example before/after screenshots showing the scroll position with main compared to this branch (notice how the background from the previous section bleeds over by a very small amount on main).

**main**
<img width="500" alt="Screen Shot 2021-12-16 at 2 01 01 PM" src="https://user-images.githubusercontent.com/212918/146465614-bcfe4503-a39f-4650-9b07-df20cb1e0483.png">

**this branch**
<img width="500" alt="Screen Shot 2021-12-16 at 2 02 32 PM" src="https://user-images.githubusercontent.com/212918/146465629-2106a9f6-1bab-4939-9d2f-17bd71f4e25b.png">

## Testing

Steps:
1. Download/unzip [manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/7731114/manual-fixtures.zip)
2. Configure `VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures npm run serve`
3. Enter "Responsive Design Mode" in Safari and choose a small device width.
4. Open the following URL: http://localhost:8080/tutorials/slothcreator/creating-custom-sloths#Create-a-new-project-and-add-SlothCreator
5. Verify that the background from the previous section is no longer visible like in the screenshot example from the main branch.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
