### PR TITLE
Add deprecated badge when item is deprecated on sidenav

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -45,6 +45,7 @@ import { TopicTypes } from 'docc-render/constants/TopicTypes';
  * @property {number} index - index of item in siblings
  * @property {number} siblingsCount - number of siblings
  * @property {number[]} childUIDs - array of child UIDs
+ * @property {boolean} deprecated - symbol is deprecated or is not
  */
 
 /**

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -66,6 +66,7 @@
             :matcher="filterPattern"
           />
         </Reference>
+        <Badge v-if="isDeprecated" variant="deprecated" />
       </div>
     </div>
   </div>
@@ -76,6 +77,7 @@ import InlineChevronRightIcon from 'theme/components/Icons/InlineChevronRightIco
 import NavigatorLeafIcon from 'docc-render/components/Navigator/NavigatorLeafIcon.vue';
 import HighlightMatches from 'docc-render/components/Navigator/HighlightMatches.vue';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
+import Badge from 'docc-render/components/Badge.vue';
 import { TopicTypes } from 'docc-render/constants/TopicTypes';
 
 export default {
@@ -85,6 +87,7 @@ export default {
     NavigatorLeafIcon,
     InlineChevronRightIcon,
     Reference,
+    Badge,
   },
   props: {
     isRendered: {
@@ -125,6 +128,7 @@ export default {
       if (!isParent) return baseLabel;
       return `${baseLabel} ${parentLabel}`;
     },
+    isDeprecated: ({ item: { deprecated } }) => !!deprecated,
   },
   methods: {
     toggleTree() {
@@ -233,7 +237,7 @@ $item-height: 32px;
 .title-container {
   min-width: 0;
   display: flex;
-  flex-flow: column;
+  align-items: center;
 }
 
 .chevron {

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -14,6 +14,10 @@ import { TopicTypes } from '@/constants/TopicTypes';
 import NavigatorLeafIcon from '@/components/Navigator/NavigatorLeafIcon.vue';
 import HighlightMatches from '@/components/Navigator/HighlightMatches.vue';
 
+const {
+  Badge,
+} = NavigatorCardItem.components;
+
 const defaultProps = {
   item: {
     depth: 2,
@@ -25,6 +29,7 @@ const defaultProps = {
     uid: 1,
     siblingsCount: 5,
     parent: 'Foo',
+    deprecated: false,
   },
   expanded: false,
   filterPattern: /foo/gi,
@@ -56,6 +61,21 @@ describe('NavigatorCardItem', () => {
       matcher: defaultProps.filterPattern,
     });
     expect(wrapper.find('.navigator-card-item').attributes('id')).toBe(`container-${defaultProps.item.uid}`);
+  });
+
+  it('renders a deprecated badge when item is deprecated', () => {
+    let wrapper;
+    wrapper = createWrapper();
+    expect(wrapper.contains(Badge)).toBe(false);
+    wrapper = createWrapper({
+      propsData: {
+        item: {
+          ...defaultProps.item,
+          deprecated: true,
+        },
+      },
+    });
+    expect(wrapper.find(Badge).attributes('variant')).toBe('deprecated');
   });
 
   it('does not render the expand button, if has no children', () => {


### PR DESCRIPTION
Bug/issue #64277424, if applicable: 

## Summary

Add deprecated badge when item is deprecated on Sidenav

<img width="313" alt="Screenshot 2022-02-23 at 20 14 28" src="https://user-images.githubusercontent.com/8567677/155391751-69c4fcaf-1634-4f7d-b37a-e23de0cd8e6a.png">

## Dependencies

NA

## Testing

Example fixture folder:
[SlothCreator-with-deprecated.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8127169/SlothCreator-with-deprecated.doccarchive.zip)

Steps:
1. Use the provided fixture folder
2. Run VUE_APP_DEV_SERVER_PROXY=/path/to/SlothCreator-with-deprecated.doccarchive/ npm run serve
3. Go to http://localhost:8080/documentation/slothcreator/
4. Open the theme-setting.json file and enable the "navigator" feature
5. Assert that you can see the deprecated badge on the "SlothGenerator" symbol

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary

