### PR TITLE
Fix sidebar resizing, when zoomed in on touch device

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -220,7 +220,8 @@ export default {
       if (!this.isDragging) return;
       const { sidebar } = this.$refs;
       const clientX = this.isTouch ? e.touches[0].clientX : e.clientX;
-      let newWidth = (clientX - sidebar.offsetLeft);
+      // make sure we add the window horizontal scroll to the touch position, fixes zoomed in iOS
+      let newWidth = ((clientX + window.scrollX) - sidebar.offsetLeft);
       // prevent going outside of the window zone
       if (newWidth > this.maxWidth) {
         newWidth = this.maxWidth;

--- a/tests/unit/components/AdjustableSidebarWidth.spec.js
+++ b/tests/unit/components/AdjustableSidebarWidth.spec.js
@@ -382,4 +382,28 @@ describe('AdjustableSidebarWidth', () => {
     expect(FocusTrap.mock.results[0].value.stop).toHaveBeenCalledTimes(1);
     expect(changeElementVOVisibility.show).toHaveBeenCalledTimes(1);
   });
+
+  it('accounts for zoomed in devices', () => {
+    window.scrollX = 55;
+    const wrapper = createWrapper();
+    const aside = wrapper.find('.aside');
+    // assert dragging
+    wrapper.find('.resize-handle').trigger('touchstart', { type: 'touchstart' });
+    document.dispatchEvent(createEvent(eventsMap.touch.move, {
+      touches: [{
+        clientX: 300,
+      }],
+    }));
+    // assert class
+    expect(aside.classes()).toContain('dragging');
+    // offset is 100, so we remove it from the clientX, but we add the scrollX.
+    assertWidth(wrapper, 255);
+    // assert maxWidth
+    document.dispatchEvent(createEvent(eventsMap.touch.move, {
+      touches: [{
+        clientX: window.innerWidth + 150,
+      }],
+    }));
+    assertWidth(wrapper, maxWidth);
+  });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 89070026

## Summary

Fixes a small bug when trying to resize the sidebar on a zoomed in device

## Dependencies

NA

## Testing

Use a doccarchive with a sidebar index in it. - 
[SlothCreator.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8154866/SlothCreator.doccarchive.zip)


Steps:
1. Change the theme-settings.json to enable the sidenav
2. Go to `documentation/slothcreator`
3. Zoom in on your mobile device, iPad or using the Simulator
4. Start resizing the sidebar
5. Assert it works properly.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
