### PR TITLE
Filter input component with tag selection

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -191,7 +191,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    focusInputOnValueChange: {
+    focusInputWhenCreated: {
       type: Boolean,
       default: false,
     },
@@ -294,18 +294,6 @@ export default {
     showSuggestedTags(value) {
       this.$emit('show-suggested-tags', value);
     },
-
-    async input() {
-      // if the `value` changes, but we are not focused on the input, we can make sure the input
-      // is focused, by setting `focusOnValueChange`
-      if (
-        this.focusInputOnValueChange
-        && document.activeElement !== this.$refs.input
-        && this.inputIsNotEmpty
-      ) {
-        this.focusInput();
-      }
-    },
   },
   methods: {
     /**
@@ -398,6 +386,15 @@ export default {
         this.$emit('focus-prev');
       }
     },
+  },
+  created() {
+    if (
+      this.focusInputWhenCreated
+      && document.activeElement !== this.$refs.input
+      && this.inputIsNotEmpty
+    ) {
+      this.focusInput();
+    }
   },
 };
 </script>

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -28,7 +28,9 @@
           @click="focusInput"
           @mousedown.prevent
         >
-          <slot name="icon" />
+          <slot name="icon">
+            <FilterIcon />
+          </slot>
         </button>
         <div
           :class="['filter__input-box-wrapper', { 'scrolling': isScrolling }]"
@@ -120,6 +122,7 @@ import ClearRoundedIcon from 'theme/components/Icons/ClearRoundedIcon.vue';
 import { pluralize } from 'docc-render/utils/strings';
 import multipleSelection from 'docc-render/mixins/multipleSelection';
 import handleScrollbar from 'docc-render/mixins/handleScrollbar';
+import FilterIcon from 'theme/components/Icons/FilterIcon.vue';
 import TagList from './TagList.vue';
 
 // Max number of tags to show
@@ -153,6 +156,7 @@ export default {
   components: {
     TagList,
     ClearRoundedIcon,
+    FilterIcon,
   },
   props: {
     positionReversed: {

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -1,0 +1,529 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <div
+    class="filter"
+    role="search"
+    tabindex="0"
+    :aria-labelledby="searchAriaLabelledBy"
+    @blur.capture="handleBlur"
+    @focus.capture="showSuggestedTags = true"
+    :class="{ 'focus': showSuggestedTags }"
+  >
+    <div :class="['filter__wrapper', { 'filter__wrapper--reversed': positionReversed }]">
+      <div class="filter__top-wrapper">
+        <button
+          @click="focusInput"
+          @mousedown.prevent
+          class="filter__filter-button"
+          aria-hidden="true"
+          tabindex="-1"
+        >
+          <div :class="{ 'blue': inputIsNotEmpty }">
+            <slot name="icon" />
+          </div>
+        </button>
+        <div
+          :class="['filter__input-box-wrapper', { 'scrolling': isScrolling }]"
+          @scroll="handleScroll"
+        >
+          <TagList
+            :id="SelectedTagsId"
+            v-if="hasSelectedTags"
+            @focus-prev="positionReversed ? focusFirstTag() : null"
+            @focus-next="focusInputFromTags"
+            @reset-filters="resetFilters"
+            @prevent-blur="$emit('update:preventedBlur', true)"
+            v-on="selectedTagsMultipleSelectionListeners"
+            :input="input"
+            :tags="selectedTags"
+            :ariaLabel="selectedTagsLabel"
+            v-bind="{
+              ...virtualKeyboardBind,
+              ...selectedTagsMultipleSelectionBind
+            }"
+            class="filter__selected-tags"
+            ref="selectedTags"
+            areTagsRemovable
+          />
+          <label
+            :for="FilterInputId"
+            class="visuallyhidden"
+            id="filter-label"
+            aria-hidden="true"
+          >
+            {{ placeholderText }}
+          </label>
+          <input
+            :id="FilterInputId"
+            v-model="modelValue"
+            @keydown.down.prevent="positionReversed ? null : focusFirstTag()"
+            @keydown.up.prevent="positionReversed ? focusFirstTag() : null"
+            @keydown.left="leftKeyInputHandler"
+            @keydown.right="rightKeyInputHandler"
+            @keydown.delete="deleteHandler"
+            @keydown.meta.a.prevent="selectInputAndTags"
+            @keydown.ctrl.a.prevent="selectInputAndTags"
+            @keydown.exact="inputKeydownHandler"
+            @keydown.enter.exact="enterHandler"
+            @keydown.shift.exact="inputKeydownHandler"
+            @keydown.shift.meta.exact="inputKeydownHandler"
+            @keydown.meta.exact="assignEventValues"
+            @keydown.ctrl.exact="assignEventValues"
+            v-on="inputMultipleSelectionListeners"
+            :placeholder="hasSelectedTags ? '' : placeholderText"
+            :aria-expanded="displaySuggestedTags ? 'true' : 'false'"
+            v-bind="AXinputProperties"
+            type="text"
+            class="filter__input"
+            ref="input"
+          >
+        </div>
+        <div class="filter__delete-button-wrapper">
+          <button
+            @click="resetFilters(true)"
+            @mousedown.prevent
+            v-if="(input.length) || displaySuggestedTags || hasSelectedTags"
+            aria-label="Reset Filter"
+            class="filter__delete-button"
+          >
+            <ClearRoundedIcon />
+          </button>
+        </div>
+      </div>
+      <TagList
+        :id="SuggestedTagsId"
+        v-if="displaySuggestedTags"
+        @click-tags="selectTag($event.tagName)"
+        @prevent-blur="$emit('update:preventedBlur', true)"
+        @focus-next="positionReversed ? focusInput() : $emit('exit-filter')"
+        @focus-prev="positionReversed ? $emit('exit-filter') : focusInput()"
+        :ariaLabel="suggestedTagsLabel"
+        :input="input"
+        :tags="suggestedTags"
+        v-bind="virtualKeyboardBind"
+        class="filter__suggested-tags"
+        ref="suggestedTags"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import ClearRoundedIcon from 'theme/components/Icons/ClearRoundedIcon.vue';
+import { pluralize } from 'docc-render/utils/strings';
+import multipleSelection from 'docc-render/mixins/multipleSelection';
+import handleScrollbar from 'docc-render/mixins/handleScrollbar';
+import TagList from './TagList.vue';
+
+export const TagLimit = 5;
+const FilterInputId = 'filter-input';
+const SelectedTagsId = 'selected-tags';
+const SuggestedTagsId = 'suggested-tags';
+const AXinputProperties = {
+  autocorrect: 'off',
+  autocapitalize: 'off',
+  autocomplete: 'off',
+  spellcheck: 'false',
+  role: 'combobox',
+  'aria-haspopup': 'true',
+  'aria-autocomplete': 'none',
+  'aria-owns': 'suggestedTags',
+  'aria-controls': 'suggestedTags',
+};
+
+export default {
+  name: 'FilterInput',
+  mixins: [handleScrollbar, multipleSelection],
+  constants: {
+    FilterInputId,
+    SelectedTagsId,
+    SuggestedTagsId,
+    AXinputProperties,
+    TagLimit,
+  },
+  components: {
+    TagList,
+    ClearRoundedIcon,
+  },
+  props: {
+    positionReversed: {
+      type: Boolean,
+      default: () => false,
+    },
+    tags: {
+      type: Array,
+      default: () => ([]),
+    },
+    selectedTags: {
+      type: Array,
+      default: () => [],
+    },
+    preventedBlur: {
+      type: Boolean,
+      default: () => false,
+    },
+    placeholderText: {
+      type: String,
+      default: () => 'Filter',
+    },
+    value: {
+      type: String,
+      default: () => '',
+    },
+  },
+  data() {
+    return {
+      resetedTagsViaDeleteButton: false,
+      FilterInputId,
+      SelectedTagsId,
+      SuggestedTagsId,
+      AXinputProperties,
+      showSuggestedTags: false,
+    };
+  },
+  methods: {
+    /**
+     * Focuses the input
+     * @returns {Promise<void>}
+     */
+    async focusInput() {
+      // make sure everything is rendered
+      await this.$nextTick();
+      // focus the input
+      this.$refs.input.focus();
+
+      if (!this.input && this.resetActiveTags) {
+        this.resetActiveTags();
+      }
+    },
+    async resetFilters(hideTags = false) {
+      this.setFilterInput('');
+      this.setSelectedTags([]);
+
+      if (!hideTags) {
+        // We prevent blur from hiding tags
+        this.$emit('update:preventedBlur', true);
+        if (this.resetActiveTags) {
+          this.resetActiveTags();
+        }
+        await this.focusInput();
+        return;
+      }
+
+      this.resetedTagsViaDeleteButton = true;
+      this.showSuggestedTags = false;
+      this.$refs.input.blur();
+    },
+    focusFirstTag() {
+      if (this.hasSuggestedTags) {
+        this.$refs.suggestedTags.focusFirstTag();
+      }
+    },
+    setFilterInput(value) {
+      this.$emit('input', value);
+    },
+    setSelectedTags(tags) {
+      this.$emit('update:selectedTags', tags);
+    },
+    deleteTags(array) {
+      this.setSelectedTags(this.selectedTags.filter(tag => !array.includes(tag)));
+    },
+    async handleBlur(event) {
+      // if the blur came from clicking a link
+      const target = event.relatedTarget;
+      if (target && target.matches && target.matches('button, input, ul')) return;
+      // Wait for mousedown to send event listeners
+      await this.$nextTick();
+
+      this.resetActiveTags();
+
+      if (this.preventedBlur) {
+        this.$emit('update:preventedBlur', false);
+        return;
+      }
+      this.showSuggestedTags = false;
+    },
+  },
+  computed: {
+    tagsText: ({ suggestedTags }) => pluralize({
+      en: {
+        one: 'tag',
+        other: 'tags',
+      },
+    }, suggestedTags.length),
+    selectedTagsLabel: ({ tagsText }) => `Selected ${tagsText}`,
+    suggestedTagsLabel: ({ tagsText }) => `Suggested ${tagsText}`,
+    hasSuggestedTags: ({ suggestedTags }) => suggestedTags.length,
+    hasSelectedTags: ({ selectedTags }) => selectedTags.length,
+    inputIsNotEmpty: ({ input, hasSelectedTags }) => input.length || hasSelectedTags,
+    searchAriaLabelledBy: ({ hasSelectedTags }) => (
+      hasSelectedTags ? FilterInputId.concat(' ', SelectedTagsId) : FilterInputId
+    ),
+    modelValue: {
+      get: ({ value }) => value,
+      set(v) {
+        this.$emit('input', v);
+      },
+    },
+    input: ({ value }) => value,
+    /**
+     * Result of filtering selectedTags out of tags
+     * Cuts off tags at dedicated length, if showing default suggested
+     * or already filtered ones.
+     * @returns {string[]}
+     */
+    suggestedTags: ({ tags, selectedTags, useDefaultSuggestedTags }) => {
+      const suggestedTags = tags.filter(tag => !selectedTags.includes(tag));
+
+      return useDefaultSuggestedTags
+        ? suggestedTags
+        : suggestedTags.slice(0, TagLimit);
+    },
+    displaySuggestedTags: ({ showSuggestedTags, suggestedTags }) => (
+      showSuggestedTags && suggestedTags.length > 0
+    ),
+    inputMultipleSelectionListeners: ({
+      resetActiveTags,
+      handleCopy,
+      handleCut,
+      handlePaste,
+    }) => (
+      {
+        click: () => resetActiveTags(),
+        copy: event => handleCopy(event),
+        cut: event => handleCut(event),
+        paste: event => handlePaste(event),
+      }
+    ),
+    selectedTagsMultipleSelectionListeners: ({
+      handleSingleTagClick,
+      selectInputAndTags,
+      handleDeleteTag,
+      selectedTagsKeydownHandler,
+      focusTagHandler,
+      handlePaste,
+    }) => (
+      {
+        'click-tags': event => handleSingleTagClick(event),
+        'select-all': () => selectInputAndTags(),
+        'delete-tag': event => handleDeleteTag(event),
+        keydown: event => selectedTagsKeydownHandler(event),
+        focus: event => focusTagHandler(event),
+        'paste-tags': event => handlePaste(event),
+      }
+    ),
+    selectedTagsMultipleSelectionBind: ({ activeTags }) => ({ activeTags }
+    ),
+  },
+  watch: {
+    async selectedTags() {
+      if (!this.resetedTagsViaDeleteButton) {
+        await this.focusInput();
+      } else {
+        this.resetedTagsViaDeleteButton = false;
+      }
+
+      if (this.displaySuggestedTags && this.hasSuggestedTags) {
+        this.$refs.suggestedTags.resetScroll();
+      }
+    },
+
+    suggestedTags(value) {
+      this.$emit('suggested-tags', value);
+    },
+
+    showSuggestedTags(value) {
+      this.$emit('show-suggested-tags', value);
+    },
+
+    // If input value changes from query parameters data, focus on the input
+    async input() {
+      // We know that changes comes from query parameters
+      // when input value changes and input element is not focus.
+      if (document.activeElement !== this.$refs.input && this.inputIsNotEmpty) {
+        this.focusInput();
+      }
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@import 'docc-render/styles/_core.scss';
+
+$filter-bar-background-color: rgba(255, 255, 255, .8);
+$tag-outline-padding: 4px;
+$input-vertical-padding: 13px;
+
+.filter {
+  position: relative;
+  box-sizing: border-box;
+  // Remove Gray Highlight When Tapping Links in Mobile Safari =>
+  // https://css-tricks.com/snippets/css/remove-gray-highlight-when-tapping-links-in-mobile-safari/
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  border-radius: $small-border-radius + 1;
+  @include on-keyboard-focus() {
+    outline: none;
+  }
+
+  &__top-wrapper {
+    display: flex;
+  }
+
+  &__filter-button {
+    position: relative;
+    margin-left: rem(10px);
+    z-index: 1;
+    cursor: text;
+    margin-right: rem(3px);
+
+    @include breakpoint(small) {
+      margin-right: rem(7px);
+    }
+
+    .svg-icon {
+      fill: var(--color-fill-gray-secondary);
+      display: block;
+      height: 21px;
+    }
+
+    .blue > * {
+      fill: var(--color-figure-blue);
+    }
+  }
+
+  &.focus {
+    .filter__wrapper {
+      box-shadow: 0 0 0 3pt var(--color-focus-color);
+      border-color: var(--color-fill-blue);
+    }
+  }
+
+  &__wrapper {
+    border: 1px solid var(--color-fill-gray-secondary);
+    background: var(--color-fill);
+    border-radius: $small-border-radius;
+
+    &--reversed {
+      display: flex;
+      flex-direction: column-reverse;
+    }
+  }
+
+  &__suggested-tags {
+    border-top: 1px solid var(--color-fill-gray-tertiary);
+    z-index: 1;
+    overflow: hidden;
+
+    /deep/ ul {
+      padding: rem($input-vertical-padding) rem(9px);
+      border: 1px solid transparent;
+      border-bottom-left-radius: $small-border-radius - 1;
+      border-bottom-right-radius: $small-border-radius - 1;
+
+      .fromkeyboard & {
+        &:focus {
+          outline: none;
+          box-shadow: 0 0 0 5px var(--color-focus-color);
+        }
+      }
+    }
+
+    .filter__wrapper--reversed & {
+      border-bottom: 1px solid var(--color-fill-gray-tertiary);
+      border-top: none;
+    }
+  }
+
+  &__selected-tags {
+    z-index: 1;
+    padding-left: $tag-outline-padding;
+    margin: -$tag-outline-padding 0;
+
+    @include breakpoint(small) {
+      padding-left: 0;
+    }
+
+    /deep/ {
+      ul {
+        padding: $tag-outline-padding;
+
+        @include breakpoint(small) {
+          padding-right: rem(7px);
+        }
+
+        .tag:last-child {
+          padding-right: 0;
+        }
+      }
+    }
+  }
+
+  &__delete-button {
+    @include replace-outline-for-shadow-on-focus;
+    position: relative;
+    margin: 0;
+    z-index: 1;
+    border-radius: 100%;
+
+    .clear-rounded-icon {
+      height: rem(16px);
+      width: rem(16px);
+      fill: var(--color-fill-gray-secondary);
+      display: block;
+    }
+  }
+
+  &__delete-button-wrapper {
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    border-top-right-radius: $small-border-radius;
+    border-bottom-right-radius: $small-border-radius;
+  }
+
+  &__input-box-wrapper {
+    @include custom-horizontal-scrollbar;
+    display: flex;
+    overflow-x: auto;
+    align-items: center;
+    cursor: text;
+    flex: 1;
+  }
+
+  &__input {
+    @include font-styles(body-large);
+    color: var(--color-text);
+    height: rem(28px);
+    border: none;
+    width: 100%;
+    min-width: 130px; // set a min width, so it does not get crushed by tags
+    background: transparent;
+    padding: rem($input-vertical-padding) 0;
+    z-index: 1;
+    // Text indent is needed instead of padding so text inside <input> doesn't get cut off
+    text-indent: rem(7px);
+
+    @include breakpoint(small) {
+      text-indent: rem(3px);
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &[placeholder] {
+      @include placeholder(var(--color-fill-gray-secondary))
+    }
+  }
+}
+</style>

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -398,9 +398,13 @@ export default {
 
 $tag-outline-padding: 4px !default;
 $input-vertical-padding: rem(13px) !default;
+$input-height: rem(28px);
 
 .filter {
   --input-vertical-padding: #{$input-vertical-padding};
+  --input-height: #{$input-height};
+  --input-border-color: var(--color-fill-gray-secondary);
+  --input-text: var(--color-fill-gray-secondary);
 
   position: relative;
   box-sizing: border-box;
@@ -428,7 +432,7 @@ $input-vertical-padding: rem(13px) !default;
     }
 
     .svg-icon {
-      fill: var(--color-fill-gray-secondary);
+      fill: var(--input-text);
       display: block;
       height: 21px;
     }
@@ -442,12 +446,12 @@ $input-vertical-padding: rem(13px) !default;
   &.focus {
     .filter__wrapper {
       box-shadow: 0 0 0 3pt var(--color-focus-color);
-      border-color: var(--color-fill-blue);
+      --input-border-color: var(--color-fill-blue);
     }
   }
 
   &__wrapper {
-    border: 1px solid var(--color-fill-gray-secondary);
+    border: 1px solid var(--input-border-color);
     background: var(--color-fill);
     border-radius: $small-border-radius;
 
@@ -516,7 +520,7 @@ $input-vertical-padding: rem(13px) !default;
     .clear-rounded-icon {
       height: rem(16px);
       width: rem(16px);
-      fill: var(--color-fill-gray-secondary);
+      fill: var(--input-text);
       display: block;
     }
   }
@@ -541,7 +545,7 @@ $input-vertical-padding: rem(13px) !default;
   &__input {
     @include font-styles(body-large);
     color: var(--color-text);
-    height: rem(28px);
+    height: var(--input-height);
     border: none;
     width: 100%;
     min-width: 130px; // set a min width, so it does not get crushed by tags
@@ -560,7 +564,7 @@ $input-vertical-padding: rem(13px) !default;
     }
 
     &[placeholder] {
-      @include placeholder(var(--color-fill-gray-secondary))
+      @include placeholder(var(--input-text))
     }
   }
 }

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -65,6 +65,7 @@
             v-model="modelValue"
             :placeholder="hasSelectedTags ? '' : placeholder"
             :aria-expanded="displaySuggestedTags ? 'true' : 'false'"
+            :disabled="disabled"
             v-bind="AXinputProperties"
             type="text"
             class="filter__input"
@@ -173,6 +174,10 @@ export default {
     placeholder: {
       type: String,
       default: () => 'Filter',
+    },
+    disabled: {
+      type: Boolean,
+      default: () => false,
     },
     value: {
       type: String,

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -287,8 +287,11 @@ export default {
       }
     },
 
-    suggestedTags(value) {
-      this.$emit('suggested-tags', value);
+    suggestedTags: {
+      immediate: true,
+      handler(value) {
+        this.$emit('suggested-tags', value);
+      },
     },
 
     showSuggestedTags(value) {

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -57,13 +57,13 @@
             class="visuallyhidden"
             aria-hidden="true"
           >
-            {{ placeholderText }}
+            {{ placeholder }}
           </label>
           <input
             :id="FilterInputId"
             ref="input"
             v-model="modelValue"
-            :placeholder="hasSelectedTags ? '' : placeholderText"
+            :placeholder="hasSelectedTags ? '' : placeholder"
             :aria-expanded="displaySuggestedTags ? 'true' : 'false'"
             v-bind="AXinputProperties"
             type="text"
@@ -170,7 +170,7 @@ export default {
       type: Boolean,
       default: () => false,
     },
-    placeholderText: {
+    placeholder: {
       type: String,
       default: () => 'Filter',
     },
@@ -179,6 +179,10 @@ export default {
       default: () => '',
     },
     shouldTruncateTags: {
+      type: Boolean,
+      default: false,
+    },
+    focusInputOnValueChange: {
       type: Boolean,
       default: false,
     },
@@ -282,11 +286,14 @@ export default {
       this.$emit('show-suggested-tags', value);
     },
 
-    // If input value changes from query parameters data, focus on the input
     async input() {
-      // We know that changes comes from query parameters
-      // when input value changes and input element is not focus.
-      if (document.activeElement !== this.$refs.input && this.inputIsNotEmpty) {
+      // if the `value` changes, but we are not focused on the input, we can make sure the input
+      // is focused, by setting `focusOnValueChange`
+      if (
+        this.focusInputOnValueChange
+        && document.activeElement !== this.$refs.input
+        && this.inputIsNotEmpty
+      ) {
         this.focusInput();
       }
     },

--- a/src/components/Filter/Tag.vue
+++ b/src/components/Filter/Tag.vue
@@ -11,6 +11,11 @@
 <template>
   <li class="tag" role="presentation">
     <button
+      ref="button"
+      :class="{ 'focus': isActiveTag }"
+      role="option"
+      :aria-selected="ariaSelected"
+      aria-roledescription="tag"
       @focus="$emit('focus', { event: $event, tagName: name })"
       @click.prevent="$emit('click', { event: $event, tagName: name })"
       @dblclick.prevent="!keyboardIsVirtual && deleteTag()"
@@ -22,11 +27,6 @@
       @keydown.delete.prevent="deleteTag"
       @mousedown.prevent="focusButton"
       @copy="handleCopy"
-      :class="{ 'focus': isActiveTag }"
-      ref="button"
-      role="option"
-      :aria-selected="ariaSelected"
-      aria-roledescription="tag"
     >
       <span v-if="!isRemovableTag" class="visuallyhidden">
         Add tag -

--- a/src/components/Filter/Tag.vue
+++ b/src/components/Filter/Tag.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information

--- a/src/components/Filter/Tag.vue
+++ b/src/components/Filter/Tag.vue
@@ -1,0 +1,206 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <li class="tag" role="presentation">
+    <button
+      @focus="$emit('focus', { event: $event, tagName: name })"
+      @click.prevent="$emit('click', { event: $event, tagName: name })"
+      @dblclick.prevent="!keyboardIsVirtual && deleteTag()"
+      @keydown.exact="$emit('keydown', { event: $event, tagName: name })"
+      @keydown.shift.exact="$emit('keydown', { event: $event, tagName: name })"
+      @keydown.shift.meta.exact="$emit('keydown', { event: $event, tagName: name })"
+      @keydown.meta.exact="$emit('keydown', { event: $event, tagName: name })"
+      @keydown.ctrl.exact="$emit('keydown', { event: $event, tagName: name })"
+      @keydown.delete.prevent="deleteTag"
+      @mousedown.prevent="focusButton"
+      @copy="handleCopy"
+      :class="{ 'focus': isActiveTag }"
+      ref="button"
+      role="option"
+      :aria-selected="ariaSelected"
+      aria-roledescription="tag"
+    >
+      <span v-if="!isRemovableTag" class="visuallyhidden">
+        Add tag -
+      </span>
+      {{ name }}
+      <span v-if="isRemovableTag" class="visuallyhidden">
+        – Tag. Select to remove from list.
+      </span>
+    </button>
+  </li>
+</template>
+<script>
+import { prepareDataForHTMLClipboard } from 'docc-render/utils/clipboard';
+
+export default {
+  name: 'Tag',
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+    isFocused: {
+      type: Boolean,
+      default: () => false,
+    },
+    isRemovableTag: {
+      type: Boolean,
+      default: false,
+    },
+    isActiveTag: {
+      type: Boolean,
+      default: false,
+    },
+    activeTags: {
+      type: Array,
+      required: false,
+    },
+    keyboardIsVirtual: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  watch: {
+    isFocused(newVal) {
+      if (newVal) {
+        this.focusButton();
+      }
+    },
+  },
+  mounted() {
+    // initialize global clipboard listeners
+    document.addEventListener('copy', this.handleCopy);
+    document.addEventListener('cut', this.handleCut);
+    document.addEventListener('paste', this.handlePaste);
+
+    this.$once('hook:beforeDestroy', () => {
+      document.removeEventListener('copy', this.handleCopy);
+      document.removeEventListener('cut', this.handleCut);
+      document.removeEventListener('paste', this.handlePaste);
+    });
+  },
+  methods: {
+    isCurrentlyActiveElement() {
+      return document.activeElement === this.$refs.button;
+    },
+    /**
+     * Handles copy event
+     * @param {ClipboardEvent} event
+     */
+    handleCopy(event) {
+      // handle only if the current focused item is the button
+      if (!this.isCurrentlyActiveElement()) return;
+      // stop the event.
+      event.preventDefault();
+      // copy as JSON
+      let tags = [];
+      if (this.activeTags.length > 0) {
+        tags = this.activeTags;
+      } else {
+        tags = [this.name];
+      }
+      event.clipboardData.setData('text/html', prepareDataForHTMLClipboard({ tags }));
+      // copy as plain text
+      event.clipboardData.setData('text/plain', tags.join(' '));
+    },
+    handleCut(event) {
+      if (!this.isCurrentlyActiveElement() || !this.isRemovableTag) return;
+      this.handleCopy(event);
+      this.deleteTag(event);
+    },
+    /**
+     * Handles pasting into the page, when the focused element,
+     * is the button of the current Tag instance
+     * @param {ClipboardEvent} event
+     */
+    handlePaste(event) {
+      if (!this.isCurrentlyActiveElement() || !this.isRemovableTag) return;
+      // stop the `paste` event.
+      event.preventDefault();
+      // delete the current tag, as we are pasting over it
+      this.deleteTag(event);
+      // emit up the event data, for the `FilterInput` to handle
+      this.$emit('paste-content', event);
+    },
+    deleteTag(event) {
+      this.$emit('delete-tag', { tagName: this.name, event });
+      this.$emit('prevent-blur');
+    },
+    /**
+     * Handles clicking on tags.
+     * Works for Mouse clicks and VO clicks.
+     * @param {MouseEvent} event
+     */
+    focusButton(event = {}) {
+      if (!this.keyboardIsVirtual) {
+        this.$refs.button.focus();
+      }
+      // if the mouse click has no buttons clicked, its coming from VO
+      if (event.buttons === 0 && this.isFocused) {
+        this.deleteTag(event);
+      }
+    },
+  },
+  computed: {
+    ariaSelected: ({ isActiveTag, isRemovableTag }) => {
+      if (!isRemovableTag) return null;
+      return isActiveTag ? 'true' : 'false';
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@import 'docc-render/styles/_core.scss';
+
+.tag {
+  display: inline-block;
+  padding-right: rem(10px);
+
+  &:focus {
+    outline: none;
+  }
+
+  button {
+    color: var(--color-figure-gray);
+    background-color: var(--color-fill-tertiary);
+    @include font-styles(body-reduced-tight);
+    border-radius: rem(14px);
+    padding: rem(4px) rem(10px);
+    white-space: nowrap;
+    border: 1px solid transparent;
+
+    @media (hover: hover) { // Prevent hover state to get stuck on iOS Safari
+      &:hover {
+        transition: background-color 0.2s, color 0.2s;
+        background-color: var(--color-fill-blue);
+        color: white;
+      }
+    }
+
+    // We only want to make active the tags when they are clicked (focus) to prevent
+    // ghost active states when deleting tags. https://stackoverflow.com/questions/1677990/
+    &:focus:active {
+      background-color: var(--color-fill-blue);
+      color: white;
+    }
+
+    &:focus, &.focus {
+      @include focus-shadow-form-element();
+    }
+
+    @include on-keyboard-focus() {
+      @include focus-shadow-form-element();
+    }
+  }
+}
+</style>

--- a/src/components/Filter/TagList.vue
+++ b/src/components/Filter/TagList.vue
@@ -10,45 +10,50 @@
 
 <template>
   <div class="tags">
-    <ul
-      @keydown.left.capture.prevent="focusPrev"
-      @keydown.right.capture.prevent="focusNext"
-      @keydown.up.capture.prevent="focusPrev"
-      @keydown.down.capture.prevent="focusNext"
-      @keydown.delete.prevent.self="$emit('reset-filters')"
-      @keydown.meta.a.capture.prevent="$emit('select-all')"
-      @keydown.ctrl.a.capture.prevent="$emit('select-all')"
-      @keydown.exact.capture="handleKeydown"
-      @keydown.shift.exact.capture="handleKeydown"
-      @scroll="handleScroll"
-      :aria-label="ariaLabel"
+    <div
+      class="scroll-wrapper"
       :class="{ 'scrolling': isScrolling }"
-      ref="tags"
-      tabindex="0"
-      :id="`${id}-tags`"
-      role="listbox"
-      :aria-multiselectable="areTagsRemovable ? 'true' : 'false'"
-      aria-orientation="horizontal"
+      ref="scroll-wrapper"
+      @scroll="handleScroll"
     >
-      <Tag
-        v-for="(tag, index) in tags"
-        :key="tag.id || index"
-        :name="tag.label || tag"
-        :isFocused="focusedIndex === index"
-        :isRemovableTag="areTagsRemovable"
-        :filterText="input"
-        :isActiveTag="activeTags.includes(tag)"
-        :activeTags="activeTags"
-        :keyboardIsVirtual="keyboardIsVirtual"
-        @focus="handleFocus($event, index)"
-        @click="$emit('click-tags', $event)"
-        @delete-tag="$emit('delete-tag', $event)"
-        @prevent-blur="$emit('prevent-blur')"
-        @paste-content="$emit('paste-tags', $event)"
-        @keydown="$emit('keydown', $event)"
-        ref="tag"
-      />
-    </ul>
+      <ul
+        :id="`${id}-tags`"
+        ref="tags"
+        :aria-label="ariaLabel"
+        tabindex="0"
+        role="listbox"
+        :aria-multiselectable="areTagsRemovable ? 'true' : 'false'"
+        aria-orientation="horizontal"
+        @keydown.left.capture.prevent="focusPrev"
+        @keydown.right.capture.prevent="focusNext"
+        @keydown.up.capture.prevent="focusPrev"
+        @keydown.down.capture.prevent="focusNext"
+        @keydown.delete.prevent.self="$emit('reset-filters')"
+        @keydown.meta.a.capture.prevent="$emit('select-all')"
+        @keydown.ctrl.a.capture.prevent="$emit('select-all')"
+        @keydown.exact.capture="handleKeydown"
+        @keydown.shift.exact.capture="handleKeydown"
+      >
+        <Tag
+          v-for="(tag, index) in tags"
+          ref="tag"
+          :key="tag.id || index"
+          :name="tag.label || tag"
+          :isFocused="focusedIndex === index"
+          :isRemovableTag="areTagsRemovable"
+          :filterText="input"
+          :isActiveTag="activeTags.includes(tag)"
+          :activeTags="activeTags"
+          :keyboardIsVirtual="keyboardIsVirtual"
+          @focus="handleFocus($event, index)"
+          @click="$emit('click-tags', $event)"
+          @delete-tag="$emit('delete-tag', $event)"
+          @prevent-blur="$emit('prevent-blur')"
+          @paste-content="$emit('paste-tags', $event)"
+          @keydown="$emit('keydown', $event)"
+        />
+      </ul>
+    </div>
   </div>
 </template>
 <script>
@@ -79,7 +84,6 @@ export default {
     input: {
       type: String,
       default: null,
-      required: false,
     },
     areTagsRemovable: {
       type: Boolean,
@@ -141,7 +145,7 @@ export default {
       }
     },
     resetScroll() {
-      this.$refs.tags.scrollLeft = 0;
+      this.$refs['scroll-wrapper'].scrollLeft = 0;
     },
 
     /**
@@ -173,12 +177,15 @@ export default {
   transition: padding-right .8s, padding-bottom .8s, max-height 1s, opacity 1s;
   padding: 0;
 
+  .scroll-wrapper {
+    overflow-x: auto;
+    @include custom-horizontal-scrollbar;
+  }
+
   ul {
     margin: 0;
     padding: 0;
     display: flex;
-    overflow-x: auto;
-    @include custom-horizontal-scrollbar;
   }
 }
 </style>

--- a/src/components/Filter/TagList.vue
+++ b/src/components/Filter/TagList.vue
@@ -104,14 +104,19 @@ export default {
   },
   methods: {
     focusFirstTag() {
-      this.$refs.tag[0].focusButton();
+      this.focusTagByIndex(0);
     },
     focusLastTag() {
       const tags = this.$refs.tag;
-      tags[tags.length - 1].focusButton();
+      this.focusTagByIndex(tags.length - 1);
     },
     focusTag(name) {
-      this.$refs.tag[this.tags.indexOf(name)].focusButton();
+      this.focusTagByIndex(this.tags.indexOf(name));
+    },
+    focusTagByIndex(index) {
+      const tag = this.$refs.tag[index];
+      if (!tag || !tag.focusButton) return;
+      tag.focusButton();
     },
     focusIndex(index) {
       this.focusedIndex = index;

--- a/src/components/Filter/TagList.vue
+++ b/src/components/Filter/TagList.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information

--- a/src/mixins/handleScrollbar.js
+++ b/src/mixins/handleScrollbar.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/src/mixins/handleScrollbar.js
+++ b/src/mixins/handleScrollbar.js
@@ -48,8 +48,11 @@ export default {
       const difference = Date.now() - this.scrollRemovedAt;
       if (difference < ScrollingDebounceDelay / 10) return;
       this.isScrolling = true;
-      // expose the current height as a css var, so we can limit it's height
-      target.style.setProperty('--scroll-target-height', `${target.offsetHeight}px`);
+      // make sure we do this only once
+      if (!target.style.getPropertyValue('--scroll-target-height')) {
+        // expose the current height as a css var, so we can limit it's height
+        target.style.setProperty('--scroll-target-height', `${target.offsetHeight}px`);
+      }
       this.deleteScroll();
     },
   },

--- a/src/mixins/handleScrollbar.js
+++ b/src/mixins/handleScrollbar.js
@@ -1,0 +1,56 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import debounce from 'docc-render/utils/debounce';
+
+const ScrollingDebounceDelay = 1000;
+
+export default {
+  constants: { ScrollingDebounceDelay },
+  data() {
+    return {
+      isScrolling: false,
+      scrollRemovedAt: 0,
+    };
+  },
+  created() {
+    // replace with a debounced version if the method
+    this.deleteScroll = debounce(this.deleteScroll, ScrollingDebounceDelay);
+  },
+  methods: {
+    deleteScroll() {
+      this.isScrolling = false;
+      this.scrollRemovedAt = Date.now();
+    },
+    handleScroll(event) {
+      const { target } = event;
+      // if we are trying to scroll vertically, prevent that.
+      if (target.scrollTop !== 0) {
+        // need to reset it back to 0, because preventDefault does not revert it.
+        target.scrollTop = 0;
+        event.preventDefault();
+        return;
+      }
+      const safeExtraWidth = 150;
+      const listWidth = target.offsetWidth;
+      const noScrollBarsWidth = listWidth + safeExtraWidth; // safe width added to the list width
+      // To prevent from applying the scrolling styles when scroll bars doesn't appear
+      if (target.scrollWidth < noScrollBarsWidth) return;
+      // make sure the scroll is not called again, right after deleting the scrollbar.
+      // The difference is around 25ms, we use 100 to be safe.
+      const difference = Date.now() - this.scrollRemovedAt;
+      if (difference < ScrollingDebounceDelay / 10) return;
+      this.isScrolling = true;
+      // expose the current height as a css var, so we can limit it's height
+      target.style.setProperty('--scroll-target-height', `${target.offsetHeight}px`);
+      this.deleteScroll();
+    },
+  },
+};

--- a/src/mixins/multipleSelection.js
+++ b/src/mixins/multipleSelection.js
@@ -235,6 +235,7 @@ export default {
       // If user clicks on a tag after being focus on the input
       if (
         target
+        // TODO: Might need to make it match the exact input, not any generic input
         && target.matches('input')
         && this.shiftKey
         && !this.metaKey

--- a/src/mixins/multipleSelection.js
+++ b/src/mixins/multipleSelection.js
@@ -68,7 +68,7 @@ export default {
       if (this.activeTags.length > 0) {
         this.setSelectedTags(this.selectedTags.filter(tag => !this.activeTags.includes(tag)));
       }
-      if (this.inputIsSelected() && this.focusesSelectedTags) {
+      if (this.inputIsSelected() && this.allSelectedTagsAreActive) {
         // stop the default event, so it doesnt trigger the `@input` handler
         e.preventDefault();
         // reset the filters
@@ -80,7 +80,7 @@ export default {
           // Because mobile and tablet users don't usually have a displayed virtual keyboard
           // all the time, behaviour has been changed to allow a safer approach:
           // delete the last tag directly when the user clicks on the delete key
-          this.setSelectedTags([...this.selectedTags].pop());
+          this.setSelectedTags(this.selectedTags.slice(0, -1));
         } else {
           // Default behaviour for desktop users is to focus on the last tag and then
           // delete it when they click on the delete key while focused on the tag
@@ -235,11 +235,11 @@ export default {
       // If user clicks on a tag after being focus on the input
       if (
         target
-          && target.matches('input')
-          && this.shiftKey
-          && !this.metaKey
-          && !this.tabbing
-          && this.$refs.input.selectionEnd !== 0
+        && target.matches('input')
+        && this.shiftKey
+        && !this.metaKey
+        && !this.tabbing
+        && this.$refs.input.selectionEnd !== 0
       ) {
         // We select from the exact input text to the tags
         this.selectInputTextToTags();

--- a/src/mixins/multipleSelection.js
+++ b/src/mixins/multipleSelection.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/src/mixins/multipleSelection.js
+++ b/src/mixins/multipleSelection.js
@@ -25,6 +25,7 @@ export default {
   data() {
     return {
       keyboardIsVirtual: false,
+      // tracks tags that are selected (for copy or delete)
       activeTags: [],
       initTagIndex: null,
       focusedTagIndex: null,
@@ -39,8 +40,7 @@ export default {
     VirtualKeyboardThreshold,
   },
   computed: {
-    virtualKeyboardBind: ({ keyboardIsVirtual }) => ({ keyboardIsVirtual }
-    ),
+    virtualKeyboardBind: ({ keyboardIsVirtual }) => ({ keyboardIsVirtual }),
     allSelectedTagsAreActive: ({ selectedTags, activeTags }) => (
       selectedTags.every(tag => activeTags.includes(tag))
     ),

--- a/src/mixins/multipleSelection.js
+++ b/src/mixins/multipleSelection.js
@@ -14,7 +14,7 @@ import {
   moveCursorToStart,
   moveCursorToEnd,
 } from 'docc-render/utils/input-helper';
-import { parseDataFromClipboard, prepareDataForHTMLClipboard } from '@/utils/clipboard';
+import { parseDataFromClipboard, prepareDataForHTMLClipboard } from 'docc-render/utils/clipboard';
 import { insertAt } from 'docc-render/utils/strings';
 import debounce from 'docc-render/utils/debounce';
 

--- a/src/mixins/multipleSelection.js
+++ b/src/mixins/multipleSelection.js
@@ -1,0 +1,583 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import {
+  getSelectionText,
+  isSingleCharacter,
+  moveCursorToStart,
+  moveCursorToEnd,
+} from 'docc-render/utils/input-helper';
+import { parseDataFromClipboard, prepareDataForHTMLClipboard } from '@/utils/clipboard';
+import { insertAt } from 'docc-render/utils/strings';
+import debounce from 'docc-render/utils/debounce';
+
+const DebounceDelay = 280;
+const VirtualKeyboardThreshold = 100;
+
+export default {
+  data() {
+    return {
+      keyboardIsVirtual: false,
+      activeTags: [],
+      initTagIndex: null,
+      focusedTagIndex: null,
+      metaKey: false,
+      shiftKey: false,
+      tabbing: false,
+      debouncedHandleDeleteTag: null,
+    };
+  },
+  constants: {
+    DebounceDelay,
+    VirtualKeyboardThreshold,
+  },
+  computed: {
+    virtualKeyboardBind: ({ keyboardIsVirtual }) => ({ keyboardIsVirtual }
+    ),
+    allSelectedTagsAreActive: ({ selectedTags, activeTags }) => (
+      selectedTags.every(tag => activeTags.includes(tag))
+    ),
+  },
+  methods: {
+    selectRangeActiveTags(startIndex = this.focusedTagIndex, endIndex = this.selectedTags.length) {
+      this.activeTags = this.selectedTags.slice(
+        startIndex,
+        endIndex,
+      );
+    },
+
+    selectTag(tag) {
+      this.updateSelectedTags([tag]);
+      this.setFilterInput('');
+    },
+
+    unselectActiveTags() {
+      if (this.activeTags.length) {
+        this.deleteTags(this.activeTags);
+        this.resetActiveTags();
+      }
+    },
+    async deleteHandler(e) {
+      if (this.activeTags.length > 0) {
+        this.setSelectedTags(this.selectedTags.filter(tag => !this.activeTags.includes(tag)));
+      }
+      if (this.inputIsSelected() && this.focusesSelectedTags) {
+        // stop the default event, so it doesnt trigger the `@input` handler
+        e.preventDefault();
+        // reset the filters
+        await this.resetFilters();
+      } else if (this.$refs.input.selectionEnd === 0 && this.hasSelectedTags) {
+        // stop the backspace from navigating back the page
+        e.preventDefault();
+        if (this.keyboardIsVirtual) {
+          // Because mobile and tablet users don't usually have a displayed virtual keyboard
+          // all the time, behaviour has been changed to allow a safer approach:
+          // delete the last tag directly when the user clicks on the delete key
+          this.setSelectedTags([...this.selectedTags].pop());
+        } else {
+          // Default behaviour for desktop users is to focus on the last tag and then
+          // delete it when they click on the delete key while focused on the tag
+          this.$refs.selectedTags.focusLastTag();
+        }
+      }
+
+      this.unselectActiveTags();
+    },
+    leftKeyInputHandler(event) {
+      this.assignEventValues(event);
+
+      if (this.hasSelectedTags) {
+        if (this.activeTags.length && !this.shiftKey) {
+          // prevent the left key from deselecting text on the input
+          event.preventDefault();
+          // if there are activeTags and shift key has stopped,
+          // focus the first tag from those activeTags
+          this.$refs.selectedTags.focusTag(this.activeTags[0]);
+          return;
+        }
+
+        // if user has shift key pressed and the cursor is on the start
+        if (
+          this.shiftKey
+          && this.$refs.input.selectionStart === 0
+        ) {
+          // selectionDirection !== 'forward' means that user is moving from input to tags
+          if (this.$refs.input.selectionDirection !== 'forward') {
+            // init focusedTagIndex as the last tag in selectedTags
+            if (this.focusedTagIndex === null) {
+              this.focusedTagIndex = this.selectedTags.length;
+            }
+            // move focusedTagIndex index one to the left
+            if (this.focusedTagIndex > 0) {
+              this.focusedTagIndex -= 1;
+            }
+
+            this.initTagIndex = this.selectedTags.length;
+            this.selectTagsPressingShift();
+            return;
+          }
+        }
+
+        if (this.$refs.input.selectionEnd === 0 || this.inputIsSelected()) {
+          // go to the last tag when the cursor is on the beginning of the input
+          // or the whole input is selected
+          this.$refs.selectedTags.focusLastTag();
+        }
+      }
+    },
+
+    rightKeyInputHandler(event) {
+      this.assignEventValues(event);
+
+      if (this.activeTags.length) {
+        // If shift key is pressed and user focus is coming from a tag
+        if (this.shiftKey && this.focusedTagIndex < this.selectedTags.length) {
+          // when there is a init tag, keep it active
+          if (this.initTagIndex < this.selectedTags.length) {
+            this.selectRangeActiveTags(this.initTagIndex, this.focusedTagIndex + 1);
+            return;
+          }
+          // prevent the right key from deselecting text on the input
+          event.preventDefault();
+          // move focusedTagIndex index one to the right
+          this.focusedTagIndex += 1;
+          // select range between focusedTagIndex index and end of tags
+          this.selectRangeActiveTags();
+        }
+      }
+    },
+    /**
+     * Handles hitting `Enter` key when in the input.
+     */
+    async enterHandler() {
+      // on Enter, move the blur the input. It will hide the suggested tags automatically.
+      this.$refs.input.blur();
+    },
+    /**
+     * Handles arbitrary keydown cases for the input
+     */
+    inputKeydownHandler(event) {
+      const { key } = event;
+
+      if (this.inputIsSelected()) {
+        // Reset the filters when a character is typed,
+        // if the entire input is selected, but not the tags
+        if (isSingleCharacter(key) && this.allSelectedTagsAreActive) {
+          this.resetFilters();
+        }
+      }
+      this.multipleTagsSelectionHandler({ event, tagName: '' });
+    },
+
+    /**
+     * Handles arbitrary keydown cases for the selected tags
+     */
+    selectedTagsKeydownHandler({ event, tagName }) {
+      // Prevent click from being fired when pressing Enter key
+      if (event.key === 'Enter') {
+        event.preventDefault();
+      }
+      this.multipleTagsSelectionHandler({ event, tagName });
+    },
+
+    /**
+     * Select exact input text from input to tags
+     */
+    selectInputTextToTags() {
+      const { input } = this.$refs;
+
+      // If user hasn't selected a partial text,
+      // select all the text from the cursor to the beginning of the text
+      if (input.selectionStart === input.selectionEnd) {
+        input.setSelectionRange(0, input.selectionEnd);
+      } else {
+        input.setSelectionRange(input.selectionStart, input.selectionEnd);
+      }
+      // We need to focus the input to get the selected text visible
+      this.focusInput();
+    },
+
+    /**
+     * Select range of tags using the shiftKey
+     */
+    selectTagsPressingShift() {
+      // If the user has selected a tag to init the shift selection
+      if (this.initTagIndex !== null) {
+        if (this.shiftKey && !this.metaKey) {
+          // Select the whole range between the init tag index and the focused tag index
+          // Comparing initTagIndex and focusedTagIndex to know which direction the slice
+          // function has
+          if (this.initTagIndex < this.focusedTagIndex) {
+            this.selectRangeActiveTags(this.initTagIndex, this.focusedTagIndex + 1);
+          } else {
+            this.selectRangeActiveTags(this.focusedTagIndex, this.initTagIndex + 1);
+          }
+        }
+      }
+    },
+
+    /**
+     * Handler when the user focus on a tag
+     */
+    focusTagHandler({ event = {}, tagName }) {
+      // Update focusedTagIndex with the current value
+      this.focusedTagIndex = this.selectedTags.indexOf(tagName);
+
+      // relatedTarget tells from where the focus element comes from
+      const target = event.relatedTarget;
+      // If user clicks on a tag after being focus on the input
+      if (
+        target
+          && target.matches('input')
+          && this.shiftKey
+          && !this.metaKey
+          && !this.tabbing
+          && this.$refs.input.selectionEnd !== 0
+      ) {
+        // We select from the exact input text to the tags
+        this.selectInputTextToTags();
+        // We select the tags
+        this.selectRangeActiveTags();
+        return;
+      }
+
+      // We select range of tags using the shiftKey on focus so it works for
+      // mouse and keyboard focus
+      this.selectTagsPressingShift();
+    },
+
+    /**
+     * Focus on the input coming from the tags
+     */
+    focusInputFromTags() {
+      // move the cursor to the start when focusing the input from tags
+      this.focusInput();
+      moveCursorToStart(this.$refs.input);
+    },
+
+    /**
+     * Select whole range from the initTag to the beginning or end of the tags
+     */
+    selectToDirections(key) {
+      if (this.metaKey && this.shiftKey) {
+        if (key === 'ArrowRight') {
+          // Select all from cursor to end of the tags
+          this.selectRangeActiveTags(this.initTagIndex, this.selectedTags.length);
+
+          if (this.input.length) {
+            this.$refs.input.select();
+          } else {
+            // Focus tag at the end of the tags
+            this.$refs.selectedTags.focusTag(this.selectedTags[this.selectedTags.length - 1]);
+          }
+        } else if (key === 'ArrowLeft') {
+          // Select all from cursor to beginning of the tags
+          this.selectRangeActiveTags(0, this.initTagIndex + 1);
+
+          if (!this.input.length) {
+            // Focus tag at the beginning of the tags
+            this.$refs.selectedTags.focusTag(this.selectedTags[0]);
+          }
+        }
+      }
+    },
+
+    /**
+     * Select and unselect tags using the metaKey only for mouse events
+     */
+    metaKeyClickSelection(event, tagName) {
+      if (this.metaKey && event instanceof MouseEvent) {
+        // If a user clicks with the mouse holding the meta key
+        if (this.activeTags.includes(tagName)) {
+          // deletes a tag when it's included in the active tags
+          this.activeTags.splice(this.activeTags.indexOf(tagName), 1);
+
+          // Remove focus from tag and focus first active tag or input depending on
+          // if there are active tags or not
+          if (this.activeTags.length) {
+            this.$refs.selectedTags.focusTag(this.activeTags[0]);
+          } else {
+            this.focusInput();
+          }
+        } else {
+          // If a tag is not included in the active tags we should add it to the active tags
+          this.activeTags.push(tagName);
+        }
+      }
+    },
+
+    /**
+     * Assign event values to update metaKey and shiftKey data values with current ones
+     */
+    assignEventValues(event = {}) {
+      const {
+        shiftKey = false, metaKey = false, ctrlKey = false, key,
+      } = event;
+      this.tabbing = key === 'Tab';
+      this.metaKey = metaKey || ctrlKey;
+      this.shiftKey = shiftKey;
+    },
+
+    /**
+     * Init tag
+     */
+    initTag(tagName) {
+      if (
+        this.initTagIndex === null
+        && !this.activeTags.includes(tagName)
+      ) {
+        if (tagName) {
+          // Init the shift key when the user click on the shift key for the first time
+          this.initTagIndex = this.selectedTags.indexOf(tagName);
+          // Add the init shift key to the active tags
+          this.activeTags.push(tagName);
+        } else {
+          // When selecting from the input value there isn't shift init tag
+          // so we take the total selected tags length
+          this.initTagIndex = this.selectedTags.length;
+        }
+      }
+    },
+
+    multipleTagsSelectionHandler({ event = new KeyboardEvent('keydown', {}), tagName }) {
+      const { key = '' } = event;
+
+      // Prevent function to run when pressing the Enter key
+      if (key === 'Enter') return;
+
+      this.assignEventValues(event);
+
+      if ((this.shiftKey || this.metaKey) && !this.tabbing) {
+        // Init tag when shift key or meta key are pressed
+        this.initTag(tagName);
+      } else if (key !== 'Backspace') {
+        // Reset the shift selected tags when user clicks in any key unless
+        // using the shift, meta or delete key
+        this.resetActiveTags();
+      }
+
+      this.selectToDirections(key);
+    },
+
+    resetActiveTags() {
+      this.activeTags = [];
+      this.initTagIndex = null;
+      this.metaKey = false;
+      this.tabbing = false;
+      this.shiftKey = false;
+      this.focusedTagIndex = null;
+    },
+
+    selectInputAndTags() {
+      this.activeTags = [...this.selectedTags];
+
+      if (this.input.length) {
+        this.$refs.input.select();
+        // set init tag as if shift key would have been triggered from input
+        this.initTagIndex = this.activeTags.length;
+        // set focused tag index to 0 keeping the real focus on the input
+        this.focusedTagIndex = 0;
+      } else if (this.activeTags.length) {
+        // set init tag on the last tag from the selected tags
+        this.initTagIndex = this.activeTags.length - 1;
+        // focus on the first tag
+        this.$refs.selectedTags.focusTag(this.activeTags[0]);
+      }
+    },
+    /**
+     * Handles clicking or hitting enter on a focused tag.
+     * @param {Event} value
+     */
+    handleSingleTagClick({ event, tagName }) {
+      if (this.keyboardIsVirtual) {
+        // init debounce function
+        if (!this.debouncedHandleDeleteTag) {
+          this.debouncedHandleDeleteTag = debounce(this.handleDeleteTag, DebounceDelay);
+        }
+        // remove the tag if it's on mobile
+        // and prevent handleDeleteTag to be called too fast
+        this.debouncedHandleDeleteTag({ tagName, event });
+      } else {
+        this.assignEventValues(event);
+        this.metaKeyClickSelection(event, tagName);
+        this.multipleTagsSelectionHandler({ event, tagName });
+      }
+    },
+    /**
+     * Returns whether the entire input text is selected
+     * @returns {boolean}
+     */
+    inputIsSelected() {
+      return this.input.length && getSelectionText() === this.input;
+    },
+    /**
+     * Return whether the input has a partial seleced
+     * @returns {boolean}
+     */
+    inputHasPartialTextSelected() {
+      const selectedText = getSelectionText();
+      // make sure its not a full match
+      return !this.inputIsSelected()
+        // make sure we at least have some selected
+        && selectedText.length
+        // make sure the input includes what is currently selected
+        && this.input.includes(selectedText);
+    },
+    /**
+     * Debounced `window.visualViewport@resize` callback.
+     * Difference beyond `VirtualKeyboardThreshold` considers a virtual keyboard is being displayed.
+     */
+    updateKeyboardType: debounce(function updateKeyboardTypeDebounced(event) {
+      // Calculate the difference between the total window height and
+      // window height without virtual keyboard
+      const heightDifference = window.innerHeight - event.target.height;
+
+      // If the height difference is bigger than 100, it means that a virtual keyboard
+      // has been displayed. 100px is the minimum height to consider a virtual keyboard.
+      if (heightDifference >= VirtualKeyboardThreshold) {
+        this.keyboardIsVirtual = true;
+      }
+    }, DebounceDelay),
+    setFilterInput(value) {
+      this.$emit('update:input', value);
+    },
+    setSelectedTags(tags) {
+      this.$emit('update:selectedTags', tags);
+    },
+    /**
+     * Appends provided tags to the already existing tags.
+     * Removes duplicates.
+     * @param {string[]} tags
+     */
+    updateSelectedTags(tags) {
+      this.setSelectedTags([...new Set([...this.selectedTags, ...tags])]);
+    },
+    /**
+     * Handles Copy-ing from the input or Selected tags
+     * @param {ClipboardEvent} event
+     * @returns {{ input: string, tags string[] }}
+     */
+    handleCopy(event) {
+      event.preventDefault();
+      // plain text payload
+      const copyBuffer = [];
+      // JSON payload
+      const copyJSONBuffer = {
+        tags: [],
+        input: getSelectionText(),
+      };
+
+      if (this.activeTags.length) {
+        const tagsToCopy = this.activeTags;
+        copyJSONBuffer.tags = tagsToCopy;
+        copyBuffer.push(tagsToCopy.join(' '));
+      }
+
+      // prepare plain text copy payload.
+      copyBuffer.push(copyJSONBuffer.input);
+      // if we have no tags or input selected, dont proceed with copy command
+      if (!copyJSONBuffer.tags.length && !copyJSONBuffer.input.length) return copyJSONBuffer;
+      // save data as JSON in clipboard, for easy retrieval.
+      event.clipboardData.setData('text/html', prepareDataForHTMLClipboard(copyJSONBuffer));
+      // fill in plain text payload
+      event.clipboardData.setData('text/plain', copyBuffer.join(' '));
+
+      return copyJSONBuffer;
+    },
+    /**
+     * Handles cutting action from the input
+     * @param {ClipboardEvent} event
+     */
+    handleCut(event) {
+      event.preventDefault();
+      const { input, tags } = this.handleCopy(event);
+      // dont overwrite the content, if nothing is copied
+      if (!input && !tags.length) return;
+      // remove what is copied from the selection and input
+      const remainingTags = this.selectedTags.filter(tag => !tags.includes(tag));
+      const remainingInput = this.input.replace(input, '');
+      // set the leftover content
+      this.setSelectedTags(remainingTags);
+      this.setFilterInput(remainingInput);
+    },
+    /**
+     * Handles pasting into the input
+     * @param {ClipboardEvent} event
+     */
+    handlePaste(event) {
+      event.preventDefault();
+      const { types } = event.clipboardData;
+      let tags = [];
+      let input = event.clipboardData.getData('text/plain');
+      // try to get the data from `text/html` content
+      if (types.includes('text/html')) {
+        const pasteBuffer = event.clipboardData.getData('text/html');
+        const data = parseDataFromClipboard(pasteBuffer);
+        // if there is match, get the `tags` and `input` from the JSON data
+        if (data) {
+          ({ tags = [], input = '' } = data);
+        }
+      }
+      const selection = getSelectionText();
+      // if we have selected parts of the input, we need to replace it.
+      // this works if you have selected all as well.
+      if (selection.length) {
+        input = this.input.replace(selection, input);
+      } else {
+        // inject the new text there hte cursor is currently at.
+        input = insertAt(this.input, input, document.activeElement.selectionStart);
+      }
+
+      this.setFilterInput(input.trim());
+      if (this.allSelectedTagsAreActive) {
+        this.setSelectedTags(tags);
+      } else {
+        this.updateSelectedTags(tags);
+      }
+      this.resetActiveTags();
+    },
+    /**
+     * Handles deleting a tag
+     * @param {string} tag
+     * @returns {Promise<void>}
+     */
+    async handleDeleteTag({ tagName, event = {} }) {
+      const { key } = event;
+
+      if (!this.activeTags.length) {
+        this.deleteTags([tagName]);
+      }
+
+      this.unselectActiveTags();
+
+      // await the parent to update the list
+      await this.$nextTick();
+      moveCursorToEnd(this.$refs.input);
+      // Move cursor position to the beginning of the input field when deleting a selected tag.
+      // The default browser behavior is to move the cursor to the end of the input field, which
+      // is not what we want.
+      if (this.hasSelectedTags) {
+        await this.focusInput();
+
+        if (key === 'Backspace') {
+          moveCursorToStart(this.$refs.input);
+        }
+      }
+    },
+  },
+  mounted() {
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', this.updateKeyboardType);
+      this.$once('hook:beforeDestroy', () => {
+        window.visualViewport.removeEventListener('resize', this.updateKeyboardType);
+      });
+    }
+  },
+};

--- a/src/styles/core/_helpers.scss
+++ b/src/styles/core/_helpers.scss
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/src/styles/core/_helpers.scss
+++ b/src/styles/core/_helpers.scss
@@ -200,3 +200,69 @@
 @function calculate-column-width($column-count: 1) {
   @return ($column-count / $total-columns) * 100%;
 }
+
+@mixin custom-horizontal-scrollbar() {
+  $border-radius: 10px;
+  $scrollbar-vertical-margin: 2px;
+  $scrollbar-horizontal-margin: (10px - $scrollbar-vertical-margin);
+  $scrollbar-height: 7px;
+  $scrollbar-total-height: $scrollbar-height + ($scrollbar-vertical-margin * 2);
+  $element-bottom-padding: 13px;
+
+  overflow-y: hidden;
+
+  -ms-overflow-style: none; /* IE 10+ */
+  scrollbar-color: var(--color-figure-gray-tertiary) transparent; /* Firefox colors */
+  scrollbar-width: thin; /* scrollbar height on Firefox (because it is horizontal) */
+  &::-webkit-scrollbar { /* Chrome & Safari */
+    height: 0;
+  }
+
+  &.scrolling {
+
+    /**
+    * `-webkit-touch-callout` to target Safari on iOS
+    * https://stackoverflow.com/questions/30102792/
+    *`scrollbar-width` to target Firefox
+    * https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width
+    *`-ms-overflow-style` to target IE
+    * https://developer.mozilla.org/es/docs/Web/CSS/-ms-overflow-style
+    */
+    @supports not ((-webkit-touch-callout: none) or (scrollbar-width: none) or (-ms-overflow-style: none)) {
+      --scrollbar-height: #{$scrollbar-total-height};
+      padding-top: var(--scrollbar-height);
+      /**
+      * Hard set the height - the padding, which should allow for the scrollbar to stay offset,
+      * without the entire element shifting.
+      * --scroll-target-height is set in `handleScrollbar.js`
+      */
+      height: calc(var(--scroll-target-height) - var(--scrollbar-height));
+      // make sure the item's content is centered
+      display: flex;
+      align-items: center;
+    }
+
+    /**
+    * Browser compatibility
+    * https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar
+    */
+    &::-webkit-scrollbar {
+      height: $scrollbar-total-height;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: $border-radius;
+      background-color: var(--color-figure-gray-tertiary);
+      border: $scrollbar-vertical-margin solid transparent;
+      background-clip: padding-box;
+    }
+
+    &::-webkit-scrollbar-track-piece:end {
+      margin-right: $scrollbar-horizontal-margin;
+    }
+
+    &::-webkit-scrollbar-track-piece:start {
+      margin-left: $scrollbar-horizontal-margin;
+    }
+  }
+}

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -17,6 +17,7 @@ $form-focus-size: 4px;
 $border-radius: 4px !default;
 $tiny-border-radius: $border-radius !default;
 $big-border-radius: $border-radius !default;
+$small-border-radius: $border-radius !default;
 
 $contenttable-spacing-single-side: 2rem;
 

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,0 +1,36 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/**
+ * Parses HTML data coming from clipboard
+ * @param {String} payload
+ * @return {Object|null}
+ */
+export function parseDataFromClipboard(payload) {
+  const match = payload.match(/<data (?:.*?)id="copy-data"(?:.*?)>(.*)<\/data>/);
+  try {
+    return match ? JSON.parse(match[1]) : null;
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Prepared data to be sent to the clipboard as `text/html` payload
+ * @param {*} payload
+ * @return {string}
+ */
+export function prepareDataForHTMLClipboard(payload) {
+  if (typeof payload !== 'string') {
+    // eslint-disable-next-line no-param-reassign
+    payload = JSON.stringify(payload);
+  }
+  return `<data id="copy-data">${payload}</data>`;
+}

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/src/utils/input-helper.js
+++ b/src/utils/input-helper.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/src/utils/input-helper.js
+++ b/src/utils/input-helper.js
@@ -1,0 +1,66 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/**
+ * A window.getSelection utility that works with all browsers.
+ * Firefox does not work with window.getSelection on `input` elements,
+ * IE does not support it at all.
+ * @returns {string}
+ */
+export function getSelectionText() {
+  if (window.getSelection) {
+    try {
+      const { activeElement } = document;
+      if (activeElement && activeElement.value) {
+        // firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=85686
+        return activeElement.value.substring(
+          activeElement.selectionStart,
+          activeElement.selectionEnd,
+        );
+      }
+      return window.getSelection().toString();
+    } catch (e) {
+      return '';
+    }
+  } else if (document.selection && document.selection.type !== 'Control') {
+    // For IE
+    return document.selection.createRange().text;
+  }
+  return '';
+}
+
+/**
+ * Moves a cursor to the end of an input
+ * @param {HTMLInputElement} el
+ */
+export function moveCursorToEnd(el) {
+  if (typeof el.selectionStart === 'number') {
+    // eslint-disable-next-line
+    el.selectionStart = el.selectionEnd = el.value.length;
+  } else if (typeof el.createTextRange !== 'undefined') {
+    el.focus();
+    const range = el.createTextRange();
+    range.collapse(false);
+    range.select();
+  }
+}
+
+/**
+ * Moves a cursor to the start of an input
+ * @param {HTMLInputElement} el
+ */
+export function moveCursorToStart(el) {
+  // eslint-disable-next-line
+  el.selectionStart = el.selectionEnd = 0;
+}
+
+export function isSingleCharacter(key) {
+  return /^[\w\W\s]$/.test(key);
+}

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -49,6 +49,7 @@ describe('FilterInput', () => {
     value: '',
     selectedTags: [],
     tags,
+    disabled: false,
     placeholder: 'Placeholder Text',
   };
 
@@ -130,6 +131,15 @@ describe('FilterInput', () => {
     wrapper.setData({ isScrolling: true });
 
     expect(inputBoxWrapper.classes('scrolling')).toBe(true);
+  });
+
+  it('renders a disabled attr on input if it is disabled', () => {
+    // input is not disabled
+    expect(input.attributes('disabled')).toBeFalsy();
+    // set disabled prop to true
+    wrapper.setProps({ disabled: true });
+    // input is disabled
+    expect(input.attributes('disabled')).toBe('disabled');
   });
 
   it('emits `show-suggested-tags` if filter button is clicked', async () => {

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -1,0 +1,1446 @@
+import { prepareDataForHTMLClipboard } from '@/utils/clipboard';
+import { shallowMount } from '@vue/test-utils';
+import FilterInput from '@/components/Filter/FilterInput.vue';
+import TagList from '@/components/Filter/TagList.vue';
+import {
+  getSelectionText, moveCursorToStart, isSingleCharacter, moveCursorToEnd,
+} from '@/utils/input-helper';
+import debounce from 'docc-render/utils/debounce';
+import FilterIcon from 'docc-render/components/Icons/FilterIcon.vue';
+import multipleSelection from '@/mixins/multipleSelection';
+import { flushPromises } from '../../../../test-utils';
+
+// TODO: Remove this Event caching, once we update VTU, as there is a bug now,
+//  that prevents you from setting extra parameters
+window.Event = null;
+
+jest.mock('docc-render/utils/debounce', () => jest.fn(fn => fn));
+
+jest.mock('@/utils/input-helper', () => ({
+  getSelectionText: jest.fn(),
+  moveCursorToEnd: jest.fn(),
+  moveCursorToStart: jest.fn(),
+  isSingleCharacter: jest.fn(),
+}));
+
+const {
+  SuggestedTagsId,
+  SelectedTagsId,
+  FilterInputId,
+} = FilterInput.constants;
+
+describe('FilterInput', () => {
+  let wrapper;
+  let input;
+  let filterButtonSVG;
+
+  const tags = ['Tag1', 'Tag2'];
+
+  const propsData = {
+    value: '',
+    selectedTags: [],
+    tags,
+    placeholder: 'Placeholder Text',
+  };
+
+  const inputValue = 'Foo';
+
+  /**
+   * Imitates resizing the screen.
+   * Calls all attached `visualViewport` event listeners.
+   * @param {number} x
+   * @param {number} y
+   * @param {object} event - mock event to pass to `visualViewport` listeners.
+   */
+  function resizeWindow(x, y, event) {
+    window.innerHeight = y;
+    // call all attached listeners
+    window.visualViewport.addEventListener.mock.calls.forEach(([, param2]) => param2(event));
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    window.visualViewport = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    wrapper = shallowMount(FilterInput, {
+      propsData,
+      stubs: { TagList },
+      slots: {
+        icon: FilterIcon,
+      },
+    });
+
+    input = wrapper.find({ ref: 'input' });
+    getSelectionText.mockImplementation(() => input.element.value);
+  });
+
+  it('adds AX related markup', () => {
+    const attrs = wrapper.attributes();
+    const filterLabel = wrapper.find('#filter-label');
+
+    // able to tab into
+    expect(attrs).toHaveProperty('tabindex', '0');
+    // labelled by these components
+    expect(attrs).toHaveProperty('aria-labelledby', FilterInputId);
+    // check filter label text
+    expect(filterLabel.text()).toBe(propsData.placeholder);
+    // check filter label is a label tag
+    expect(filterLabel.is('label')).toBe(true);
+    // check that label is associated to filter input
+    expect(filterLabel.attributes('for')).toBe(FilterInputId);
+  });
+
+  it('renders an `input` element', async () => {
+    expect(input.exists()).toBe(true);
+    expect(input.attributes('placeholder')).toBe(propsData.placeholder);
+    wrapper.setProps({
+      placeholder: 'Foo',
+    });
+    expect(input.attributes('placeholder')).toBe('Foo');
+    // make sure it emits the correct event
+    input.setValue(inputValue);
+    expect(wrapper.emitted('input')).toEqual([[inputValue]]);
+    // make sure the input is bound
+    wrapper.setProps({
+      value: 'new-value',
+    });
+    await wrapper.vm.$nextTick();
+    expect(input.element.value).toEqual('new-value');
+  });
+
+  it('renders a `scrolling` class inside the input box wrapper if `isScrolling` is true', () => {
+    const inputBoxWrapper = wrapper.find('.filter__input-box-wrapper');
+
+    expect(inputBoxWrapper.classes('scrolling')).toBe(false);
+
+    // simulate the `handleScrollbar` mixin triggering ON
+    wrapper.setData({ isScrolling: true });
+
+    expect(inputBoxWrapper.classes('scrolling')).toBe(true);
+  });
+
+  it('emits `show-suggested-tags` if filter button is clicked', async () => {
+    wrapper.find('.filter__filter-button').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted()['show-suggested-tags']).toBeTruthy();
+  });
+
+  it('renders a filter button with an icon slot', () => {
+    const filterButton = wrapper.find('.filter__filter-button');
+    expect(filterButton.attributes()).toMatchObject({
+      'aria-hidden': 'true',
+      tabindex: '-1',
+      class: expect.not.stringContaining('blue'),
+    });
+    filterButtonSVG = filterButton.find(FilterIcon);
+    expect(filterButtonSVG.exists()).toBe(true);
+  });
+
+  it('renders a filter button with blue color if input has any value', async () => {
+    wrapper.setProps({ value: 'Foo' });
+    await flushPromises();
+    expect(wrapper.find('.filter__filter-button').classes('blue')).toBe(true);
+  });
+
+  it('blurs the input if hitting enter', async () => {
+    wrapper.setProps({ value: inputValue, selectedTags: ['Tag1'] });
+    await wrapper.vm.focusInput();
+    expect(document.activeElement).toBe(input.element);
+    input.trigger('keydown', {
+      key: 'Enter',
+    });
+    // await for the ticks to end
+    await flushPromises();
+    expect(document.activeElement).not.toBe(input.element);
+  });
+
+  it('focuses the input, on external `value` change', async () => {
+    wrapper.setProps({ value: 'It changes' });
+    // Wait for the nextTick inside the input watcher
+    await wrapper.vm.$nextTick();
+    expect(document.activeElement).not.toBe(input.element);
+    wrapper.setProps({
+      value: 'Change',
+      focusInputOnValueChange: true,
+    });
+    await wrapper.vm.$nextTick();
+    expect(document.activeElement).not.toBe(input.element);
+  });
+
+  describe('copy/paste', () => {
+    let clipboardData = {};
+
+    beforeEach(() => {
+      clipboardData = {
+        setData: jest.fn(),
+        getData: jest.fn((param) => {
+          if (param === 'text/plain') return 'baz';
+          return prepareDataForHTMLClipboard({
+            input: 'baz',
+            tags: ['tag', 'tag2'],
+          });
+        }),
+        types: ['text/plain'],
+      };
+      jest.clearAllMocks();
+      clipboardData.types = ['text/plain'];
+    });
+
+    it('copies the search query in both plain text and HTML', () => {
+      wrapper.setProps({
+        value: inputValue,
+        selectedTags: tags,
+      });
+      // select all the text
+      input.trigger('keydown', {
+        metaKey: true,
+        key: 'a',
+      });
+      // copy
+      input.trigger('copy', { clipboardData });
+      // assert the copy payload
+      expect(clipboardData.setData).toHaveBeenCalledTimes(2);
+      // in HTML
+      expect(clipboardData.setData)
+        .toHaveBeenNthCalledWith(1, 'text/html', prepareDataForHTMLClipboard({
+          tags,
+          input: inputValue,
+        }));
+      // in Plain text
+      expect(clipboardData.setData)
+        .toHaveBeenNthCalledWith(2, 'text/plain', 'Tag1 Tag2 Foo');
+    });
+
+    it('does not copy tags, if they are not selected', () => {
+      // getSelectionText is mocked to be the input value
+      wrapper.setProps({
+        value: inputValue,
+        selectedTags: tags,
+      });
+      // copy
+      input.trigger('copy', { clipboardData });
+      expect(clipboardData.setData)
+        .toHaveBeenNthCalledWith(2, 'text/plain', 'Foo');
+    });
+
+    it('does not copy, if nothing is selected', () => {
+      wrapper.setProps({
+        value: inputValue,
+      });
+      getSelectionText.mockReturnValueOnce('');
+      // copy
+      input.trigger('copy', { clipboardData });
+      expect(clipboardData.setData)
+        .toHaveBeenCalledTimes(0);
+    });
+
+    it('does not cut, if nothing is selected', () => {
+      wrapper.setProps({
+        value: inputValue,
+      });
+      getSelectionText.mockReturnValueOnce('');
+      // copy
+      input.trigger('cut', { clipboardData });
+      expect(clipboardData.setData)
+        .toHaveBeenCalledTimes(0);
+      expect(wrapper.emitted('input')).toBeFalsy();
+      expect(wrapper.emitted('update:selectedTags')).toBeFalsy();
+    });
+
+    it('cuts selected text and tags', () => {
+      wrapper.setProps({
+        value: inputValue,
+        selectedTags: tags,
+      });
+      // select all the text
+      input.trigger('keydown', {
+        metaKey: true,
+        key: 'a',
+      });
+      // copy
+      input.trigger('cut', { clipboardData });
+      // assert the data is copied
+      expect(clipboardData.setData).toHaveBeenCalledTimes(2);
+      expect(clipboardData.setData)
+        .toHaveBeenNthCalledWith(1, 'text/html', prepareDataForHTMLClipboard({
+          tags,
+          input: inputValue,
+        }));
+      // in Plain text
+      expect(clipboardData.setData)
+        .toHaveBeenNthCalledWith(2, 'text/plain', 'Tag1 Tag2 Foo');
+      // assert the tags and input are removed
+      expect(wrapper.emitted('update:selectedTags')[0][0]).toEqual([]);
+      expect(wrapper.emitted('input')[0][0]).toEqual('');
+    });
+
+    it('selects all tags, and focuses the first one, input is empty', () => {
+      const spy = jest.spyOn(TagList.methods, 'focusTagByIndex');
+      wrapper.setProps({
+        selectedTags: tags,
+        value: '',
+      });
+      const selectedTags = wrapper.find({ ref: 'selectedTags' });
+      input.trigger('keydown', {
+        key: 'a',
+        metaKey: true,
+      });
+      expect(selectedTags.props('activeTags')).toEqual(tags);
+      // assert we tried to ficus first item
+      expect(spy).toHaveBeenCalledWith(0);
+    });
+
+    it('on paste, handles clipboard in HTML format, when copying and pasting from search directly', () => {
+      clipboardData.types = ['text/html'];
+      input.trigger('paste', { clipboardData });
+      // assert getData is called properly
+      expect(clipboardData.getData).toHaveBeenCalledTimes(2);
+      expect(clipboardData.getData).toHaveBeenCalledWith('text/plain');
+      expect(clipboardData.getData).toHaveBeenCalledWith('text/html');
+      // assert the input and tags are emitted
+      expect(wrapper.emitted('input')).toEqual([['baz']]);
+      // one vent, one param, which is an array
+      expect(wrapper.emitted('update:selectedTags')).toEqual([[['tag', 'tag2']]]);
+    });
+
+    it('on paste, handles clipboard when copying and pasting from any HTML outside the search', () => {
+      clipboardData.getData = jest.fn((param) => {
+        if (param === 'text/plain') return 'Title';
+        return `
+          <meta charset='utf-8'>
+          <h1 class="title">
+            Title
+          </h1>
+        `;
+      });
+      clipboardData.types.push('text/html');
+
+      input.trigger('paste', { clipboardData });
+      // assert getData is called properly
+      expect(clipboardData.getData).toHaveBeenCalledTimes(2);
+      expect(clipboardData.getData).toHaveBeenCalledWith('text/plain');
+      expect(clipboardData.getData).toHaveBeenCalledWith('text/html');
+      // assert the input and tags are emitted
+      expect(wrapper.emitted('input')).toHaveLength(1);
+      expect(wrapper.emitted('input')[0]).toEqual(['Title']);
+      expect(wrapper.emitted('update:selectedTags')).toHaveLength(1);
+      expect(wrapper.emitted('update:selectedTags')[0]).toEqual([[]]);
+    });
+
+    it('on paste, reads directly from plain text, if json is not available', () => {
+      clipboardData.getData.mockReturnValueOnce('[tag1][tag2] string');
+      input.trigger('paste', { clipboardData });
+      // assert getData is called properly
+      expect(clipboardData.getData).toHaveBeenCalledTimes(1);
+      expect(clipboardData.getData).toHaveBeenCalledWith('text/plain');
+      expect(clipboardData.getData).not.toHaveBeenCalledWith('text/html');
+      // assert the input and tags are emitted
+      expect(wrapper.emitted('input')).toHaveLength(1);
+      expect(wrapper.emitted('input')[0]).toEqual(['[tag1][tag2] string']);
+      expect(wrapper.emitted('update:selectedTags')).toHaveLength(1);
+      expect(wrapper.emitted('update:selectedTags')[0]).toEqual([[]]);
+    });
+
+    it('on paste, overwrites all the tags if they are selected', () => {
+      clipboardData.types.push('text/html');
+      // add pre-selected tags
+      wrapper.setProps({
+        selectedTags: tags,
+        input: 'Foo',
+      });
+      // select all
+      const selectedTags = wrapper.find({ ref: 'selectedTags' });
+      selectedTags.vm.$emit('select-all');
+
+      input.trigger('paste', { clipboardData });
+      // assert that tags are overwritten
+      expect(wrapper.emitted('update:selectedTags')).toHaveLength(1);
+      expect(wrapper.emitted('update:selectedTags')[0][0])
+        .toEqual(['tag', 'tag2']);
+    });
+
+    it('on paste, adds tags to the already selected, removing duplicates', () => {
+      clipboardData.types.push('text/html');
+      // add pre-selected tags
+      wrapper.setProps({
+        selectedTags: ['tag'],
+      });
+
+      input.trigger('paste', { clipboardData });
+      // assert that tags are overwritten
+      expect(wrapper.emitted('update:selectedTags')).toHaveLength(1);
+      expect(wrapper.emitted('update:selectedTags')[0][0])
+        .toEqual(['tag', 'tag2']);
+    });
+
+    it('on paste, overwrites just the selected part of the input text', () => {
+      getSelectionText.mockImplementationOnce(() => 'part');
+      wrapper.setProps({
+        value: 'partial input',
+      });
+      input.trigger('paste', { clipboardData });
+      expect(wrapper.emitted('input')[0][0]).toBe('bazial input');
+    });
+
+    it('on paste, inserts the text, at the position, where the caret is, if no text is selected', () => {
+      // overwrite the currently selected element position
+      Object.defineProperty(document.activeElement, 'selectionStart', {
+        value: 2,
+      });
+      clipboardData.getData.mockReturnValueOnce('fact');
+      getSelectionText.mockImplementationOnce(() => '');
+      wrapper.setProps({
+        value: 'input',
+      });
+      input.trigger('paste', { clipboardData });
+      expect(wrapper.emitted('input')[0][0]).toBe('infactput');
+    });
+  });
+
+  describe('once `suggestedTags` is rendered', () => {
+    let suggestedTags;
+    let deleteButton;
+    const relatedTargetCard = document.createElement('a');
+    document.body.appendChild(relatedTargetCard);
+
+    beforeEach(() => {
+      // show the suggested tags
+      wrapper.find('.filter').trigger('focus');
+
+      suggestedTags = wrapper.find({ ref: 'suggestedTags' });
+      deleteButton = wrapper.find('.filter__delete-button');
+    });
+
+    it('renders `deleteButton` when there are tags and they are shown', () => {
+      expect(deleteButton.exists()).toBe(true);
+    });
+
+    it('renders `suggestedTags` component when `displaySuggestedTags` is true', () => {
+      expect(suggestedTags.exists()).toBe(true);
+      expect(suggestedTags.props('tags')).toEqual(propsData.tags);
+    });
+
+    it('adds the correct aria label to `suggestedTags` component', () => {
+      expect(suggestedTags.props()).toHaveProperty('id', SuggestedTagsId);
+      expect(suggestedTags.props()).toHaveProperty('ariaLabel', 'Suggested tags');
+      wrapper.setProps({ tags: ['1'] });
+      expect(suggestedTags.props()).toHaveProperty('ariaLabel', 'Suggested tag');
+    });
+
+    it('keeps `suggestedTags` component when `suggestedTags` gets focus instead of `input`', () => {
+      suggestedTags.trigger('focus');
+      expect(wrapper.emitted('show-suggested-tags')).toBeTruthy();
+      expect(suggestedTags.exists()).toBe(true);
+    });
+
+    it('keeps `suggestedTags` component when `deleteButton` gets focus instead of `input`', () => {
+      deleteButton.trigger('focus');
+      expect(wrapper.emitted('show-suggested-tags')).toBeTruthy();
+      expect(suggestedTags.exists()).toBe(true);
+    });
+
+    it('removes `suggestedTags` component when `suggestedTags` looses its focus on an external component', async () => {
+      suggestedTags.trigger('focus');
+      expect(wrapper.emitted('show-suggested-tags')).toEqual([[true]]);
+      expect(wrapper.find({ ref: 'suggestedTags' }).exists()).toBe(true);
+
+      suggestedTags.trigger('blur', {
+        relatedTarget: relatedTargetCard,
+      });
+      await wrapper.vm.$nextTick();
+      // first time was `true`, from `focus`, then `blur` made it `false`
+      expect(wrapper.emitted('show-suggested-tags')).toEqual([[true], [false]]);
+      expect(suggestedTags.exists()).toBe(false);
+    });
+
+    it('deletes `suggestedTags` component when `deleteButton` looses its focus on an external component', async () => {
+      deleteButton.trigger('focus');
+      expect(deleteButton.exists()).toBe(true);
+      expect(wrapper.emitted('show-suggested-tags')).toEqual([[true]]);
+
+      deleteButton.trigger('blur', {
+        relatedTarget: relatedTargetCard,
+      });
+      await wrapper.vm.$nextTick();
+      expect(wrapper.emitted('show-suggested-tags')).toEqual([[true], [false]]);
+      expect(suggestedTags.exists()).toBe(false);
+    });
+
+    it('does not hide the tags, if the new focus target matches `input, button`', () => {
+      const buttonTarget = document.createElement('button');
+      const inputTarget = document.createElement('input');
+
+      input.trigger('blur', {
+        relatedTarget: buttonTarget,
+      });
+      input.trigger('blur', {
+        relatedTarget: inputTarget,
+      });
+
+      expect(suggestedTags.exists()).toBe(true);
+      expect(wrapper.emitted('show-suggested-tags')).toEqual([[true]]);
+    });
+
+    it('hides the tags, if the new focus target is a link, outside the FilterInput', async () => {
+      const relatedTargetOther = document.createElement('p');
+
+      input.trigger('blur', {
+        relatedTarget: relatedTargetCard,
+      });
+      input.trigger('blur', {
+        relatedTarget: relatedTargetOther,
+      });
+
+      await wrapper.vm.$nextTick();
+      expect(suggestedTags.exists()).toBe(false);
+      expect(wrapper.emitted('show-suggested-tags')).toEqual([[true], [false]]);
+    });
+
+    it('does not hide the tags, if `:preventedBlur=true`', async () => {
+      wrapper.setProps({ preventedBlur: true });
+
+      input.trigger('blur', {
+        relatedTarget: relatedTargetCard,
+      });
+
+      await wrapper.vm.$nextTick();
+      expect(wrapper.emitted('show-suggested-tags')).toEqual([[true]]);
+      expect(suggestedTags.exists()).toBe(true);
+    });
+
+    describe('when there is no tags shown', () => {
+      beforeEach(() => {
+        wrapper.setProps({ tags: [] });
+        deleteButton = wrapper.find('.filter__delete-button');
+      });
+
+      it('deletes `suggestedTags` component when no tags available', () => {
+        expect(suggestedTags.exists()).toBe(false);
+      });
+
+      it('does not render `deleteButton` when there are no tags and `input` is empty', () => {
+        expect(deleteButton.exists()).toBe(false);
+      });
+
+      it('renders `deleteButton` when there are no tags or they are not shown but there is text on `input`', () => {
+        expect(deleteButton.exists()).toBe(false);
+        wrapper.setProps({ value: 'foo' });
+
+        deleteButton = wrapper.find('.filter__delete-button');
+        expect(deleteButton.exists()).toBe(true);
+      });
+    });
+
+    it('adds tag to `selectedTags` when it is clicked', () => {
+      const selectedTag = 'Tag1';
+      suggestedTags.vm.$emit('click-tags', { tagName: selectedTag });
+      expect(wrapper.emitted('update:selectedTags')).toEqual([[[selectedTag]]]);
+    });
+
+    describe('when a tag is selected', () => {
+      let selectedTagsComponent;
+      const selectedTag = 'Tag1';
+
+      beforeEach(async () => {
+        wrapper.setProps({ selectedTags: [selectedTag] });
+        await wrapper.vm.$nextTick();
+        selectedTagsComponent = wrapper.find({ ref: 'selectedTags' });
+      });
+
+      it('renders `selectedTags` component with selected tag', () => {
+        expect(selectedTagsComponent.exists()).toBe(true);
+        expect(selectedTagsComponent.props('tags')).toEqual([selectedTag]);
+        expect(selectedTagsComponent.props()).toHaveProperty('areTagsRemovable', true);
+      });
+
+      it('adds the `selected-tags` id to the AX `aria-labelledby` property', () => {
+        const attrs = wrapper.attributes();
+        expect(attrs).toHaveProperty('aria-labelledby', 'filter-input selected-tags');
+      });
+
+      it('re-emits the the `preventedBlur` event, from selected tags', () => {
+        selectedTagsComponent.vm.$emit('prevent-blur');
+        expect(wrapper.emitted('update:preventedBlur')).toEqual([[true]]);
+      });
+
+      it('renders a filter button with blue color', () => {
+        const filterButton = wrapper.find('.filter__filter-button');
+        expect(filterButton.classes('blue')).toBe(true);
+      });
+
+      it('focuses input, when selectedTags changes', async () => {
+        expect(document.activeElement).toBe(input.element);
+        input.element.blur();
+        expect(document.activeElement).not.toBe(input.element);
+        wrapper.setProps({ selectedTags: [] });
+        await flushPromises();
+        expect(document.activeElement).toBe(input.element);
+      });
+
+      it('changes the input placeholder to empty', () => {
+        expect(input.attributes('placeholder')).toBe('');
+      });
+
+      it('resets scroll on `suggestedTags` when selectedTags changes if there is suggested tags', async () => {
+        const spy = jest.spyOn(TagList.methods, 'resetScroll');
+        wrapper = shallowMount(FilterInput, {
+          propsData,
+          stubs: { TagList },
+        });
+
+        wrapper.setProps({
+          selectedTags: [selectedTag],
+        });
+        // wait for the watcher to kick in
+        await flushPromises();
+        expect(spy).toHaveBeenCalledTimes(1);
+        spy.mockRestore();
+      });
+
+      it('select latest selected tag, if delete key is pressed on keyboard, and there is no input text', () => {
+        const spy = jest.spyOn(TagList.methods, 'focusLastTag').mockReturnValueOnce();
+
+        wrapper = shallowMount(FilterInput, {
+          propsData: { selectedTags: [selectedTag] },
+          stubs: { TagList },
+        });
+
+        input = wrapper.find({ ref: 'input' });
+        input.trigger('keydown.delete');
+
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not move the cursor to the beginning of the input when selected tags have all been deleted', async () => {
+        wrapper.setProps({ value: 'Foo' });
+        wrapper.find({ ref: 'selectedTags' }).vm.$emit('delete-tag', selectedTag);
+        wrapper.setProps({ selectedTags: [] });
+        await flushPromises();
+        expect(document.activeElement).toEqual(input.element);
+        expect(moveCursorToStart).toHaveBeenCalledTimes(0);
+      });
+
+      it('moves cursor to the start of the input if selected tags have changed and there are still available', async () => {
+        const updatedSelectedTag = 'AppKit';
+        // prepare
+        wrapper.setProps({ selectedTags: [selectedTag, updatedSelectedTag], input: 'Foo' });
+        // delete a tag
+        selectedTagsComponent.vm.$emit('delete-tag', {
+          tagName: selectedTag,
+          event: new KeyboardEvent('keydown', { key: 'Backspace' }),
+        });
+
+        await flushPromises();
+        // assert it emits the updated selected tags
+        expect(wrapper.emitted('update:selectedTags')[0]).toEqual([[updatedSelectedTag]]);
+        // assert it moves the caret if more tags still available
+        expect(moveCursorToStart).toHaveBeenCalledTimes(1);
+      });
+
+      it('moves cursor to the end of the input if user types on top of a tag', async () => {
+        const updatedSelectedTag = 'AppKit';
+        // prepare
+        wrapper.setProps({ selectedTags: [selectedTag, updatedSelectedTag], input: 'Foo' });
+        // delete a tag
+        wrapper.find({ ref: 'selectedTags' }).vm.$emit('delete-tag', {
+          tagName: selectedTag,
+          event: new KeyboardEvent('keydown', { key: 'k' }),
+        });
+
+        await flushPromises();
+        // assert it emits the updated selected tags
+        expect(wrapper.emitted('update:selectedTags')[0]).toEqual([[updatedSelectedTag]]);
+        // assert it moves the caret if more tags still available
+        expect(moveCursorToEnd).toHaveBeenCalledTimes(1);
+        expect(moveCursorToStart).toHaveBeenCalledTimes(0);
+      });
+
+      it('reset filters if delete key is pressed on input when input and tags are selected', async () => {
+        wrapper.setProps({ value: 'foo', selectedTags: [selectedTag] });
+
+        input.trigger('keydown', {
+          key: 'a',
+          metaKey: true,
+        });
+        input.trigger('keydown.delete');
+
+        expect(wrapper.emitted('update:selectedTags')[0][0]).toEqual([]);
+        await flushPromises();
+        expect(document.activeElement).toBe(input.element);
+      });
+
+      it('reset filters when `reset-filters` event is called on `selectedTags`', () => {
+        selectedTagsComponent.vm.$emit('reset-filters');
+
+        expect(wrapper.emitted('input')).toEqual([['']]);
+        expect(wrapper.emitted('update:selectedTags')).toEqual([[[]]]);
+        expect(wrapper.emitted('show-suggested-tags')).toEqual([[true]]);
+      });
+
+      it('keeps the focus on input after resetting filters', async () => {
+        const spy = jest.spyOn(selectedTagsComponent.vm, 'focusTag').mockReturnValueOnce();
+
+        // add tags
+        wrapper.setProps({ value: '', selectedTags: tags });
+        expect(spy).toHaveBeenCalledTimes(0);
+        // select all
+        wrapper.find({ ref: 'input' }).trigger('keydown', {
+          key: 'a',
+          metaKey: true,
+        });
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        // simulate resetting the filters
+        selectedTagsComponent.vm.$emit('reset-filters');
+        await flushPromises();
+
+        expect(document.activeElement).toBe(input.element);
+      });
+
+      it('sets the `keyboardIsVirtual` to true, when resizing the screen and there is a substantial height difference', async () => {
+        const { VirtualKeyboardThreshold } = multipleSelection.constants;
+
+        expect(window.visualViewport.addEventListener)
+          .toHaveBeenLastCalledWith('resize', wrapper.vm.updateKeyboardType);
+
+        const height = 568;
+        const eventProperty = { target: { height: height - VirtualKeyboardThreshold } };
+        resizeWindow(320, height, eventProperty);
+        expect(wrapper.vm.keyboardIsVirtual).toBe(true);
+      });
+
+      it('removes the `visualViewport` listeners', () => {
+        wrapper.destroy();
+        expect(window.visualViewport.removeEventListener)
+          .toHaveBeenLastCalledWith('resize', wrapper.vm.updateKeyboardType);
+      });
+
+      it('sets the `keyboardIsVirtual` to false, when resizing the screen and there is little to no height difference', async () => {
+        const height = 568;
+        // small difference
+        const eventProperty = { target: { height: height - 10 } };
+
+        resizeWindow(320, height, eventProperty);
+        expect(wrapper.vm.keyboardIsVirtual).toBe(false);
+      });
+
+      it('deletes the last tag, if delete button is pressed on a virtual keyboard, when no input', () => {
+        wrapper.setData({ keyboardIsVirtual: true });
+
+        wrapper.find({ ref: 'input' }).trigger('keydown.delete');
+
+        expect(wrapper.emitted('update:selectedTags')).toEqual([[[]]]);
+      });
+
+      it('deletes selected tag when tag is clicked on a virtual keyboard', async () => {
+        wrapper.setData({ keyboardIsVirtual: true });
+        wrapper.setProps({ selectedTags: [selectedTag, 'Tag2'] });
+        await wrapper.vm.$nextTick();
+
+        selectedTagsComponent.vm.$emit('click-tags', { tagName: 'Tag2' });
+        await flushPromises();
+
+        expect(wrapper.emitted('update:selectedTags')).toEqual([[[selectedTag]]]);
+      });
+
+      it('deletes selected tag debounced', async () => {
+        wrapper.setData({ keyboardIsVirtual: true });
+
+        const selectedTags = wrapper.find({ ref: 'selectedTags' });
+        selectedTags.vm.$emit('click-tags', { tagName: selectedTag });
+        expect(debounce).toHaveBeenLastCalledWith(wrapper.vm.handleDeleteTag, 280);
+        await flushPromises();
+        expect(wrapper.emitted('update:selectedTags')).toEqual([[[]]]);
+      });
+
+      it('focuses the input and does not delete selected tag when it is clicked on desktop', () => {
+        const selectedTags = wrapper.find({ ref: 'selectedTags' });
+        selectedTags.vm.$emit('click-tags', selectedTag);
+        expect(wrapper.vm.selectedTags).toEqual([selectedTag]);
+        expect(document.activeElement).toBe(input.element);
+      });
+    });
+
+    it('resets filters when `deleteButton` is clicked', async () => {
+      wrapper.setProps({ value: '', selectedTags: [] });
+      deleteButton.trigger('click');
+
+      // last emitted item is false. We have one true, because we focused.
+      expect(wrapper.emitted('show-suggested-tags')).toEqual([[true], [false]]);
+      expect(wrapper.emitted('input')).toEqual([['']]);
+      expect(wrapper.emitted('update:selectedTags')).toEqual([[[]]]);
+      expect(document.activeElement).not.toBe(input.element);
+      expect(wrapper.vm.resetedTagsViaDeleteButton).toEqual(true);
+
+      wrapper.setProps({ value: 'foo', selectedTags: tags });
+      deleteButton.trigger('click');
+
+      expect(wrapper.emitted('show-suggested-tags')).toEqual([[true], [false]]);
+      expect(wrapper.emitted('input')).toEqual([[''], ['']]);
+      expect(wrapper.emitted('update:selectedTags')).toEqual([[[]], [[]]]);
+      expect(document.activeElement).not.toBe(input.element);
+      expect(wrapper.vm.resetedTagsViaDeleteButton).toEqual(true);
+    });
+
+    it('emits `focus-card` if the down key is pressed on input and there is no suggestedTags', () => {
+      wrapper.setProps({ suggestedTags: [] });
+      input = wrapper.find('input');
+
+      input.trigger('keydown.down');
+
+      expect(wrapper.emitted('focus-card')).toBeTruthy();
+    });
+
+    it('resets filters when `reset-filters` is emitted from selectedTags', async () => {
+      wrapper.setProps({ value: 'foo', selectedTags: tags });
+      const selectedTags = wrapper.find({ ref: 'selectedTags' });
+      selectedTags.vm.$emit('reset-filters');
+
+      expect(wrapper.emitted('reset-input')).toBeTruthy();
+      expect(wrapper.emitted('reset-selected-tags')).toBeTruthy();
+      await wrapper.vm.$nextTick();
+      expect(document.activeElement).toBe(input.element);
+    });
+
+    it('resets all the filters after the user selects all the content and writes over it, if key is a single character', async () => {
+      isSingleCharacter.mockImplementation(() => true);
+      wrapper.setProps({ value: 'foo', selectedTags: tags });
+
+      const singleCharacter = 'a';
+
+      wrapper.find({ ref: 'selectedTags' }).vm.$emit('select-all');
+      input.trigger('keydown', { key: singleCharacter });
+      input.setValue(singleCharacter);
+
+      expect(wrapper.emitted('reset-input')).toHaveLength(1);
+      expect(wrapper.emitted('reset-selected-tags')).toHaveLength(1);
+      await wrapper.vm.$nextTick();
+      expect(document.activeElement).toBe(input.element);
+      expect(wrapper.emitted('input')).toEqual([[singleCharacter]]);
+    });
+
+    it('resets all the filters, if user selects all text and enters a character with pressing shift', async () => {
+      isSingleCharacter.mockImplementation(() => true);
+      wrapper.setProps({ value: 'foo', selectedTags: tags });
+
+      const singleCharacter = 'A';
+
+      wrapper.find({ ref: 'selectedTags' }).vm.$emit('select-all');
+
+      input.trigger('keydown', {
+        key: singleCharacter,
+        shiftKey: true,
+      });
+      input.setValue(singleCharacter);
+
+      expect(wrapper.emitted('reset-input')).toHaveLength(1);
+      expect(wrapper.emitted('reset-selected-tags')).toHaveLength(1);
+      await wrapper.vm.$nextTick();
+      expect(document.activeElement).toBe(input.element);
+      expect(wrapper.emitted('input')).toEqual([[singleCharacter]]);
+    });
+
+    it('does not reset all the filters after the user selects all the content and types something on top if key is not a single character', () => {
+      isSingleCharacter.mockImplementation(() => false);
+      wrapper.setProps({ value: 'foo', selectedTags: tags });
+
+      const nonSingleCharacter = '>';
+
+      wrapper.find({ ref: 'selectedTags' }).vm.$emit('select-all');
+      input.trigger('keydown', { key: nonSingleCharacter });
+
+      input.trigger('keydown', {
+        key: nonSingleCharacter,
+        shiftKey: true,
+      });
+
+      expect(wrapper.emitted('input')).toBeFalsy();
+      expect(wrapper.emitted('update:selectedTags')).toBeFalsy();
+    });
+
+    it('does not reset tags if only text is fully selected when typing', () => {
+      wrapper.setProps({ value: 'foo', selectedTags: tags });
+      input.trigger('keydown', {
+        key: 'c', // single char
+      });
+      expect(wrapper.emitted('hide-tags')).toBeFalsy();
+      expect(wrapper.emitted('reset-input')).toBeFalsy();
+      expect(wrapper.emitted('reset-selected-tags')).toBeFalsy();
+    });
+
+    it('focuses selected tags if `select-all` is emitted from selectedTags and input has value', () => {
+      wrapper.setProps({ value: 'foo', selectedTags: tags });
+      const selectedTags = wrapper.find({ ref: 'selectedTags' });
+      selectedTags.vm.$emit('select-all');
+
+      expect(wrapper.vm.selectedTag).toEqual(wrapper.vm.activeTag);
+    });
+
+    it('focuses selected tags if `cmd + a` is triggered on input that has a value', () => {
+      wrapper.setProps({ value: 'foo', selectedTags: tags });
+      input.trigger('keydown', {
+        key: 'a',
+        metaKey: true,
+      });
+
+      expect(wrapper.vm.selectedTag).toEqual(wrapper.vm.activeTag);
+    });
+
+    it('does not focus selected tags if `cmd + a` is triggered on input that has a value and then user clicks on input', () => {
+      wrapper.setProps({ value: 'foo', selectedTags: tags });
+      input.trigger('keydown', {
+        key: 'a',
+        metaKey: true,
+      });
+
+      input.trigger('click');
+
+      expect(wrapper.vm.activeTags).toEqual([]);
+    });
+
+    it('focuses selected tags if `ctrl + a` is triggered on input that has a value', () => {
+      wrapper.setProps({ value: 'foo', selectedTags: tags });
+      input.trigger('keydown', {
+        key: 'a',
+        ctrlKey: true,
+      });
+
+      expect(wrapper.vm.selectedTag).toEqual(wrapper.vm.activeTag);
+    });
+
+    it('focus on the first tag of selectedTags if cmd + a is triggered on an empty input, there is not a shift init tag and there are selected tags', () => {
+      const spy = jest.spyOn(TagList.methods, 'focusTag').mockReturnValueOnce();
+      wrapper = shallowMount(FilterInput, {
+        propsData,
+        stubs: { TagList },
+      });
+
+      wrapper.setProps({ value: '', selectedTags: tags });
+      wrapper.find({ ref: 'input' }).trigger('keydown', {
+        key: 'a',
+        metaKey: true,
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('assigns selected tags to active tags when cmd + a is triggered on input', () => {
+      wrapper.setProps({ value: 'Foo', selectedTags: tags });
+      wrapper.find({ ref: 'input' }).trigger('keydown', {
+        key: 'a',
+        metaKey: true,
+      });
+      expect(wrapper.vm.activeTags).toEqual(wrapper.vm.selectedTags);
+    });
+
+    it('focus on the first tag when the left key is trigger on a selected input and tags are selected as well', () => {
+      const spy = jest.spyOn(TagList.methods, 'focusTag').mockReturnValueOnce();
+
+      wrapper = shallowMount(FilterInput, {
+        propsData: { input: 'foo', selectedTags: tags },
+        stubs: { TagList },
+      });
+
+      input = wrapper.find({ ref: 'input' });
+      input.trigger('keydown', {
+        key: 'a',
+        metaKey: true,
+      });
+      input.trigger('keydown.left');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('focus on the last tag when the left key is trigger on a selected input and but tags are not selected', () => {
+      const spy = jest.spyOn(TagList.methods, 'focusLastTag').mockReturnValueOnce();
+
+      wrapper = shallowMount(FilterInput, {
+        propsData: { input: 'foo', selectedTags: tags },
+        stubs: { TagList },
+      });
+
+      input = wrapper.find({ ref: 'input' });
+      input.element.select();
+      input.trigger('keydown.left');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('focus on the last tag when the left key is trigger on input if user cursor is on the beginning', () => {
+      const spy = jest.spyOn(TagList.methods, 'focusLastTag').mockReturnValueOnce();
+      wrapper = shallowMount(FilterInput, {
+        propsData: { selectedTags: tags },
+        stubs: { TagList },
+      });
+
+      input = wrapper.find({ ref: 'input' });
+      input.trigger('keydown.left');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Shift and Meta selection', () => {
+    const selectedTags = ['Tag1', 'Tag2', 'Tag3'];
+    let spyFocusTag;
+    let selectedTagsComponent;
+
+    describe('starting from input', () => {
+      beforeEach(async () => {
+        jest.resetAllMocks();
+        spyFocusTag = jest.spyOn(TagList.methods, 'focusTag').mockReturnValueOnce();
+
+        wrapper = shallowMount(FilterInput, {
+          propsData: { selectedTags, input: inputValue },
+          stubs: { TagList },
+        });
+
+        await wrapper.vm.$nextTick();
+        input = wrapper.find({ ref: 'input' });
+        selectedTagsComponent = wrapper.find({ ref: 'selectedTags' });
+      });
+
+      it('selects the whole range between the text input and tag that has been focused afterwards', () => {
+        const spy = jest.spyOn(input.element, 'setSelectionRange');
+
+        // Put cursor on the second position of the input
+        // eslint-disable-next-line
+        input.element.selectionStart = input.element.selectionEnd = 2;
+
+        // Set shift key on the input
+        input.trigger('keydown', { shiftKey: true });
+
+        // Focus on the first tag
+        selectedTagsComponent.vm.$emit('focus', {
+          tagName: selectedTags[0],
+          event: { relatedTarget: document.createElement('input') },
+        });
+
+        // All tags should be active
+        expect(wrapper.vm.activeTags).toEqual(selectedTags);
+        // Text selection should have been called from characters 0 to 2
+        expect(spy).toHaveBeenCalledWith(0, 2);
+        spy.mockRestore();
+      });
+
+      it('selects selected text and all tags until the last one when user has selected a text and focused on a tag while holding the shift key', () => {
+        const spy = jest.spyOn(input.element, 'setSelectionRange');
+
+        // Select text from character 1 to 2
+        input.element.selectionStart = 1;
+        input.element.selectionEnd = 2;
+
+        // Set shift key on the input
+        input.trigger('keydown', { shiftKey: true });
+
+        // Focus on the middle tag
+        selectedTagsComponent.vm.$emit('focus', {
+          tagName: selectedTags[1],
+          event: { relatedTarget: document.createElement('input') },
+        });
+
+        // Tags from middle to the last one should get active
+        expect(wrapper.vm.activeTags).toEqual([selectedTags[1], selectedTags[2]]);
+        // Text selection should have been called from characters 1 to 2
+        expect(spy).toHaveBeenCalledWith(1, 2);
+        spy.mockRestore();
+      });
+
+      describe('when the left arrow is pressed while holding the shift key on input', () => {
+        beforeEach(() => {
+          // Put cursor on the beginning of the input
+          // eslint-disable-next-line
+          input.element.selectionStart = input.element.selectionEnd = 0;
+
+          // Press left key + shift on input
+          input.trigger('keydown.left', { shiftKey: true });
+        });
+
+        it('selects tags from right to left', () => {
+          // Last tag should get active
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[2]]);
+
+          // Press left key + shift on the last tag
+          selectedTagsComponent.vm.$emit('keydown', {
+            tagName: selectedTags[2],
+            event: new KeyboardEvent('keydown.left', { shiftKey: true }),
+          });
+
+          // Previous tag get focus
+          selectedTagsComponent.vm.$emit('focus', { tagName: selectedTags[1] });
+
+          // Last two tags get active
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[1], selectedTags[2]]);
+        });
+
+        it('unselects tags from left to right', () => {
+          // Press left key + shift on the last tag
+          selectedTagsComponent.vm.$emit('keydown', {
+            tagName: selectedTags[2],
+            event: new KeyboardEvent('keydown.left', { shiftKey: true }),
+          });
+          selectedTagsComponent.vm.$emit('focus', { tagName: selectedTags[1] });
+
+          // Last two tags get active
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[1], selectedTags[2]]);
+
+          // Press right key + shift when focusing on the middle tag
+          selectedTagsComponent.vm.$emit('keydown', {
+            tagName: selectedTags[1],
+            event: new KeyboardEvent('keydown.right', { shiftKey: true }),
+          });
+          // Last tag get focus
+          selectedTagsComponent.vm.$emit('focus', { tagName: selectedTags[2] });
+
+          // Only the last tag get active
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[2]]);
+        });
+
+        it('unselects tags clicking on them using the meta key', () => {
+          // Press left key + shift on the last tag
+          selectedTagsComponent.vm.$emit('keydown', {
+            tagName: selectedTags[2],
+            event: new KeyboardEvent('keydown.left', { shiftKey: true }),
+          });
+          selectedTagsComponent.vm.$emit('focus', { tagName: selectedTags[1] });
+
+          // Last two tags get active
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[1], selectedTags[2]]);
+
+          // Click on the selected tag 1 while pressing the metaKey
+          selectedTagsComponent.vm.$emit('click-tags', {
+            tagName: selectedTags[1],
+            event: new MouseEvent('click', { metaKey: true }),
+          });
+
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[2]]);
+          expect(spyFocusTag).toHaveBeenCalledTimes(1);
+        });
+
+        it('unselects tags clicking on them using the ctrl key', () => {
+          // Press left key + shift on the last tag
+          selectedTagsComponent.vm.$emit('keydown', {
+            tagName: selectedTags[2],
+            event: new KeyboardEvent('keydown.left', { shiftKey: true }),
+          });
+          selectedTagsComponent.vm.$emit('focus', { tagName: selectedTags[1] });
+
+          // Last two tags get active
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[1], selectedTags[2]]);
+
+          // Click on the selected tag 1 while pressing the metaKey
+          selectedTagsComponent.vm.$emit('click-tags', {
+            tagName: selectedTags[1],
+            event: new MouseEvent('click', { ctrlKey: true }),
+          });
+
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[2]]);
+          expect(spyFocusTag).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not select tags if user tabs while holding the shift key from input', () => {
+          input.trigger('keydown', { key: 'Tab', shiftKey: true });
+          expect(wrapper.vm.activeTags).toEqual([]);
+
+          selectedTagsComponent.vm.$emit('focus', { tagName: selectedTags[2] });
+          expect(wrapper.vm.activeTags).toEqual([]);
+        });
+      });
+    });
+
+    describe('starting from tags', () => {
+      beforeEach(async () => {
+        jest.resetAllMocks();
+        spyFocusTag = jest.spyOn(TagList.methods, 'focusTag').mockReturnValueOnce();
+
+        wrapper = shallowMount(FilterInput, {
+          propsData: { selectedTags },
+          stubs: { TagList },
+        });
+
+        await wrapper.vm.$nextTick();
+        selectedTagsComponent = wrapper.find({ ref: 'selectedTags' });
+        input = wrapper.find({ ref: 'input' });
+      });
+
+      it('selects the whole range between the init tag index and the focused tag index from right to left', () => {
+        selectedTagsComponent.vm.$emit('keydown', {
+          tagName: selectedTags[2],
+          event: new KeyboardEvent('keydown', { shiftKey: true }),
+        });
+        selectedTagsComponent.vm.$emit('focus', { tagName: selectedTags[0] });
+
+        expect(wrapper.vm.activeTags).toEqual(selectedTags);
+      });
+
+      it('keeps tags selected when focusing on the input after pressing on the right key on the last tag', async () => {
+        // Press right key + shift on the last tag
+        selectedTagsComponent.vm.$emit('keydown', {
+          tagName: selectedTags[2],
+          event: new KeyboardEvent('keydown.right', { shiftKey: true }),
+        });
+
+        selectedTagsComponent.vm.$emit('focus-next');
+
+        expect(wrapper.vm.activeTags).toEqual([selectedTags[2]]);
+        await wrapper.vm.$nextTick();
+        expect(document.activeElement).toBe(input.element);
+      });
+
+      it('selects the whole range between the init tag index and the end of the active tags from left to right', async () => {
+        const relatedTargetCard = document.createElement('a');
+        // Select init tag
+        selectedTagsComponent.vm.$emit('click-tags', {
+          tagName: selectedTags[0],
+          event: new MouseEvent('click'),
+        });
+
+        // Trigger shift + meta + arrow right
+        selectedTagsComponent.vm.$emit('keydown', {
+          tagName: selectedTags[0],
+          event: new KeyboardEvent('keydown', { shiftKey: true, metaKey: true, key: 'ArrowRight' }),
+        });
+
+        expect(wrapper.vm.activeTags).toEqual(selectedTags);
+        // Focus on the last tag
+        expect(spyFocusTag).toHaveBeenNthCalledWith(1, selectedTags[2]);
+
+        // Select init tag again to reset active tags
+        selectedTagsComponent.vm.$emit('click-tags', {
+          tagName: selectedTags[0],
+          event: new MouseEvent('click'),
+        });
+
+        selectedTagsComponent.trigger('blur', {
+          relatedTarget: relatedTargetCard,
+        });
+
+        await wrapper.vm.$nextTick();
+        expect(wrapper.vm.activeTags).toEqual([]);
+
+        // Trigger shift + ctrl + arrow right
+        selectedTagsComponent.vm.$emit('keydown', {
+          tagName: selectedTags[0],
+          event: new KeyboardEvent('keydown', { shiftKey: true, ctrlKey: true, key: 'ArrowRight' }),
+        });
+
+        expect(wrapper.vm.activeTags).toEqual(selectedTags);
+        // Focus on the last tag
+        expect(spyFocusTag).toHaveBeenNthCalledWith(2, selectedTags[2]);
+      });
+
+      it('selects the whole range between the init tag index and the start of the active tags from right to left', () => {
+        // Select init tag
+        selectedTagsComponent.vm.$emit('click-tags', {
+          tagName: selectedTags[2],
+          event: new MouseEvent('click'),
+        });
+
+        // Trigger shift + meta + arrow left
+        selectedTagsComponent.vm.$emit('keydown', {
+          tagName: selectedTags[2],
+          event: new KeyboardEvent('keydown', { shiftKey: true, metaKey: true, key: 'ArrowLeft' }),
+        });
+
+        expect(wrapper.vm.activeTags).toEqual(selectedTags);
+        // Focus on the first tag
+        expect(spyFocusTag).toHaveBeenNthCalledWith(1, selectedTags[0]);
+
+        // Select init tag again to reset active tags
+        selectedTagsComponent.vm.$emit('click-tags', {
+          tagName: selectedTags[2],
+          event: new MouseEvent('click'),
+        });
+
+        expect(wrapper.vm.activeTags).toEqual([]);
+
+        // Trigger shift + ctrl + arrow left
+        selectedTagsComponent.vm.$emit('keydown', {
+          tagName: selectedTags[2],
+          event: new KeyboardEvent('keydown', { shiftKey: true, ctrlKey: true, key: 'ArrowLeft' }),
+        });
+
+        expect(wrapper.vm.activeTags).toEqual(selectedTags);
+        // Focus on the first tag
+        expect(spyFocusTag).toHaveBeenNthCalledWith(1, selectedTags[0]);
+      });
+
+      it('adds a tag to the selection when user click on it holding the cmd key', () => {
+        expect(wrapper.vm.activeTags).toEqual([]);
+        selectedTagsComponent.vm.$emit('click-tags', {
+          tagName: selectedTags[1],
+          event: new MouseEvent('click', { metaKey: true }),
+        });
+
+        expect(wrapper.vm.activeTags).toEqual([selectedTags[1]]);
+
+        selectedTagsComponent.vm.$emit('click-tags', {
+          tagName: selectedTags[0],
+          event: new MouseEvent('click', { metaKey: true }),
+        });
+
+        expect(wrapper.vm.activeTags).toEqual([selectedTags[1], selectedTags[0]]);
+      });
+
+      it('adds a tag to the selection when user click on it holding the ctrl key', () => {
+        expect(wrapper.vm.activeTags).toEqual([]);
+        selectedTagsComponent.vm.$emit('click-tags', {
+          tagName: selectedTags[1],
+          event: new MouseEvent('click', { ctrlKey: true }),
+        });
+
+        expect(wrapper.vm.activeTags).toEqual([selectedTags[1]]);
+
+        selectedTagsComponent.vm.$emit('click-tags', {
+          tagName: selectedTags[0],
+          event: new MouseEvent('click', { ctrlKey: true }),
+        });
+
+        expect(wrapper.vm.activeTags).toEqual([selectedTags[1], selectedTags[0]]);
+      });
+
+      it('selects the init tag as the length of selected tags when the selection starts on the input value', () => {
+        input = wrapper.find({ ref: 'input' });
+        input.trigger('keydown.left', {
+          shiftKey: true,
+        });
+
+        expect(wrapper.vm.initTagIndex).toEqual(selectedTags.length);
+        expect(wrapper.vm.activeTags).toEqual([selectedTags[selectedTags.length - 1]]);
+
+        selectedTagsComponent.vm.$emit('focus', { tagName: selectedTags[0] });
+
+        expect(wrapper.vm.activeTags).toEqual(selectedTags);
+      });
+
+      describe('When the user has selected a tag to init the shift selection', () => {
+        beforeEach(async () => {
+          selectedTagsComponent.vm.$emit('keydown', {
+            tagName: selectedTags[0],
+            event: new KeyboardEvent('keydown', { shiftKey: true }),
+          });
+          selectedTagsComponent.vm.$emit('focus', { tagName: selectedTags[2] });
+        });
+
+        it('selects the init tag', () => {
+          expect(wrapper.vm.initTagIndex).toBe(0);
+        });
+
+        it('resets all the active tags when selected tags get blur', async () => {
+          const relatedTargetCard = document.createElement('a');
+
+          selectedTagsComponent.trigger('blur', {
+            relatedTarget: relatedTargetCard,
+          });
+          await wrapper.vm.$nextTick();
+
+          expect(wrapper.vm.activeTags).toEqual([]);
+          expect(wrapper.vm.initTagIndex).toEqual(null);
+        });
+
+        it('reset filters when typing while being focus on active tags', () => {
+          const alphanumKey = 'a';
+          const space = ' ';
+
+          selectedTagsComponent.vm.$emit('delete-tag', {
+            tagName: selectedTags[2],
+            event: new KeyboardEvent('keydown', { key: alphanumKey, shiftKey: false }),
+          });
+
+          expect(wrapper.emitted('update:selectedTags')).toHaveLength(1);
+
+          selectedTagsComponent.vm.$emit('delete-tag', {
+            tagName: selectedTags[2],
+            event: new KeyboardEvent('keydown', { key: space, shiftKey: false }),
+          });
+
+          expect(wrapper.emitted('update:selectedTags')).toHaveLength(2);
+
+          // is triggered by only shiftkey modifier combination
+          selectedTagsComponent.vm.$emit('delete-tag', {
+            tagName: selectedTags[2],
+            event: new KeyboardEvent('keydown', { key: alphanumKey, shiftKey: true }),
+          });
+
+          expect(wrapper.emitted('update:selectedTags')).toHaveLength(3);
+        });
+
+        it('selects the whole range between the init tag index and the focused tag index from left to right', () => {
+          expect(wrapper.vm.activeTags).toEqual(selectedTags);
+        });
+
+        it('deletes the selection when user types the delete key', () => {
+          selectedTagsComponent.vm.$emit('delete-tag', {
+            tagName: selectedTags[0],
+            event: new KeyboardEvent('keydown', { key: 'Backspace' }),
+          });
+          expect(wrapper.emitted('update:selectedTags')[0][0]).toEqual([]);
+          expect(wrapper.vm.activeTags).toEqual([]);
+        });
+
+        it('removes a tag from the shift selection when user click on it holding the cmd key', async () => {
+          selectedTagsComponent.vm.$emit('click-tags', {
+            tagName: selectedTags[1],
+            event: new MouseEvent('click', { metaKey: true }),
+          });
+
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[0], selectedTags[2]]);
+          expect(spyFocusTag).toHaveBeenCalledTimes(1);
+
+          selectedTagsComponent.vm.$emit('click-tags', {
+            tagName: selectedTags[0],
+            event: new MouseEvent('click', { metaKey: true }),
+          });
+
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[2]]);
+          expect(spyFocusTag).toHaveBeenCalledTimes(2);
+
+          selectedTagsComponent.vm.$emit('click-tags', {
+            tagName: selectedTags[2],
+            event: new MouseEvent('click', { metaKey: true }),
+          });
+
+          expect(wrapper.vm.activeTags).toEqual([]);
+
+          input = wrapper.find({ ref: 'input' });
+          await wrapper.vm.$nextTick();
+          // When there aren't activeTags anymore, focus goes to the input
+          expect(document.activeElement).toBe(input.element);
+        });
+
+        it('removes a tag from the shift selection when user click on it holding the ctrl key', async () => {
+          selectedTagsComponent.vm.$emit('click-tags', {
+            tagName: selectedTags[1],
+            event: new MouseEvent('click', { ctrlKey: true }),
+          });
+
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[0], selectedTags[2]]);
+          expect(spyFocusTag).toHaveBeenCalledTimes(1);
+
+          selectedTagsComponent.vm.$emit('click-tags', {
+            tagName: selectedTags[0],
+            event: new MouseEvent('click', { ctrlKey: true }),
+          });
+
+          expect(wrapper.vm.activeTags).toEqual([selectedTags[2]]);
+          expect(spyFocusTag).toHaveBeenCalledTimes(2);
+
+          selectedTagsComponent.vm.$emit('click-tags', {
+            tagName: selectedTags[2],
+            event: new MouseEvent('click', { ctrlKey: true }),
+          });
+
+          expect(wrapper.vm.activeTags).toEqual([]);
+
+          input = wrapper.find({ ref: 'input' });
+          await wrapper.vm.$nextTick();
+          // When there aren't activeTags anymore, focus goes to the input
+          expect(document.activeElement).toBe(input.element);
+        });
+      });
+    });
+  });
+});

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -174,17 +174,23 @@ describe('FilterInput', () => {
     expect(document.activeElement).not.toBe(input.element);
   });
 
-  it('focuses the input, on external `value` change', async () => {
+  it('focuses the input if `focusInputWhenCreated` is on and input has content when component is created', async () => {
     wrapper.setProps({ value: 'It changes' });
     // Wait for the nextTick inside the input watcher
     await wrapper.vm.$nextTick();
     expect(document.activeElement).not.toBe(input.element);
-    wrapper.setProps({
-      value: 'Change',
-      focusInputOnValueChange: true,
+    // create component with input value
+    wrapper = shallowMount(FilterInput, {
+      propsData: {
+        ...propsData,
+        value: 'Change',
+        focusInputWhenCreated: true,
+      },
+      stubs: { TagList },
     });
     await wrapper.vm.$nextTick();
-    expect(document.activeElement).not.toBe(input.element);
+    input = wrapper.find({ ref: 'input' });
+    expect(document.activeElement).toBe(input.element);
   });
 
   describe('copy/paste', () => {

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -79,9 +79,6 @@ describe('FilterInput', () => {
     wrapper = shallowMount(FilterInput, {
       propsData,
       stubs: { TagList },
-      slots: {
-        icon: FilterIcon,
-      },
     });
 
     input = wrapper.find({ ref: 'input' });

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -1,3 +1,13 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
 import { prepareDataForHTMLClipboard } from '@/utils/clipboard';
 import { shallowMount } from '@vue/test-utils';
 import FilterInput from '@/components/Filter/FilterInput.vue';
@@ -25,7 +35,6 @@ jest.mock('@/utils/input-helper', () => ({
 
 const {
   SuggestedTagsId,
-  SelectedTagsId,
   FilterInputId,
 } = FilterInput.constants;
 

--- a/tests/unit/components/Filter/Tag.spec.js
+++ b/tests/unit/components/Filter/Tag.spec.js
@@ -1,0 +1,278 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import { prepareDataForHTMLClipboard } from 'docc-render/utils/clipboard';
+import { shallowMount } from '@vue/test-utils';
+import Tag from 'docc-render/components/Filter/Tag.vue';
+
+describe('Tag', () => {
+  let wrapper;
+  let button;
+
+  const propsData = {
+    name: 'Tag A',
+    isFocused: false,
+    isRemovableTag: false,
+    isActiveTag: false,
+    activeTags: [],
+  };
+
+  beforeEach(() => {
+    wrapper = shallowMount(Tag, { propsData });
+    button = wrapper.find('button');
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    // remove global even listeners before each test begins
+    wrapper.destroy();
+  });
+
+  it('renders a tag', () => {
+    expect(wrapper.is('.tag')).toBe(true);
+    expect(wrapper.attributes()).toHaveProperty('role', 'presentation');
+
+    expect(button.exists()).toBe(true);
+    expect(button.attributes()).toHaveProperty('aria-roledescription', 'tag');
+  });
+
+  it('emits `click` when being clicked', () => {
+    button.trigger('click');
+
+    expect(wrapper.emitted().click).toBeTruthy();
+  });
+
+  it('emits `delete-tag` when being double clicked', () => {
+    button.trigger('dblclick');
+
+    expect(wrapper.emitted('delete-tag')).toBeTruthy();
+    expect(wrapper.emitted('delete-tag')[0][0].tagName).toEqual(propsData.name);
+  });
+
+  it('does not emit `delete-tag` when being double clicked if `keyboardIsVirtual` is true', () => {
+    wrapper.setProps({ keyboardIsVirtual: true });
+    button.trigger('dblclick');
+
+    expect(wrapper.emitted('delete-tag')).toBeFalsy();
+  });
+
+  it('emits `delete-tag` when pressing the delete keydown', () => {
+    button.trigger('keydown.delete');
+
+    expect(wrapper.emitted('delete-tag')).toBeTruthy();
+  });
+
+  it('prevents blur when deleting a tag', () => {
+    button.trigger('keydown.delete');
+
+    expect(wrapper.emitted('prevent-blur')).toBeTruthy();
+  });
+
+  it('focuses button when user clicks on tag', () => {
+    // This is needed to focus tags on Safari
+    // We use mousedown event instead of click to be able
+    // to focus on the input right after on suggestedTags
+    button.trigger('mousedown');
+    expect(wrapper.emitted('delete-tag')).toBeFalsy();
+
+    expect(document.activeElement).toBe(button.element);
+    expect(wrapper.emitted('focus')).toBeTruthy();
+  });
+
+  it('does not prevent blur when focusing in a tag', () => {
+    button.trigger('mousedown');
+
+    expect(document.activeElement).toBe(button.element);
+    expect(wrapper.emitted('prevent-blur')).toBeFalsy();
+  });
+
+  it('does not focus the button when `keyboardIsVirtual` is true', () => {
+    // This is needed to prevent from focusing the button
+    // on tags when user uses a virtual keyboard
+    wrapper.setProps({ keyboardIsVirtual: true });
+    button = wrapper.find('button');
+    button.trigger('mousedown');
+
+    expect(wrapper.emitted('focus')).toBeFalsy();
+  });
+
+  it('does not delete the tag if clicked from VO but NOT focused', () => {
+    button.trigger('mousedown', {
+      buttons: 0,
+    });
+    expect(wrapper.emitted('delete-tag')).toBeFalsy();
+
+    expect(document.activeElement).toBe(button.element);
+  });
+
+  it('deletes the tag if clicked from VO and is focused', () => {
+    wrapper.setProps({ isFocused: true });
+    button.trigger('mousedown', {
+      buttons: 0,
+    });
+    expect(wrapper.emitted('delete-tag')).toBeTruthy();
+
+    expect(document.activeElement).toBe(button.element);
+    expect(wrapper.emitted('prevent-blur')).toBeTruthy();
+  });
+
+  it('adds extra text `Add tag -` as a span inside button if `isRemovableTag: false`', () => {
+    wrapper.setProps({
+      isRemovableTag: false,
+    });
+    const span = wrapper.findAll('span.visuallyhidden');
+    expect(span.exists()).toBe(true);
+    expect(span.length).toBe(1);
+    expect(span.at(0).text()).toEqual('Add tag -');
+  });
+
+  it('adds extra text `– Tag` as a span inside button if `isRemovableTag: true`', () => {
+    wrapper.setProps({
+      isRemovableTag: true,
+    });
+    const span = wrapper.findAll('span.visuallyhidden');
+    expect(span.length).toBe(1);
+    expect(span.at(0).text()).toEqual('– Tag. Select to remove from list.');
+  });
+
+  describe('copy/cut', () => {
+    const setData = jest.fn();
+    const clipboardData = {
+      setData,
+    };
+    const { Event } = window;
+
+    function triggerGlobalEvent(eventName, data = clipboardData) {
+      const clipboardEvent = new Event(eventName);
+      clipboardEvent.clipboardData = data;
+      document.dispatchEvent(clipboardEvent);
+      return clipboardEvent;
+    }
+
+    beforeEach(() => {
+      // TODO: remove hack for VueTestUtils to overwrite `clipboardData`, when we update version.
+      window.Event = null;
+    });
+    afterEach(() => {
+      window.Event = Event;
+    });
+    it('adds and removes event listeners on mounted and destroyed', () => {
+      const addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+      const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+      wrapper = shallowMount(Tag, { propsData });
+      // assert `copy` and `cut` are added
+      expect(addEventListenerSpy).toHaveBeenCalledTimes(3);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('copy', wrapper.vm.handleCopy);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('cut', wrapper.vm.handleCut);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('paste', wrapper.vm.handlePaste);
+      // assert `copy` and `cut` are removed
+      wrapper.destroy();
+      expect(removeEventListenerSpy).toHaveBeenCalledTimes(3);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('copy', wrapper.vm.handleCopy);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('cut', wrapper.vm.handleCut);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('paste', wrapper.vm.handlePaste);
+      addEventListenerSpy.mockRestore();
+      removeEventListenerSpy.mockRestore();
+    });
+
+    it('handles a global copy command, only when tag is focused', async () => {
+      expect(setData).not.toHaveBeenCalled();
+
+      wrapper.setProps({
+        isFocused: true,
+      });
+      triggerGlobalEvent('copy');
+      expect(setData).toHaveBeenCalledTimes(2);
+      expect(setData)
+        .toHaveBeenNthCalledWith(1, 'text/html', prepareDataForHTMLClipboard({ tags: [propsData.name] }));
+      expect(setData).toHaveBeenNthCalledWith(2, 'text/plain', propsData.name);
+      expect(wrapper.emitted('delete-tag')).toBeFalsy();
+    });
+
+    it('handles cutting a tag, only when tag is focused and removable', () => {
+      triggerGlobalEvent('cut');
+
+      expect(setData).not.toHaveBeenCalled();
+
+      wrapper.setProps({
+        isFocused: true,
+      });
+      triggerGlobalEvent('cut');
+
+      expect(setData).not.toHaveBeenCalled();
+
+      wrapper.setProps({
+        isFocused: true,
+        isRemovableTag: true,
+      });
+      triggerGlobalEvent('cut');
+
+      expect(setData).toHaveBeenCalledTimes(2);
+      expect(setData)
+        .toHaveBeenNthCalledWith(1, 'text/html', prepareDataForHTMLClipboard({ tags: [propsData.name] }));
+      expect(setData).toHaveBeenNthCalledWith(2, 'text/plain', propsData.name);
+      expect(wrapper.emitted('delete-tag')).toBeTruthy();
+    });
+
+    it('handles copying a tag directly on the button', () => {
+      wrapper.setProps({
+        isFocused: true,
+      });
+      wrapper.find({ ref: 'button' }).trigger('copy', { clipboardData });
+      expect(clipboardData.setData).toHaveBeenCalledTimes(2);
+      expect(clipboardData.setData)
+        .toHaveBeenCalledWith('text/html', prepareDataForHTMLClipboard({ tags: [propsData.name] }));
+      expect(clipboardData.setData).toHaveBeenCalledWith('text/plain', propsData.name);
+    });
+
+    it('on paste, does nothing if tag is not focused', () => {
+      triggerGlobalEvent('paste');
+
+      expect(wrapper.emitted('paste-content')).toBeFalsy();
+      expect(wrapper.emitted('delete-tag')).toBeFalsy();
+    });
+
+    it('on paste, does nothing if tag is focused but not removable', () => {
+      wrapper.setProps({
+        isFocused: true,
+      });
+
+      triggerGlobalEvent('paste');
+
+      expect(wrapper.emitted('paste-content')).toBeFalsy();
+      expect(wrapper.emitted('delete-tag')).toBeFalsy();
+    });
+
+    it('on paste, does nothing if tag is not focused, but removable', () => {
+      wrapper.setProps({
+        isRemovableTag: true,
+      });
+
+      triggerGlobalEvent('paste');
+
+      expect(wrapper.emitted('paste-content')).toBeFalsy();
+      expect(wrapper.emitted('delete-tag')).toBeFalsy();
+    });
+
+    it('on paste, deletes the current tag and emits up the event body, if focused and removable', () => {
+      wrapper.setProps({
+        isFocused: true,
+        isRemovableTag: true,
+      });
+
+      const event = triggerGlobalEvent('paste');
+
+      // assert the tag is being deleted and the `paste-content` event is emitted once
+      expect(wrapper.emitted('delete-tag')).toHaveLength(1);
+      expect(wrapper.emitted('paste-content')).toHaveLength(1);
+      // assert the event is being passed up.
+      expect(wrapper.emitted('paste-content')[0][0]).toEqual(event);
+    });
+  });
+});

--- a/tests/unit/components/Filter/Tag.spec.js
+++ b/tests/unit/components/Filter/Tag.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/tests/unit/components/Filter/TagList.spec.js
+++ b/tests/unit/components/Filter/TagList.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/tests/unit/components/Filter/TagList.spec.js
+++ b/tests/unit/components/Filter/TagList.spec.js
@@ -1,0 +1,214 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import { shallowMount } from '@vue/test-utils';
+import TagList from 'docc-render/components/Filter/TagList.vue';
+
+describe('TagList', () => {
+  let wrapper;
+  let tag1;
+  let tag2;
+
+  const {
+    Tag,
+  } = TagList.components;
+
+  const propsData = {
+    tags: ['Tag1', 'Tag2'],
+    activeTags: [],
+  };
+
+  beforeEach(() => {
+    wrapper = shallowMount(TagList, { propsData });
+    tag1 = wrapper.findAll(Tag).at(0);
+    tag2 = wrapper.findAll(Tag).at(1);
+  });
+
+  it('renders `Tag` components', () => {
+    const tags = wrapper.findAll(Tag);
+
+    expect(tags.length).toBe(2);
+  });
+
+  it('renders an `scrolling` class inside the tag list if `isScrolling` is true', () => {
+    const list = wrapper.find({ ref: 'tags' });
+
+    expect(list.classes('scrolling')).toBe(false);
+
+    wrapper.setData({ isScrolling: true });
+
+    expect(list.classes('scrolling')).toBe(true);
+  });
+
+  it('sets `focusedIndex` to `null` if user is not focusing on any tag', () => {
+    expect(wrapper.vm.focusedIndex).toBe(null);
+  });
+
+  it('re-emits `prevent-blur` when tag emitted `prevent-blur`', () => {
+    tag1.vm.$emit('prevent-blur');
+
+    expect(wrapper.emitted('prevent-blur')).toBeTruthy();
+  });
+
+  describe('when being focus on the first tag', () => {
+    beforeEach(() => {
+      tag1.vm.$emit('focus');
+    });
+
+    it('sets `focusedIndex` to the index value of the focused tag', () => {
+      expect(wrapper.vm.focusedIndex).toBe(0);
+    });
+
+    it('allows the user to navigate through arrow keys', () => {
+      tag1.trigger('keydown.right');
+      expect(wrapper.vm.focusedIndex).toBe(1);
+
+      tag2.trigger('keydown.left');
+      expect(wrapper.vm.focusedIndex).toBe(0);
+
+      tag1.trigger('keydown.down');
+      expect(wrapper.vm.focusedIndex).toBe(1);
+
+      tag2.trigger('keydown.up');
+      expect(wrapper.vm.focusedIndex).toBe(0);
+    });
+
+    it('does not allow users to navigate through arrow keys if they are holding shift + cmd or shift + ctrl', () => {
+      tag1.trigger('keydown.shift.cmd.right');
+      expect(wrapper.vm.focusedIndex).toBe(0);
+
+      tag2.trigger('keydown.shift.cmd.left');
+      expect(wrapper.vm.focusedIndex).toBe(0);
+
+      tag1.trigger('keydown.shift.cmd.down');
+      expect(wrapper.vm.focusedIndex).toBe(0);
+
+      tag2.trigger('keydown.shift.cmd.up');
+      expect(wrapper.vm.focusedIndex).toBe(0);
+
+      tag1.trigger('keydown.shift.ctrl.right');
+      expect(wrapper.vm.focusedIndex).toBe(0);
+
+      tag2.trigger('keydown.shift.ctrl.left');
+      expect(wrapper.vm.focusedIndex).toBe(0);
+
+      tag1.trigger('keydown.shift.ctrl.down');
+      expect(wrapper.vm.focusedIndex).toBe(0);
+
+      tag2.trigger('keydown.shift.ctrl.up');
+      expect(wrapper.vm.focusedIndex).toBe(0);
+    });
+
+    it('emits `focus-prev` when clicking on the up arrow', () => {
+      tag1.trigger('keydown.up');
+      expect(wrapper.vm.focusedIndex).toBe(0);
+      expect(wrapper.emitted('focus-prev')).toBeTruthy();
+    });
+  });
+
+  describe('when being focus on the last tag', () => {
+    beforeEach(() => {
+      tag2.vm.$emit('focus');
+    });
+
+    it('sets `focusedIndex` to the index value of the focus tag', () => {
+      expect(wrapper.vm.focusedIndex).toBe(1);
+    });
+
+    it('emits `focus-next` when clicking on the down arrow', () => {
+      tag2.trigger('keydown.down');
+      expect(wrapper.vm.focusedIndex).toBe(1);
+      expect(wrapper.emitted('focus-next')).toBeTruthy();
+    });
+
+    it('emits `focus-next` when clicking on the right arrow', () => {
+      tag2.trigger('keydown.right');
+      expect(wrapper.vm.focusedIndex).toBe(1);
+      expect(wrapper.emitted('focus-next')).toBeTruthy();
+    });
+  });
+
+  it('reset filters when pressing the delete button while being focus only on the list', () => {
+    const list = wrapper.find({ ref: 'tags' });
+    expect(list.exists()).toBe(true);
+
+    list.trigger('keydown.delete.self');
+    expect(wrapper.emitted('reset-filters')).toBeTruthy();
+  });
+
+  it('does not reset filters when hitting `Enter` while being focus only on the list', () => {
+    const list = wrapper.find({ ref: 'tags' });
+
+    list.trigger('keydown', {
+      key: 'Enter',
+    });
+
+    expect(wrapper.emitted('reset-filters')).not.toBeTruthy();
+  });
+
+  it('does not delete tag when hitting `Enter` while being focus only tag', () => {
+    const tag = wrapper.find({ ref: 'tag' });
+
+    tag.trigger('keydown', {
+      key: 'Enter',
+    });
+
+    expect(wrapper.emitted('delete-tag')).not.toBeTruthy();
+  });
+
+  it('deletes tag when hitting an alphanum key or space while being focus only tag', () => {
+    const tag = wrapper.find({ ref: 'tag' });
+    const alphanumKey = 'a';
+    const input = 'foo';
+    const space = ' ';
+    wrapper.setProps({ input });
+    wrapper.setData({ focusedIndex: 0 });
+    tag.trigger('keydown', { key: alphanumKey });
+
+    expect(wrapper.emitted('delete-tag')[0][0].tagName).toEqual(propsData.tags[0]);
+
+    tag.trigger('keydown', { key: space });
+
+    expect(wrapper.emitted('delete-tag')).toBeTruthy();
+  });
+
+  it('emits `select-all` when user has text on input and `command + a` is triggered on any tag', () => {
+    wrapper.setProps({ input: 'something' });
+
+    wrapper.find({ ref: 'tags' }).trigger('keydown', {
+      key: 'a',
+      metaKey: true,
+    });
+
+    expect(wrapper.emitted('select-all')).toBeTruthy();
+  });
+
+  it('emits up `paste-tags`, when a tag emits a `paste-content` event', () => {
+    const tag = wrapper.find({ ref: 'tag' });
+    const payload = { someData: 'someData' };
+    tag.vm.$emit('paste-content', payload);
+    // assert its emitted only once
+    expect(wrapper.emitted('paste-tags')).toHaveLength(1);
+    // assert it passes up the event payload up
+    expect(wrapper.emitted('paste-tags')[0][0]).toEqual(payload);
+  });
+
+  describe('Removable Tags', () => {
+    it('sets passed down `isRemovableTag` on tags', () => {
+      expect(wrapper.find(Tag).props()).toHaveProperty('isRemovableTag', false);
+      wrapper.setProps({ areTagsRemovable: true });
+      expect(wrapper.find(Tag).props()).toHaveProperty('isRemovableTag', true);
+    });
+
+    it('sets the tabindex on the `ul`', () => {
+      expect(wrapper.find('ul').attributes()).toHaveProperty('tabindex', '0');
+    });
+  });
+});

--- a/tests/unit/components/Filter/TagList.spec.js
+++ b/tests/unit/components/Filter/TagList.spec.js
@@ -38,7 +38,7 @@ describe('TagList', () => {
   });
 
   it('renders an `scrolling` class inside the tag list if `isScrolling` is true', () => {
-    const list = wrapper.find({ ref: 'tags' });
+    const list = wrapper.find({ ref: 'scroll-wrapper' });
 
     expect(list.classes('scrolling')).toBe(false);
 

--- a/tests/unit/mixins/handleScrollbar.spec.js
+++ b/tests/unit/mixins/handleScrollbar.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/tests/unit/mixins/handleScrollbar.spec.js
+++ b/tests/unit/mixins/handleScrollbar.spec.js
@@ -1,0 +1,122 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import { shallowMount } from '@vue/test-utils';
+import handleScrollbar from 'docc-render/mixins/handleScrollbar';
+
+const { ScrollingDebounceDelay } = handleScrollbar.constants;
+
+const scrollBarAppearsEvent = {
+  target: {
+    offsetWidth: 605,
+    scrollWidth: 900,
+    offsetHeight: 150,
+    scrollTop: 0,
+    style: {
+      setProperty: jest.fn(),
+    },
+  },
+  preventDefault: jest.fn(),
+};
+
+const scrollBarDoesNotAppearEvent = {
+  ...scrollBarAppearsEvent,
+  target: {
+    ...scrollBarAppearsEvent.target,
+    offsetWidth: 605,
+    scrollWidth: 625,
+  },
+};
+
+describe('handleScrollbar', () => {
+  let wrapper;
+  jest.useFakeTimers();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    wrapper = shallowMount({
+      name: 'MyComponent',
+      mixins: [handleScrollbar],
+      render() {
+        return null;
+      },
+    });
+  });
+
+  it('shows the scrollbar', () => {
+    wrapper.vm.handleScroll(scrollBarAppearsEvent);
+    expect(wrapper.vm.isScrolling).toEqual(true);
+  });
+
+  it('sets the current height as a custom css property', () => {
+    wrapper.vm.handleScroll(scrollBarAppearsEvent);
+    expect(scrollBarAppearsEvent.target.style.setProperty)
+      .toHaveBeenCalledWith('--scroll-target-height', '150px');
+  });
+
+  it('hides the scrollbar after the scrolling debounce delay time has passed', () => {
+    wrapper.vm.handleScroll(scrollBarAppearsEvent);
+    // Wait longer than 1000 miliseconds
+    jest.advanceTimersByTime(ScrollingDebounceDelay + 10);
+    expect(wrapper.vm.isScrolling).toEqual(false);
+  });
+
+  it('does not hide the scrollbar if the scrolling debounce delay time has not passed yet', () => {
+    wrapper.vm.handleScroll(scrollBarAppearsEvent);
+    wrapper.vm.handleScroll(scrollBarAppearsEvent);
+    // Wait only 10 miliseconds
+    jest.advanceTimersByTime(10);
+    expect(wrapper.vm.isScrolling).toEqual(true);
+  });
+
+  it('does not hide the scrollbar, before enough time has passed', () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    wrapper.vm.handleScroll(scrollBarAppearsEvent);
+    expect(wrapper.vm.isScrolling).toEqual(true);
+    // Wait longer than 1000 miliseconds
+    jest.advanceTimersByTime(ScrollingDebounceDelay);
+    // make sure we are not scrolling any more
+    expect(wrapper.vm.isScrolling).toEqual(false);
+    // scroll
+    wrapper.vm.handleScroll(scrollBarAppearsEvent);
+    // make sure scrolling does not begin again, as not enough time has passed
+    expect(wrapper.vm.isScrolling).toEqual(false);
+    // force 110 seconds to pass
+    nowSpy.mockReturnValueOnce(Date.now() + 110);
+    jest.advanceTimersByTime(110);
+    // scroll again
+    wrapper.vm.handleScroll(scrollBarAppearsEvent);
+    // assert the time is correct
+    expect(wrapper.vm.isScrolling).toEqual(true);
+    nowSpy.mockRestore();
+  });
+
+  it('prevent `isScrolling` from being true when scroll bars does not appear', () => {
+    wrapper.vm.handleScroll(scrollBarDoesNotAppearEvent);
+    expect(wrapper.vm.isScrolling).toEqual(false);
+
+    wrapper.vm.handleScroll(scrollBarAppearsEvent);
+    expect(wrapper.vm.isScrolling).toEqual(true);
+  });
+
+  it('does not allow events that change the scrollTop property', () => {
+    const event = {
+      ...scrollBarAppearsEvent,
+      target: {
+        ...scrollBarAppearsEvent.target,
+        scrollTop: 150,
+      },
+    };
+    wrapper.vm.handleScroll(event);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.target.scrollTop).toEqual(0);
+    expect(wrapper.vm.isScrolling).toBe(false);
+  });
+});

--- a/tests/unit/mixins/handleScrollbar.spec.js
+++ b/tests/unit/mixins/handleScrollbar.spec.js
@@ -21,6 +21,7 @@ const scrollBarAppearsEvent = {
     scrollTop: 0,
     style: {
       setProperty: jest.fn(),
+      getPropertyValue: jest.fn().mockReturnValue(''),
     },
   },
   preventDefault: jest.fn(),
@@ -59,6 +60,15 @@ describe('handleScrollbar', () => {
     wrapper.vm.handleScroll(scrollBarAppearsEvent);
     expect(scrollBarAppearsEvent.target.style.setProperty)
       .toHaveBeenCalledWith('--scroll-target-height', '150px');
+  });
+
+  it('does not set the height a second time', () => {
+    wrapper.vm.handleScroll(scrollBarAppearsEvent);
+    expect(scrollBarAppearsEvent.target.style.setProperty)
+      .toHaveBeenCalledWith('--scroll-target-height', '150px');
+    scrollBarAppearsEvent.target.style.getPropertyValue.mockReturnValueOnce(150);
+    wrapper.vm.handleScroll(scrollBarAppearsEvent);
+    expect(scrollBarAppearsEvent.target.style.setProperty).toHaveBeenCalledTimes(1);
   });
 
   it('hides the scrollbar after the scrolling debounce delay time has passed', () => {

--- a/tests/unit/utils/clipboard.spec.js
+++ b/tests/unit/utils/clipboard.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/tests/unit/utils/clipboard.spec.js
+++ b/tests/unit/utils/clipboard.spec.js
@@ -1,0 +1,60 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import { parseDataFromClipboard, prepareDataForHTMLClipboard } from 'docc-render/utils/clipboard';
+
+const payload = { foo: 'foo' };
+const xmlPayload = `<data id="copy-data">${JSON.stringify(payload)}</data>`;
+
+describe('clipboard', () => {
+  describe('parseDataFromClipboard', () => {
+    it('parses data from an html clipboard', () => {
+      expect(parseDataFromClipboard(xmlPayload)).toEqual(payload);
+    });
+
+    it('returns null, if the data is not properly formatted', () => {
+      expect(parseDataFromClipboard('<div id="copy-data">{ "foo": "bar" }</div>')).toEqual(null);
+      expect(parseDataFromClipboard('<data id="copy-data">{ "foo": "bar" }')).toEqual(null);
+      expect(parseDataFromClipboard('<data>{ "foo": "bar" }</data>')).toEqual(null);
+    });
+
+    it('returns proper JSON if content has special tags in it', () => {
+      expect(parseDataFromClipboard('<data id="copy-data">{ "foo": "</data>"  }</data>')).toEqual({ foo: '</data>' });
+    });
+
+    it('returns proper JSON if wrapper has extra attributes', () => {
+      expect(parseDataFromClipboard(`<data id="copy-data" style="color: pink">${JSON.stringify(payload)}</data>`)).toEqual(payload);
+    });
+
+    it('retrieves data from deeply nested xml data', () => {
+      // Different browsers wrap the data differently, so we need to make sure it works deeply
+      expect(parseDataFromClipboard(`<html><body>${xmlPayload}</body></html>`)).toEqual(payload);
+    });
+
+    it('does not error out, if the data is not properly formatted', () => {
+      expect(parseDataFromClipboard('<data id="copy-data">not JSON</data>')).toBe(null);
+      expect(parseDataFromClipboard('<data id="copy-data">{ "foo": bar  }</data>')).toEqual(null);
+    });
+  });
+
+  describe('prepareDataForHTMLClipboard', () => {
+    it('accepts string data', () => {
+      expect(prepareDataForHTMLClipboard(JSON.stringify(payload))).toEqual(xmlPayload);
+    });
+
+    it('accepts none string data', () => {
+      expect(prepareDataForHTMLClipboard(payload)).toEqual(xmlPayload);
+    });
+
+    it('does not sanitize data', () => {
+      expect(prepareDataForHTMLClipboard('foo')).toEqual('<data id="copy-data">foo</data>');
+    });
+  });
+});

--- a/tests/unit/utils/input-helper.spec.js
+++ b/tests/unit/utils/input-helper.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/tests/unit/utils/input-helper.spec.js
+++ b/tests/unit/utils/input-helper.spec.js
@@ -1,0 +1,47 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import {
+  isSingleCharacter,
+} from 'docc-render/utils/input-helper';
+
+describe('isSingleCharacter', () => {
+  it('detects single characters', () => {
+    const singleCharacters = {
+      alphanumKey: 'a',
+      capitalAlphanumKey: 'A',
+      space: ' ',
+      number: '8',
+      arrow: '>',
+      exclamationMarks: '!',
+      parenthesis: '(',
+      punctuationMarks: '.',
+      quotationMarks: "'",
+    };
+
+    const nonSingleCharacters = {
+      arrowKey: 'ArrowRight',
+      tab: 'Tab',
+      alt: 'Alt',
+      shift: 'Shift',
+      meta: 'Meta',
+    };
+
+    Object.keys(singleCharacters).forEach((key) => {
+      const test = singleCharacters[key];
+      expect(isSingleCharacter(test)).toBe(true);
+    });
+
+    Object.keys(nonSingleCharacters).forEach((key) => {
+      const test = nonSingleCharacters[key];
+      expect(isSingleCharacter(test)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Bug/issue #88010647 if applicable: 

## Summary

Adding a filter input component with tag selection.

Some of the features it has are:
- Multiple tag selection implementing macOS keyboard shortcuts 
- Great AX
- Reversed Tags UI
- Tags truncation

## Dependencies

NA

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
