### PR TITLE
Prevents code listings inside questions to have border radius

### DIFF
--- a/src/components/Tutorial/Assessments/Quiz.vue
+++ b/src/components/Tutorial/Assessments/Quiz.vue
@@ -270,6 +270,7 @@ input[type="radio"] {
 
 /deep/ .question  > .code-listing {
   padding: unset;
+  border-radius: 0;
 }
 
 /deep/ pre {


### PR DESCRIPTION
Bug/issue #87742486, if applicable: 

## Summary

Prevents code listings inside questions to have border radius

<img width="909" alt="Screenshot 2022-02-23 at 16 20 16" src="https://user-images.githubusercontent.com/8567677/155349747-97815ac9-c15e-494f-a2c2-aac64c3dff3f.png">

## Dependencies

NA

## Testing

Example fixture folder:
[manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/8125486/manual-fixtures.zip)

Steps:
1. Use example attached above
2. Run VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures/ npm run serve
3. Go to http://localhost:8080/tutorials/technologyx/tutorial and scroll to "Check Your Understanding"
4. Select first option with code listing
5. Click Submit
6. Assert that there is no border radius cutting the content

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
