### PR TITLE
Fix the right nav-actions spacing, so it does not add extra space on desktop

### DIFF
--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -613,11 +613,11 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   display: flex;
   align-items: center;
   max-height: $nav-height-small;
-  padding-right: $nav-padding-small;
 
   @include nav-in-breakpoint {
     grid-area: actions;
     justify-content: flex-end;
+    padding-right: $nav-padding-small;
   }
 }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 88172979

## Summary


This is a fix to remove an extra spacing on desktop, introduced in - https://github.com/apple/swift-docc-render/pull/31.

## Dependencies

na

## Testing

Currently there is no visual difference. This is only to fix visuals for eventual third party clients.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
