### PR TITLE
Fix minor import syntax issue

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/PossibleValues.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/PossibleValues.vue
@@ -27,7 +27,7 @@
 <script>
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
 import ContentNode from 'docc-render/components/ContentNode.vue';
-import WordBreak from '@/components/WordBreak.vue';
+import WordBreak from 'docc-render/components/WordBreak.vue';
 
 export default {
   name: 'PossibleValues',


### PR DESCRIPTION
Bug/issue #, if applicable: 48833910

## Summary

Fixes a very minor syntax issue with a recently added import statement to use the `docc-render` alias instead of `@`, which could cause issues for other applications using this project as a component library.

(This import statement was recently added with #34)

## Testing

Steps:
1. Ensure all unit tests still pass and application still builds.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
