### PR TITLE
Fix scroll to section, when called from inside opened mobile navigation

### DIFF
--- a/src/mixins/onPageLoadScrollToFragment.js
+++ b/src/mixins/onPageLoadScrollToFragment.js
@@ -8,14 +8,12 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { waitFrames } from 'docc-render/utils/loading';
 import scrollToElement from 'docc-render/mixins/scrollToElement';
 
 export default {
   mixins: [scrollToElement],
-  async mounted() {
+  mounted() {
     if (this.$route.hash) {
-      await waitFrames(8);
       this.scrollToElement(this.$route.hash);
     }
   },

--- a/src/mixins/scrollToElement.js
+++ b/src/mixins/scrollToElement.js
@@ -8,21 +8,24 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import { waitFrames } from 'docc-render/utils/loading';
+
 export default {
   methods: {
-    scrollToElement(hash) {
+    async scrollToElement(hash) {
+      // wait a few frames, so the app has settled down animating, loading or unlocking scrolls
+      await waitFrames(8);
       const resolvedRoute = this.$router.resolve({ hash });
-      return this.$router.options.scrollBehavior(resolvedRoute.route).then(({
+      const {
         selector,
         offset,
-      }) => {
-        const element = document.querySelector(selector);
-        if (!element) return null;
+      } = await this.$router.options.scrollBehavior(resolvedRoute.route);
+      const element = document.querySelector(selector);
+      if (!element) return null;
 
-        element.scrollIntoView();
-        window.scrollBy(-offset.x, -offset.y);
-        return element;
-      });
+      element.scrollIntoView();
+      window.scrollBy(-offset.x, -offset.y);
+      return element;
     },
   },
 };

--- a/tests/unit/components/Tutorial/NavigationBar.spec.js
+++ b/tests/unit/components/Tutorial/NavigationBar.spec.js
@@ -14,6 +14,12 @@ import {
 } from '@vue/test-utils';
 import NavigationBar from 'docc-render/components/Tutorial/NavigationBar.vue';
 import TopicStore from 'docc-render/stores/TopicStore';
+import scrollToElement from 'docc-render/mixins/scrollToElement';
+import { flushPromises } from '../../../../test-utils';
+
+jest.mock('docc-render/mixins/scrollToElement');
+
+scrollToElement.methods.scrollToElement.mockResolvedValue(true);
 
 const {
   PrimaryDropdown,
@@ -102,6 +108,10 @@ describe('NavigationBar', () => {
       NavBase,
     },
   };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('renders the NavBase', () => {
     wrapper = shallowMount(NavigationBar, mountOptions);
@@ -196,6 +206,22 @@ describe('NavigationBar', () => {
           },
         ],
       });
+    });
+
+    it('scrolls to a section, on `@select-section`, on MobileDropdown', async () => {
+      const dropdown = wrapper.find(MobileDropdown);
+      dropdown.vm.$emit('select-section', 'path/to/item#section-foo');
+      await flushPromises();
+      expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledTimes(1);
+      expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledWith('#section-foo');
+    });
+
+    it('scrolls to a section, on `@select-section`, on SecondaryDropdown', async () => {
+      const dropdown = wrapper.find(SecondaryDropdown);
+      dropdown.vm.$emit('select-section', 'path/to/item#section-foo');
+      await flushPromises();
+      expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledTimes(1);
+      expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledWith('#section-foo');
     });
 
     it('renders a "Primary Dropdown" with chapters', () => {

--- a/tests/unit/mixins/scrollToElement.spec.js
+++ b/tests/unit/mixins/scrollToElement.spec.js
@@ -10,6 +10,9 @@
 
 import { shallowMount } from '@vue/test-utils';
 import scrollToElement from 'docc-render/mixins/scrollToElement';
+import * as loading from 'docc-render/utils/loading';
+
+const framesWait = jest.spyOn(loading, 'waitFrames');
 
 describe('scrollToElement', () => {
   it('scrolls to the correct element when "scrollToElement" is called', async () => {
@@ -51,16 +54,21 @@ describe('scrollToElement', () => {
     document.querySelector = querySelectorMock;
     window.scrollBy = scrollByMock;
 
+    // start asserting
     const noneExistResponse = await wrapper.vm.scrollToElement('none-existent');
     expect(noneExistResponse).toEqual(null);
     expect(scrollIntoViewMock).not.toHaveBeenCalled();
     expect(scrollByMock).not.toHaveBeenCalled();
+    expect(framesWait).toHaveBeenCalledTimes(1);
+    expect(framesWait).toHaveBeenCalledWith(8);
 
     const response = await wrapper.vm.scrollToElement(anchor);
 
     expect(response).toEqual(mockElement);
     expect(querySelectorMock).toBeCalledWith(anchor);
     expect(scrollIntoViewMock).toBeCalled();
+    expect(framesWait).toHaveBeenCalledTimes(2);
+    expect(framesWait).toHaveBeenLastCalledWith(8);
 
     expect(scrollByMock).toBeCalledWith(-scrollOffset.x, -scrollOffset.y);
   });


### PR DESCRIPTION
Bug/issue #, if applicable: 87872480

## Summary

This PR fixes an issue on Android, where when clicking on a section of the Tutorials page, it does not scroll to it.

## Dependencies

NA

## Testing


Steps:
1. Point to a doccarchive with a tutorial `VUE_APP_DEV_SERVER_PROXY=~/path/to/archive npm run serve`
2. Go to a Tutorial
3. Using an Android device, or Chrome in responsive mode, expand the nav
4. Click on a section, within your current page
5. Assert it scrolls to that section upon closing the nav automatically.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
