### PR TITLE
Improve swift declaration formatting

### DIFF
--- a/app/public/theme-settings.json
+++ b/app/public/theme-settings.json
@@ -1,6 +1,9 @@
 {
   "meta": {},
   "theme": {
+    "code": {
+      "indentationWidth": 4
+    },
     "colors": {
       "text": "",
       "text-background": "",

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationGroup.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationGroup.vue
@@ -19,8 +19,6 @@
     </p>
     <Source
       :tokens="declaration.tokens"
-      :simple-indent="shouldSimpleIndent"
-      :smart-indent="shouldSmartIndent"
       :language="interfaceLanguage"
     />
   </div>
@@ -30,7 +28,6 @@
 import DeclarationSource from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue';
 import Language from 'docc-render/constants/Language';
 import { APIChangesMultipleLines } from 'docc-render/mixins/apiChangesHelpers';
-import { isParentSymbolKind } from 'docc-render/utils/symbols';
 
 /**
  * Renders a code source with an optional caption.
@@ -83,9 +80,6 @@ export default {
       return this.declaration.platforms.join(', ');
     },
     isSwift: ({ interfaceLanguage }) => interfaceLanguage === Language.swift.key.api,
-    shouldSimpleIndent: ({ isSwift, shouldSmartIndent }) => isSwift && !shouldSmartIndent,
-    shouldSmartIndent: ({ languages, symbolKind }) => languages.has(Language.objectiveC.key.api)
-      && !isParentSymbolKind(symbolKind),
   },
 };
 </script>

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -88,7 +88,7 @@ export default {
 
         // loop through the token text to look for "(" and ")" characters
         // eslint-disable-next-line no-plusplus
-        for (let k = 0; k < token.text.length; k++) {
+        for (let k = 0; k < (token.text || '').length; k++) {
           if (token.text.charAt(k) === '(') {
             numUnclosedParens += 1;
             // keep track of the token/character position of the first "("
@@ -112,7 +112,8 @@ export default {
         // if we find some text ending with ", " and the next token is the start
         // of a new param, update this token text to replace the space with a
         // newline followed by 4 spaces
-        if (token.text.endsWith(', ') && nextToken && nextToken.kind === TokenKind.externalParam) {
+        if (token.text && token.text.endsWith(', ')
+          && nextToken && nextToken.kind === TokenKind.externalParam) {
           token.text = `${token.text.trimEnd()}\n    `;
           indentedParams = true;
         }

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -56,7 +56,7 @@ export default {
       language,
       formattedSwiftTokens,
       tokens,
-    }) => (language === Language.swift.api ? formattedSwiftTokens : tokens),
+    }) => (language === Language.swift.key.api ? formattedSwiftTokens : tokens),
     // Return a formatted version of the tokens array, with additional
     // indentation whitespace to break parameters onto individual lines for
     // improved readability and scanning of Swift functions/initializers.
@@ -84,6 +84,7 @@ export default {
       while (i < tokens.length) {
         // keep track of the current token and the next one (if any)
         const token = tokens[i];
+        const newToken = { ...token };
         const nextToken = j < tokens.length ? tokens[j] : undefined;
 
         // loop through the token text to look for "(" and ")" characters
@@ -114,11 +115,11 @@ export default {
         // newline followed by 4 spaces
         if (token.text && token.text.endsWith(', ')
           && nextToken && nextToken.kind === TokenKind.externalParam) {
-          token.text = `${token.text.trimEnd()}\n    `;
+          newToken.text = `${token.text.trimEnd()}\n    `;
           indentedParams = true;
         }
 
-        newTokens.push(token);
+        newTokens.push(newToken);
         i += 1;
         j += 1;
       }

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -12,7 +12,7 @@
   <pre
     ref="declarationGroup"
     class="source"
-    :class="{ indented: simpleIndent, [multipleLinesClass]: hasMultipleLines }"
+    :class="{ [multipleLinesClass]: hasMultipleLines }"
   ><code ref="code"><Token
     v-for="(token, i) in tokens"
     :key="i"
@@ -39,10 +39,6 @@ export default {
       type: Array,
       required: true,
     },
-    smartIndent: {
-      type: Boolean,
-      default: false,
-    },
     simpleIndent: {
       type: Boolean,
       default: false,
@@ -65,7 +61,7 @@ export default {
   async mounted() {
     if (hasMultipleLines(this.$refs.declarationGroup)) this.hasMultipleLines = true;
 
-    if (!this.smartIndent || !this.language) return;
+    if (!this.language) return;
     await this.$nextTick();
     indentDeclaration(this.$refs.code, this.language);
   },

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -91,8 +91,9 @@ export default {
         const nextToken = j < tokens.length ? tokens[j] : undefined;
 
         // loop through the token text to look for "(" and ")" characters
+        const tokenLength = (token.text || '').length;
         // eslint-disable-next-line no-plusplus
-        for (let k = 0; k < (token.text || '').length; k++) {
+        for (let k = 0; k < tokenLength; k++) {
           if (token.text.charAt(k) === '(') {
             numUnclosedParens += 1;
             // keep track of the token/character position of the first "("

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -65,11 +65,18 @@ export default {
     // at certain key points to insert spaces and newlines so that each
     // parameter of a multi-parameter function gets its own line.
     //
+    // Ideally this should be implemented with a tool like SwiftFormat in the
+    // future with the raw text before it gets tokenized for syntax
+    // highlighting—however, this post-tokenization JavaScript logic should be
+    // an improvement until that kind of work can be integrated.
+    //
     // @param {Array} tokens The original syntax tokens.
     //   See `DeclarationToken.props`
     // @return {Array} A formatted version of the original tokens.
     //   See `DeclarationToken.props`
     formattedSwiftTokens: ({ tokens }) => {
+      const numSpacesForIndent = 4; // maybe this could be configurable in the future
+      const indent = ' '.repeat(numSpacesForIndent);
       let indentedParams = false;
       const newTokens = [];
       let i = 0;
@@ -115,7 +122,7 @@ export default {
         // newline followed by 4 spaces
         if (token.text && token.text.endsWith(', ')
           && nextToken && nextToken.kind === TokenKind.externalParam) {
-          newToken.text = `${token.text.trimEnd()}\n    `;
+          newToken.text = `${token.text.trimEnd()}\n${indent}`;
           indentedParams = true;
         }
 
@@ -131,7 +138,7 @@ export default {
         const originalText = newTokens[openParenTokenIndex].text;
         const begin = originalText.slice(0, openParenCharIndex);
         const end = originalText.slice(openParenCharIndex);
-        const newText = `${begin}${end}\n    `;
+        const newText = `${begin}${end}\n${indent}`;
         newTokens[openParenTokenIndex].text = newText;
       }
 

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -42,10 +42,6 @@ export default {
       type: Array,
       required: true,
     },
-    simpleIndent: {
-      type: Boolean,
-      default: false,
-    },
     language: {
       type: String,
       required: false,
@@ -166,9 +162,10 @@ export default {
   async mounted() {
     if (hasMultipleLines(this.$refs.declarationGroup)) this.hasMultipleLines = true;
 
-    if (!this.language) return;
-    await this.$nextTick();
-    indentDeclaration(this.$refs.code, this.language);
+    if (this.language === Language.objectiveC.key.api) {
+      await this.$nextTick();
+      indentDeclaration(this.$refs.code, this.language);
+    }
   },
 };
 </script>
@@ -194,13 +191,6 @@ $docs-declaration-source-border-width: 1px !default;
 
   &.has-multiple-lines {
     border-radius: $border-radius;
-  }
-
-  // simple indent
-  &.indented {
-    padding-left: $indent-spacing + $horizontal-padding;
-    text-indent: -$indent-spacing;
-    white-space: normal;
   }
 
   > code {

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -136,10 +136,7 @@ export default {
       // param onto its own line
       if (indentedParams && openParenTokenIndex !== null) {
         const originalText = newTokens[openParenTokenIndex].text;
-        const begin = originalText.slice(0, openParenCharIndex);
-        const end = originalText.slice(openParenCharIndex);
-        const newText = `${begin}${end}\n${indent}`;
-        newTokens[openParenTokenIndex].text = newText;
+        newTokens[openParenTokenIndex].text = `${originalText}\n${indent}`;
       }
 
       // if we indented some params, we want to find the closing ")" symbol

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -23,10 +23,13 @@
 import { indentDeclaration } from 'docc-render/utils/indentation';
 import { hasMultipleLines } from 'docc-render/utils/multipleLines';
 import { multipleLinesClass } from 'docc-render/constants/multipleLines';
+import { getSetting } from 'docc-render/utils/theme-settings';
 import Language from 'docc-render/constants/Language';
 import DeclarationToken from './DeclarationToken.vue';
 
 const { TokenKind } = DeclarationToken.constants;
+
+const DEFAULT_INDENTATION_WIDTH = 4;
 
 export default {
   name: 'DeclarationSource',
@@ -48,6 +51,11 @@ export default {
     },
   },
   computed: {
+    indentationWidth: () => getSetting([
+      'theme',
+      'code',
+      'indentationWidth',
+    ], DEFAULT_INDENTATION_WIDTH),
     formattedTokens: ({
       language,
       formattedSwiftTokens,
@@ -70,9 +78,8 @@ export default {
     //   See `DeclarationToken.props`
     // @return {Array} A formatted version of the original tokens.
     //   See `DeclarationToken.props`
-    formattedSwiftTokens: ({ tokens }) => {
-      const numSpacesForIndent = 4; // maybe this could be configurable in the future
-      const indent = ' '.repeat(numSpacesForIndent);
+    formattedSwiftTokens: ({ indentationWidth, tokens }) => {
+      const indent = ' '.repeat(indentationWidth);
       let indentedParams = false;
       const newTokens = [];
       let i = 0;

--- a/src/utils/indentation.js
+++ b/src/utils/indentation.js
@@ -46,7 +46,7 @@ function indentObjcDeclaration(codeElement) {
 
 /**
  * Indents content declaration tokens
- * Works only for Swift and Objc
+ * Works only for Objc
  * @param {HTMLElement} codeElement
  * @param {('occ'|'swift')} language
  */

--- a/src/utils/indentation.js
+++ b/src/utils/indentation.js
@@ -55,7 +55,7 @@ function indentSwiftDeclaration(codeElement) {
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < externalParams.length; i++) {
     const originalHtml = externalParams[i].innerHTML.trim();
-    externalParams[i].innerHTML = `\n  ${originalHtml}`;
+    externalParams[i].innerHTML = `\n    ${originalHtml}`;
   }
 
   // find the position of the closing paren for the symbol (being careful not to

--- a/src/utils/indentation.js
+++ b/src/utils/indentation.js
@@ -79,8 +79,10 @@ function indentSwiftDeclaration(codeElement) {
 
   // add a break for the closing of the function, starting with its closing paren
   const [begin, end] = [originalHtml.slice(0, closeIndex), originalHtml.slice(closeIndex)];
+  // the .replaceAll call below is used to cleanup the spaces trailing each
+  // comma since they aren't needed now that each param is on its own line
   // eslint-disable-next-line no-param-reassign
-  codeElement.innerHTML = `${begin}\n${end}`;
+  codeElement.innerHTML = `${begin.replaceAll(', ', ',')}\n${end}`;
 }
 
 /**

--- a/src/utils/indentation.js
+++ b/src/utils/indentation.js
@@ -45,64 +45,42 @@ function indentObjcDeclaration(codeElement) {
 }
 
 function indentSwiftDeclaration(codeElement) {
-  // the token-keyword token can be used to pivot on the type of declaration
-  const reservedWords = codeElement.getElementsByClassName('token-keyword');
-
-  // determine the appropriate param element to start with when applying
-  // indentation and newlines: 1 for initializers and functions.
-  let startIndex;
-  // eslint-disable-next-line no-plusplus
-  for (let i = 0; i < reservedWords.length; i++) {
-    switch (reservedWords[i].textContent.trim()) {
-    case 'func':
-    case 'init':
-      startIndex = 1;
-      break;
-      // no default
-    }
-
-    // found an initializer or a function, stop looking
-    if (startIndex) {
-      break;
-    }
-  }
-
-  // don't attempt indentation for symbols other than initializers or functions
-  if (!startIndex) {
+  const externalParams = codeElement.getElementsByClassName('token-externalParam');
+  // leave the declaration untouched if there aren't multiple params involved
+  if (externalParams.length < 2) {
     return;
   }
 
-  // find all param identifiers
-  const params = codeElement.getElementsByClassName('token-externalParam');
-  if (startIndex >= params.length) {
-    return;
-  }
-
-  // use the position of the first parenthesis as the offset to determine
-  // indentation for following lines
-  const offset = codeElement.textContent.indexOf('(');
-
-  // loop through every param name (after the first one) and calculate/apply the
-  // number of spaces to indent by subtracting the length of the name from the
-  // original offset
+  // break each function param onto its own line
   // eslint-disable-next-line no-plusplus
-  for (let i = startIndex; i < params.length; i++) {
-    const originalHtml = params[i].innerHTML.trim();
-    const originalText = params[i].textContent.trim();
-
-    const paramLen = originalText.length;
-    const numSpaces = Math.max(0, offset - paramLen);
-
-    params[i].innerHTML = `\n${' '.repeat(numSpaces)}${originalHtml}`;
+  for (let i = 0; i < externalParams.length; i++) {
+    const originalHtml = externalParams[i].innerHTML.trim();
+    externalParams[i].innerHTML = `\n  ${originalHtml}`;
   }
 
-  // Adds a newline to the end of the code listing if there isn't one. Without it,
-  // the <wbr> elements will impact items on the last line, when we don't want
-  // it to (after applying this indentation logic)
-  if (codeElement.innerHTML.charAt(codeElement.innerHTML.length - 1) !== '\n') {
-    // eslint-disable-next-line no-param-reassign
-    codeElement.innerHTML = `${codeElement.innerHTML}\n`;
+  // find the position of the closing paren for the symbol (being careful not to
+  // get tripped up by param types that are functions themselves)
+  const originalHtml = codeElement.innerHTML;
+  const openIndex = originalHtml.indexOf('(');
+  let numUnclosedParens = 1;
+  let closeIndex = openIndex + 1;
+  while (numUnclosedParens > 0 && closeIndex < originalHtml.length) {
+    const character = originalHtml.charAt(closeIndex);
+    if (character === '(') {
+      numUnclosedParens += 1;
+    }
+    if (character === ')') {
+      numUnclosedParens -= 1;
+    }
+    if (numUnclosedParens > 0) {
+      closeIndex += 1;
+    }
   }
+
+  // add a break for the closing of the function, starting with its closing paren
+  const [begin, end] = [originalHtml.slice(0, closeIndex), originalHtml.slice(closeIndex)];
+  // eslint-disable-next-line no-param-reassign
+  codeElement.innerHTML = `${begin}\n${end}`;
 }
 
 /**

--- a/src/utils/indentation.js
+++ b/src/utils/indentation.js
@@ -44,47 +44,6 @@ function indentObjcDeclaration(codeElement) {
   }
 }
 
-function indentSwiftDeclaration(codeElement) {
-  const externalParams = codeElement.getElementsByClassName('token-externalParam');
-  // leave the declaration untouched if there aren't multiple params involved
-  if (externalParams.length < 2) {
-    return;
-  }
-
-  // break each function param onto its own line
-  // eslint-disable-next-line no-plusplus
-  for (let i = 0; i < externalParams.length; i++) {
-    const originalHtml = externalParams[i].innerHTML.trim();
-    externalParams[i].innerHTML = `\n    ${originalHtml}`;
-  }
-
-  // find the position of the closing paren for the symbol (being careful not to
-  // get tripped up by param types that are functions themselves)
-  const originalHtml = codeElement.innerHTML;
-  const openIndex = originalHtml.indexOf('(');
-  let numUnclosedParens = 1;
-  let closeIndex = openIndex + 1;
-  while (numUnclosedParens > 0 && closeIndex < originalHtml.length) {
-    const character = originalHtml.charAt(closeIndex);
-    if (character === '(') {
-      numUnclosedParens += 1;
-    }
-    if (character === ')') {
-      numUnclosedParens -= 1;
-    }
-    if (numUnclosedParens > 0) {
-      closeIndex += 1;
-    }
-  }
-
-  // add a break for the closing of the function, starting with its closing paren
-  const [begin, end] = [originalHtml.slice(0, closeIndex), originalHtml.slice(closeIndex)];
-  // the .replaceAll call below is used to cleanup the spaces trailing each
-  // comma since they aren't needed now that each param is on its own line
-  // eslint-disable-next-line no-param-reassign
-  codeElement.innerHTML = `${begin.replaceAll(', ', ',')}\n${end}`;
-}
-
 /**
  * Indents content declaration tokens
  * Works only for Swift and Objc
@@ -99,9 +58,6 @@ export function indentDeclaration(codeElement, language) {
     switch (language) {
     case Language.objectiveC.key.api:
       indentObjcDeclaration(codeElement);
-      break;
-    case Language.swift.key.api:
-      indentSwiftDeclaration(codeElement);
       break;
       // no default
     }

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationGroup.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationGroup.spec.js
@@ -74,25 +74,10 @@ describe('DeclarationGroup', () => {
     expect(source.props('tokens')).toEqual(propsData.declaration.tokens);
   });
 
-  it('renders the `Source` with smart indentation', () => {
+  it('renders the `Source`', () => {
     const wrapper = createWrapper();
     const srcComponent = wrapper.find(DeclarationSource);
     expect(srcComponent.props('language')).toEqual('swift');
-    expect(srcComponent.props('smartIndent')).toEqual(true);
-    expect(srcComponent.props('simpleIndent')).toEqual(false);
-  });
-
-  it('renders the `Source` with simple indentation', () => {
-    const wrapper = createWrapper({
-      provide: {
-        interfaceLanguage: 'swift',
-        languages: new Set(['swift']),
-      },
-    });
-    const srcComponent = wrapper.find(DeclarationSource);
-    expect(srcComponent.props('language')).toEqual('swift');
-    expect(srcComponent.props('smartIndent')).toEqual(false);
-    expect(srcComponent.props('simpleIndent')).toEqual(true);
   });
 
   it('applies the `multipleLinesClass` class if `hasMultipleLinesAfterAPIChanges` is true', () => {
@@ -109,31 +94,5 @@ describe('DeclarationGroup', () => {
     });
 
     expect(wrapper.classes()).toContain(multipleLinesClass);
-  });
-
-  it('does not apply a "smart indent" for Objective-C classes/structs/etc', () => {
-    ['class', 'enum', 'protocol', 'struct'].forEach((symbolKind) => {
-      const source = createWrapper({
-        provide: {
-          interfaceLanguage: 'occ',
-          languages: new Set(['occ']),
-          symbolKind,
-        },
-      }).find(DeclarationSource);
-      expect(source.exists()).toBe(true);
-      expect(source.props('smartIndent')).toBe(false);
-    });
-  });
-
-  it('applies a "smart indent" for other Objective-C symbols', () => {
-    const source = createWrapper({
-      provide: {
-        interfaceLanguage: 'occ',
-        languages: new Set(['occ']),
-        symbolKind: 'instm',
-      },
-    }).find(DeclarationSource);
-    expect(source.exists()).toBe(true);
-    expect(source.props('smartIndent')).toBe(true);
   });
 });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -13,6 +13,7 @@ import DeclarationSource
   from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue';
 import { multipleLinesClass } from 'docc-render/constants/multipleLines';
 import { hasMultipleLines } from 'docc-render/utils/multipleLines';
+import { themeSettingsState } from 'docc-render/utils/theme-settings';
 
 const { Token } = DeclarationSource.components;
 const { TokenKind } = Token.constants;
@@ -441,5 +442,107 @@ describe('Swift function/initializer formatting', () => {
     expect(tokenComponents.at(5).props('text')).toBe('(\n    ');
     expect(tokenComponents.at(9).props('text')).toBe(',\n    ');
     expect(tokenComponents.at(13).props('text')).toBe('\n) ');
+  });
+
+  it('indents parameters using provided/customizable indentation width', () => {
+    const originalTheme = themeSettingsState.theme;
+    themeSettingsState.theme = {
+      ...originalTheme,
+      code: {
+        indentationWidth: 2,
+      },
+    };
+
+    // Before:
+    // func foo(_ a: A, _ b: B) -> Bar
+    //
+    // After:
+    // func foo(
+    //   _ a: A,
+    //   _ b: B,
+    // ) -> Bar
+    const tokens = [
+      {
+        kind: TokenKind.keyword,
+        text: 'func',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.identifier,
+        text: 'foo',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: '_',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.internalParam,
+        text: 'a',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        identifier: 'doc://com.example/documentation/blah/a',
+        text: 'A',
+      },
+      {
+        kind: TokenKind.text,
+        text: ', ',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: '_',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.internalParam,
+        text: 'b',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        identifier: 'doc://com.example/documentation/blah/b',
+        text: 'B',
+      },
+      {
+        kind: TokenKind.text,
+        text: ') -> ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        identifier: 'doc://com.example/documentation/blah/bar',
+        text: 'Bar',
+      },
+    ];
+    const wrapper = mountWithTokens(tokens);
+
+    const tokenComponents = wrapper.findAll(Token);
+    expect(tokenComponents.length).toBe(tokens.length);
+    // should be indented with 2 spaces now instead of the default of 4 spaces
+    expect(tokenComponents.at(3).props('text')).toBe('(\n  ');
+    expect(tokenComponents.at(9).props('text')).toBe(',\n  ');
+    expect(tokenComponents.at(15).props('text')).toBe('\n) -> ');
+
+    themeSettingsState.theme = originalTheme;
   });
 });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -254,4 +254,192 @@ describe('Swift function/initializer formatting', () => {
     expect(tokenComponents.at(9).props('text')).toBe(',\n    ');
     expect(tokenComponents.at(15).props('text')).toBe('\n) -> ');
   });
+
+  it('breaks apart parameters in functions with generic where clauses', () => {
+    /* eslint-disable max-len */
+    // Before:
+    // public func f(t: T, u: U) where T : Sequence, U : Sequence, T.Iterator.Element : Equatable, T.Iterator.Element == U.Iterator.Element
+    //
+    // After:
+    // public func f(
+    //     t: T,
+    //     u: U,
+    // ) where T : Sequence, U : Sequence, T.Iterator.Element : Equatable, T.Iterator.Element == U.Iterator.Element
+    /* eslint-enable max-len */
+    const tokens = [
+      {
+        kind: 'keyword',
+        text: 'public',
+      },
+      {
+        kind: 'text',
+        text: ' ',
+      },
+      {
+        kind: 'keyword',
+        text: 'func',
+      },
+      {
+        kind: 'text',
+        text: ' ',
+      },
+      {
+        kind: 'identifier',
+        text: 'f',
+      },
+      {
+        kind: 'text',
+        text: '(',
+      },
+      {
+        kind: 'externalParam',
+        text: 't',
+      },
+      {
+        kind: 'text',
+        text: ': ',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'T',
+        preciseIdentifier: 's:14ExamplePackage0A6StructV1Tq_mfp',
+      },
+      {
+        kind: 'text',
+        text: ', ',
+      },
+      {
+        kind: 'externalParam',
+        text: 'u',
+      },
+      {
+        kind: 'text',
+        text: ': ',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'U',
+        preciseIdentifier: 's:14ExamplePackage0A6StructV1Uxmfp',
+      },
+      {
+        kind: 'text',
+        text: ') ',
+      },
+      {
+        kind: 'keyword',
+        text: 'where',
+      },
+      {
+        kind: 'text',
+        text: ' ',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'U',
+      },
+      {
+        kind: 'text',
+        text: ' : ',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'Sequence',
+        preciseIdentifier: 's:ST',
+      },
+      {
+        kind: 'text',
+        text: ', ',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'T',
+      },
+      {
+        kind: 'text',
+        text: ' : ',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'Sequence',
+        preciseIdentifier: 's:ST',
+      },
+      {
+        kind: 'text',
+        text: ', ',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'U',
+      },
+      {
+        kind: 'text',
+        text: '.',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'Element',
+      },
+      {
+        kind: 'text',
+        text: ' : ',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'Equatable',
+        preciseIdentifier: 's:SQ',
+      },
+      {
+        kind: 'text',
+        text: ', ',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'U',
+      },
+      {
+        kind: 'text',
+        text: '.',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'Element',
+      },
+      {
+        kind: 'text',
+        text: ' == ',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'T',
+      },
+      {
+        kind: 'text',
+        text: '.',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'Element',
+      },
+    ];
+
+    const wrapper = mountWithTokens(tokens);
+
+    const tokenComponents = wrapper.findAll(Token);
+    expect(tokenComponents.length).toBe(tokens.length);
+
+    const modifiedTokenIndexes = new Set([5, 9, 13]);
+    tokens.forEach((token, i) => {
+      const tokenComponent = tokenComponents.at(i);
+      expect(tokenComponent.props('kind')).toBe(token.kind);
+      if (modifiedTokenIndexes.has(i)) {
+        expect(tokenComponent.props('text')).not.toBe(token.text);
+      } else {
+        expect(tokenComponent.props('text')).toBe(token.text);
+      }
+    });
+
+    expect(tokenComponents.at(5).props('text')).toBe('(\n    ');
+    expect(tokenComponents.at(9).props('text')).toBe(',\n    ');
+    expect(tokenComponents.at(13).props('text')).toBe('\n) ');
+  });
 });

--- a/tests/unit/utils/indentation.spec.js
+++ b/tests/unit/utils/indentation.spec.js
@@ -19,48 +19,6 @@ const prepare = (originalCode) => {
 };
 
 describe('indentDeclaration', () => {
-  describe('swift', () => {
-    describe('with a function', () => {
-      it('should align the param names', () => {
-        const originalCode = '<span class="token-keyword">func</span> <span class="token-identifier">components</span>(<span class="token-externalParam">_</span> <span class="token-internalParam">unitFlags</span>: NSCalendarUnit, <span class="token-externalParam">fromDate</span> <span class="token-internalParam">date</span>: NSDate) -&gt; NSDateComponents';
-        const expectedCode = '<span class="token-keyword">func</span> <span class="token-identifier">components</span>(<span class="token-externalParam">_</span> <span class="token-internalParam">unitFlags</span>: NSCalendarUnit, <span class="token-externalParam">\n       fromDate</span> <span class="token-internalParam">date</span>: NSDate) -&gt; NSDateComponents\n';
-
-        const code = prepare(originalCode);
-
-        indentDeclaration(code, 'swift');
-
-        expect(code.innerHTML).not.toEqual(originalCode);
-        expect(code.innerHTML).toEqual(expectedCode);
-      });
-    });
-
-    describe('with an initializer', () => {
-      it('should add newlines for param names', () => {
-        const originalCode = '<span class="token-keyword">init</span>(<span class="token-externalParam">foo</span> <span class="token-internalParam">foo</span>: Foo, <span class="token-externalParam">bar</span> <span class="internalParam">bar</span>: Bar)';
-        const expectedCode = '<span class="token-keyword">init</span>(<span class="token-externalParam">foo</span> <span class="token-internalParam">foo</span>: Foo, <span class="token-externalParam">\n bar</span> <span class="internalParam">bar</span>: Bar)\n';
-
-        const code = prepare(originalCode);
-
-        indentDeclaration(code, 'swift');
-
-        expect(code.innerHTML).not.toEqual(originalCode);
-        expect(code.innerHTML).toEqual(expectedCode);
-      });
-    });
-
-    describe('with a property', () => {
-      it('should not add indentation', () => {
-        const originalCode = '<span class="token-keyword">var</span> <span class="token-identifier">description</span>: <span class="token-type">String</span> { <span class="token-keyword">get</span>';
-
-        const code = prepare(originalCode);
-
-        indentDeclaration(code, 'swift');
-
-        expect(code.innerHTML).toEqual(originalCode);
-      });
-    });
-  });
-
   describe('occ', () => {
     describe('with a function', () => {
       it('should align the param names', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 88594221

## Summary

This implements a new formatting strategy for Swift declarations whereby each parameter of a multi-parameter symbol will be broken onto its own line and indented.

This should be an improvement over the way Swift declarations are currently rendered where they simply wrap at arbitrary points with some indentation. It should be easier for viewers of the documentation to visually and mentally scan/parse functions/initializers/etc for their parameters when symbols are presented in this manner.

**Example:**

Before:
![Screen Shot 2022-02-04 at 13 42 46](https://user-images.githubusercontent.com/212918/152883197-efe183e1-9c23-4de5-9f8d-91f45fb7222d.png)
After:
![Screen Shot 2022-02-04 at 13 42 57](https://user-images.githubusercontent.com/212918/152883214-e583bb9d-c266-4a19-a64a-774a36818951.png)

## Testing

Steps:
1. Download/unzip [ExamplePackage.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8019198/ExamplePackage.doccarchive.zip) and configure `VUE_DEV_SERVER_PROXY=/path/to/ExamplePackage.doccarchive` (or use an alternate fixture with Swift symbols)
2. Run the dev server with `npm run serve` and use the example docs at http://localhost:8080/documentation/examplepackage to verify that symbols are formatted as described above or compare with existing data.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary