### PR TITLE
Update `DocumentationTopic.technology` to retrieve current route path in improved way

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -198,10 +198,10 @@ export default {
       paths.slice(-1)[0]
     ),
     technology: ({
+      $route,
       topicProps: {
         identifier, references, role, title,
       },
-      swiftPath,
       parentTopicIdentifiers,
     }) => {
       if (!parentTopicIdentifiers.length) return references[identifier];
@@ -211,8 +211,7 @@ export default {
       // if there is a top level collection that does not have a reference to
       // itself, manufacture a minimal one using other available data
       if (role === TopicRole.collection && !references[identifier]) {
-        const url = swiftPath.startsWith('/') ? swiftPath : `/${swiftPath}`;
-        return { title, url };
+        return { title, url: $route.path };
       }
 
       return references[parentTopicIdentifiers[1]] || references[identifier];

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -52,7 +52,9 @@ const mocks = {
     off: jest.fn(),
     send: jest.fn(),
   },
-  $route: {},
+  $route: {
+    path: '/documentation/somepath',
+  },
 };
 
 const topicData = {
@@ -211,8 +213,8 @@ describe('DocumentationTopic', () => {
     const navigator = wrapper.find(Navigator);
     expect(navigator.exists()).toBe(true);
     expect(navigator.props('technology')).toEqual({
-      title: 'FooKit',
-      url: '/documentation/swift',
+      title: topicData.metadata.title,
+      url: mocks.$route.path,
     });
   });
 
@@ -482,10 +484,11 @@ describe('DocumentationTopic', () => {
     });
     expect(wrapper.vm.topicData.identifier.interfaceLanguage).toBe(oldInterfaceLang);
 
+    const from = mocks.$route;
     const to = {
+      ...from,
       query: { language: 'objc' },
     };
-    const from = mocks.$route;
     const next = jest.fn();
     // there is probably a more realistic way to simulate this
     DocumentationTopic.beforeRouteUpdate.call(wrapper.vm, to, from, next);


### PR DESCRIPTION
Bug/issue #, if applicable: 89580510

## Summary

This fixes a bug introduced in #60 where the logic to retrieve the URL path of the current page would only work for Swift frameworks. This change will allow it to work for any top level collection page.

## Testing

Follow the testing instructions for #51 and ensure that there are no regressions in the base sidebar functionality.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
