### PR TITLE
Prevent scrolling the page, when using the custom dropdown component

### DIFF
--- a/src/components/DropdownCustom.vue
+++ b/src/components/DropdownCustom.vue
@@ -117,7 +117,7 @@ export default {
     async closeAndFocusToggler() {
       this.closeDropdown();
       await this.$nextTick();
-      this.$refs.dropdownToggle.focus();
+      this.$refs.dropdownToggle.focus({ preventScroll: true });
     },
     closeDropdown() {
       this.isOpen = false;
@@ -151,7 +151,7 @@ export default {
         return;
       }
       // focus the new element
-      nextElement.focus();
+      nextElement.focus({ preventScroll: true });
     },
     /**
      * Focuses the currently active option
@@ -161,7 +161,7 @@ export default {
       const currentOption = this.$el.querySelector(`.${ActiveOptionClass}`);
       if (!currentOption) return;
       await this.$nextTick();
-      currentOption.focus();
+      currentOption.focus({ preventScroll: true });
     },
   },
 };
@@ -237,6 +237,7 @@ $focus-shadow: 0 0 0 2px var(--color-focus-color);
 // the wrapping in `dropdown-custom` is needed to properly apply the /deep/ selector
 .dropdown-custom {
   border-radius: $border-radius;
+
   &.is-open {
     border-radius: $border-radius $border-radius 0 0;
   }


### PR DESCRIPTION
Bug/issue #, if applicable:  86641543

## Summary

In latest Safari Technology Preview if you click on the Tutorial pages navigation dropdowns, you get scrolled to the top.

This is a result of us focusing items inside the dropdown, and the page trying to scroll to those items.

## Dependencies

NA

## Testing

Steps:
1. Use any docc archive with a tutorial in it
2. Open the tutorial page and one of the two dropdowns in the Navigation bar
3. Assert that the page does not scroll to the top, upon opening the dropdowns.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - no need
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
