### PR TITLE
Update `DocumentationTopic.technology` to handle edge case

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -198,7 +198,9 @@ export default {
       paths.slice(-1)[0]
     ),
     technology: ({
-      topicProps: { identifier, references, role },
+      topicProps: {
+        identifier, references, role, title,
+      },
       swiftPath,
       parentTopicIdentifiers,
     }) => {
@@ -210,7 +212,7 @@ export default {
       // itself, manufacture a minimal one using other available data
       if (role === TopicRole.collection && !references[identifier]) {
         const url = swiftPath.startsWith('/') ? swiftPath : `/${swiftPath}`;
-        return { url };
+        return { title, url };
       }
 
       return references[parentTopicIdentifiers[1]] || references[identifier];

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -66,6 +66,7 @@
 <script>
 import { apply } from 'docc-render/utils/json-patch';
 import { getSetting } from 'docc-render/utils/theme-settings';
+import { TopicRole } from 'docc-render/constants/roles';
 import {
   clone,
   fetchDataForRouteEnter,
@@ -196,10 +197,22 @@ export default {
     navigatorParentTopicIdentifiers: ({ topicProps: { hierarchy: { paths = [] } } }) => (
       paths.slice(-1)[0]
     ),
-    technology: ({ topicProps: { references, identifier }, parentTopicIdentifiers }) => {
+    technology: ({
+      topicProps: { identifier, references, role },
+      swiftPath,
+      parentTopicIdentifiers,
+    }) => {
       if (!parentTopicIdentifiers.length) return references[identifier];
       const first = references[parentTopicIdentifiers[0]];
       if (first.kind !== 'technologies') return first;
+
+      // if there is a top level collection that does not have a reference to
+      // itself, manufacture a minimal one using other available data
+      if (role === TopicRole.collection && !references[identifier]) {
+        const url = swiftPath.startsWith('/') ? swiftPath : `/${swiftPath}`;
+        return { url };
+      }
+
       return references[parentTopicIdentifiers[1]] || references[identifier];
     },
     // Use `variants` data to build a map of paths associated with each unique

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -210,7 +210,10 @@ describe('DocumentationTopic', () => {
 
     const navigator = wrapper.find(Navigator);
     expect(navigator.exists()).toBe(true);
-    expect(navigator.props('technology')).toEqual({ url: '/documentation/swift' });
+    expect(navigator.props('technology')).toEqual({
+      title: 'FooKit',
+      url: '/documentation/swift',
+    });
   });
 
   it('renders without a sidebar', () => {

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -180,6 +180,39 @@ describe('DocumentationTopic', () => {
     getSetting.mockReset();
   });
 
+  it('renders the Navigator with data when no reference is found for a top-level collection', () => {
+    getSetting.mockImplementation(getSettingWithNavigatorEnabled);
+
+    const technologies = {
+      id: 'topic://technologies',
+      title: 'Technologies',
+      url: '/technologies',
+      kind: 'technologies',
+    };
+    wrapper.setData({
+      topicData: {
+        ...topicData,
+        metadata: {
+          ...topicData.metadata,
+          role: 'collection',
+        },
+        references: {
+          ...topicData.references,
+          [technologies.id]: technologies,
+        },
+        hierarchy: {
+          paths: [
+            [technologies.id, ...topicData.hierarchy.paths[0]],
+          ],
+        },
+      },
+    });
+
+    const navigator = wrapper.find(Navigator);
+    expect(navigator.exists()).toBe(true);
+    expect(navigator.props('technology')).toEqual({ url: '/documentation/swift' });
+  });
+
   it('renders without a sidebar', () => {
     getSetting.mockImplementation(defaultGetSetting);
 


### PR DESCRIPTION
Bug/issue #, if applicable: 89580510

## Summary

There may be a situation for a top level collection page where it does not have a reference to itself in the `references` map, so the minimal data for its URL needs to be created based on already existing page data.

## Testing

Follow the testing instructions from https://github.com/apple/swift-docc-render/pull/51 and ensure that there are no regressions in the base sidebar functionality.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
