### PR TITLE
Sidenav not being displayed in the root page because of a type error

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -90,13 +90,15 @@ export default {
       return parentTopicIdentifiers.map(identifier => references[identifier]);
     },
     // splits out the top-level technology crumb
-    activePath({ parentTopicReferences, $route }) {
+    activePath({ parentTopicReferences, $route: { path } }) {
+      // route's path is activePath on root
+      if (!parentTopicReferences.length) return [path];
       let itemsToSlice = 1;
       // if the first item is a `technology`, slice off it and the technology itself
       if (parentTopicReferences[0].kind === 'technologies') {
         itemsToSlice = 2;
       }
-      return parentTopicReferences.slice(itemsToSlice).map(r => r.url).concat($route.path);
+      return parentTopicReferences.slice(itemsToSlice).map(r => r.url).concat(path);
     },
     /**
      * Recomputes the list of flat children.

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -161,6 +161,15 @@ describe('Navigator', () => {
     ]);
   });
 
+  it('renders the root path as activePath when there is no parentTopicIdentifiers', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        parentTopicIdentifiers: [],
+      },
+    });
+    expect(wrapper.find(NavigatorCard).props('activePath')).toEqual([mocks.$route.path]);
+  });
+
   it('re-emits the `@close` event', () => {
     const wrapper = createWrapper();
     wrapper.find(NavigatorCard).vm.$emit('close');


### PR DESCRIPTION
Bug/issue #89245661, if applicable: 

## Summary

Sidenav not being displayed in the root page because of a type error
Regression introduced on https://github.com/apple/swift-docc-render/pull/51/commits/ba42e3940a8aeb08585e3eccdd57b3c387d2b624

## Dependencies

NA

## Testing

Example fixture folder:
[SlothCreator.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8111573/SlothCreator.doccarchive.zip)

Steps:
1. Use any data or docc documentation, example attached above
2. Run VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures/ npm run serve
3. Go to any page, like http://localhost:8080/documentation/slothcreator/ if using example data
4. Open the theme-setting.json file and enable the "navigator" feature
4. Assert that you can see the sidenav properly

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
