### PR TITLE
Present "Image failed to load" message in fallback image title tooltip

### DIFF
--- a/src/components/ImageAsset.vue
+++ b/src/components/ImageAsset.vue
@@ -12,7 +12,7 @@
   <img
     v-if="fallbackImageSrcSet"
     class="fallback"
-    title="Image failed to load."
+    title="Image failed to load"
     :alt="alt"
     :srcset="fallbackImageSrcSet"
   />

--- a/src/components/ImageAsset.vue
+++ b/src/components/ImageAsset.vue
@@ -12,7 +12,8 @@
   <img
     v-if="fallbackImageSrcSet"
     class="fallback"
-    :alt="`${alt} Image failed to load.`"
+    title="Image failed to load."
+    :alt="alt"
     :srcset="fallbackImageSrcSet"
   />
   <picture v-else>

--- a/tests/unit/components/ImageAsset.spec.js
+++ b/tests/unit/components/ImageAsset.spec.js
@@ -268,6 +268,6 @@ describe('ImageAsset', () => {
     expect(fallbackImg.exists()).toBe(true);
     expect(fallbackImg.classes('fallback')).toBe(true);
     expect(fallbackImg.attributes('alt')).toBe(alt);
-    expect(fallbackImg.attributes('title')).toBe('Image failed to load.');
+    expect(fallbackImg.attributes('title')).toBe('Image failed to load');
   });
 });

--- a/tests/unit/components/ImageAsset.spec.js
+++ b/tests/unit/components/ImageAsset.spec.js
@@ -267,6 +267,7 @@ describe('ImageAsset', () => {
     const fallbackImg = wrapper.find('img');
     expect(fallbackImg.exists()).toBe(true);
     expect(fallbackImg.classes('fallback')).toBe(true);
-    expect(fallbackImg.attributes('alt')).toBe(`${alt} Image failed to load.`);
+    expect(fallbackImg.attributes('alt')).toBe(alt);
+    expect(fallbackImg.attributes('title')).toBe('Image failed to load.');
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 83366845

## Summary

This updates the fallback image `alt` and `title` attributes so that the `alt` retains the unmodified alt text while the `title` now has a failure message indicating that the original image failed to load when the fallback image is hovered.

Example:
<img width="378" alt="Screen Shot 2022-02-11 at 10 08 08 AM" src="https://user-images.githubusercontent.com/212918/153646670-efe10dd7-33cd-49a5-8ba8-6776512c80ed.png">

## Testing

Refer to the ["improved testing instructions"](https://github.com/apple/swift-docc-render/pull/42#issuecomment-1021516452) from a previous PR. Now, the fallback image should have a tooltip on hover like the example image.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
