### PR TITLE
Add more extendability to tutorial navs

### DIFF
--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -33,7 +33,7 @@
 <script>
 import { PortalTarget } from 'portal-vue';
 
-import NavigationBar from 'docc-render/components/Tutorial/NavigationBar.vue';
+import NavigationBar from 'theme/components/Tutorial/NavigationBar.vue';
 import pageTitle from 'docc-render/mixins/pageTitle';
 import Body from './Article/Body.vue';
 import CallToAction from './Article/CallToAction.vue';

--- a/src/components/NavMenuItemBase.vue
+++ b/src/components/NavMenuItemBase.vue
@@ -43,7 +43,7 @@ export default {
   @include nav-in-breakpoint {
     margin-left: 0;
     width: 100%;
-    height: rem(42px);
+    min-height: rem(42px);
     // remove the first border of the first element
     &:first-child {
       /deep/ .nav-menu-link {

--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -36,7 +36,7 @@ import CodeThemeStore from 'docc-render/stores/CodeThemeStore';
 import pageTitle from 'docc-render/mixins/pageTitle';
 import isClientMobile from 'docc-render/mixins/isClientMobile';
 import Hero from 'theme/components/Tutorial/Hero.vue';
-import NavigationBar from './Tutorial/NavigationBar.vue';
+import NavigationBar from 'theme/components/Tutorial/NavigationBar.vue';
 import Assessments from './Tutorial/Assessments.vue';
 import SectionList from './Tutorial/SectionList.vue';
 import CallToAction from './Tutorial/CallToAction.vue';

--- a/src/components/Tutorial/NavigationBar.vue
+++ b/src/components/Tutorial/NavigationBar.vue
@@ -53,6 +53,7 @@
           @select-section="onSelectSection"
         />
       </div>
+      <slot name="tray" :siblings="chapters.length + optionsForSections.length" />
     </template>
   </NavBase>
 </template>
@@ -173,10 +174,6 @@ export default {
       display: grid;
       grid-template-columns: auto auto 3fr;
       align-items: center;
-    }
-
-    .nav-menu-tray {
-      width: auto;
     }
 
     .nav-menu {

--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -38,9 +38,9 @@
 import TutorialsOverviewStore from 'docc-render/stores/TutorialsOverviewStore';
 
 import pageTitle from 'docc-render/mixins/pageTitle';
+import Nav from 'theme/components/TutorialsOverview/Nav.vue';
 import Hero from './TutorialsOverview/Hero.vue';
 import LearningPath from './TutorialsOverview/LearningPath.vue';
-import Nav from './TutorialsOverview/Nav.vue';
 
 const SectionKind = {
   hero: 'hero',

--- a/src/components/TutorialsOverview/Nav.vue
+++ b/src/components/TutorialsOverview/Nav.vue
@@ -17,9 +17,10 @@
       <template slot="subhead">Tutorials</template>
     </NavTitleContainer>
     <template slot="menu-items">
-      <li>
+      <NavMenuItemBase class="in-page-navigation">
         <TutorialsNavigation :sections="sections" />
-      </li>
+      </NavMenuItemBase>
+      <slot name="menu-items" />
     </template>
   </NavBase>
 </template>
@@ -29,6 +30,7 @@ import NavBase from 'docc-render/components/NavBase.vue';
 import TutorialsNavigation from 'docc-render/components/TutorialsOverview/TutorialsNavigation.vue';
 import NavTitleContainer from 'docc-render/components/NavTitleContainer.vue';
 import { buildUrl } from 'docc-render/utils/url-helper';
+import NavMenuItemBase from 'docc-render/components/NavMenuItemBase.vue';
 
 const SectionKind = {
   resources: 'resources',
@@ -39,6 +41,7 @@ export default {
   name: 'Nav',
   constants: { SectionKind },
   components: {
+    NavMenuItemBase,
     NavTitleContainer,
     TutorialsNavigation,
     NavBase,
@@ -58,25 +61,21 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-.tutorials-navigation {
-  display: none;
+.nav /deep/ .nav-menu {
+  padding-top: 0;
 
-  @include breakpoint(small, $scope: nav) {
-    display: block;
-  }
-}
+  .nav-menu-items {
+    margin-left: auto;
 
-.nav /deep/ .nav-menu .nav-menu-items {
-  padding: 12px 0 44px 0;
-  @include breakpoints-from(medium, $scope: nav) {
-    display: none;
-  }
-  @include breakpoint-exact(medium) {
-    padding-top: 25px;
-  }
-  @include breakpoint-exact(small) {
-    padding-top: 18px;
-    padding-bottom: 40px;
+    @include breakpoints-from(medium, $scope: nav) {
+      .in-page-navigation {
+        display: none;
+      }
+    }
+
+    @include breakpoint-exact(small) {
+      padding: 18px 0 40px;
+    }
   }
 }
 </style>

--- a/tests/unit/components/Tutorial/NavigationBar.spec.js
+++ b/tests/unit/components/Tutorial/NavigationBar.spec.js
@@ -122,6 +122,23 @@ describe('NavigationBar', () => {
     expect(container.exists()).toBe(true);
   });
 
+  it('renders a tray scoped slot', () => {
+    let slotProps = {};
+    wrapper = shallowMount(NavigationBar, {
+      ...mountOptions,
+      scopedSlots: {
+        tray(props) {
+          slotProps = props;
+          return 'Tray Content';
+        },
+      },
+    });
+    expect(wrapper.text()).toContain('Tray Content');
+    expect(slotProps).toEqual({
+      siblings: chapters.length,
+    });
+  });
+
   describe('with a current section', () => {
     beforeEach(() => {
       TopicStore.reset();
@@ -277,6 +294,23 @@ describe('NavigationBar', () => {
       ]);
       expect(secondaryDropdown.props('currentOption'))
         .toBe('Introduction');
+    });
+
+    it('renders a tray scoped slot', () => {
+      let slotProps = {};
+      wrapper = shallowMount(NavigationBar, {
+        ...mountOptions,
+        scopedSlots: {
+          tray(props) {
+            slotProps = props;
+            return 'Tray Content';
+          },
+        },
+      });
+      expect(wrapper.text()).toContain('Tray Content');
+      expect(slotProps).toEqual({
+        siblings: 5, // 1 chapter + 4 sections registered
+      });
     });
   });
 });

--- a/tests/unit/components/TutorialsOverview/Nav.spec.js
+++ b/tests/unit/components/TutorialsOverview/Nav.spec.js
@@ -13,6 +13,7 @@ import {
 } from '@vue/test-utils';
 import Nav from 'docc-render/components/TutorialsOverview/Nav.vue';
 import TutorialsNavigation from 'docc-render/components/TutorialsOverview/TutorialsNavigation.vue';
+import NavMenuItemBase from '@/components/NavMenuItemBase.vue';
 
 const { SectionKind } = Nav.constants;
 const {
@@ -67,7 +68,9 @@ describe('nav', () => {
   });
 
   it('renders TutorialsNavigation and passes all sections to it', () => {
-    const navigation = wrapper.find(TutorialsNavigation);
+    const itemBase = wrapper.find(NavMenuItemBase);
+    expect(itemBase.classes()).toContain('in-page-navigation');
+    const navigation = itemBase.find(TutorialsNavigation);
     expect(navigation.props('sections')).toEqual(propsData.sections);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 88095565

## Summary

Fixes minor styling leftovers from prior refactors and allows for the tutorial navigations to be more extendable by external clients.

## Dependencies

NA

## Testing

Steps:
1. Mount using an archive with tutorials
2. Make sure the navigation looks identical on both TutorialOverview and TutorialTopic pages.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
