### PR TITLE
Make sure borders on the navigator show only when needed and clean up animation.

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -20,6 +20,8 @@
         :style="{ width: widthInPx }"
         class="aside"
         ref="aside"
+        @transitionstart="isTransitioning = true"
+        @transitionend="isTransitioning = false"
       >
         <slot
           name="aside"
@@ -120,6 +122,7 @@ export default {
       windowWidth,
       breakpoint,
       noTransition: false,
+      isTransitioning: false,
       focusTrapInstance: null,
     };
   },
@@ -133,8 +136,13 @@ export default {
     widthInPx: ({ width }) => `${width}px`,
     isMaxWidth: ({ width, maxWidth }) => width === maxWidth,
     events: ({ isTouch }) => (isTouch ? eventsMap.touch : eventsMap.mouse),
-    asideClasses: ({ isDragging, openExternally, noTransition }) => ({
-      dragging: isDragging, 'force-open': openExternally, 'no-transition': noTransition,
+    asideClasses: ({
+      isDragging, openExternally, noTransition, isTransitioning,
+    }) => ({
+      dragging: isDragging,
+      'force-open': openExternally,
+      'no-transition': noTransition,
+      animating: isTransitioning,
     }),
     scrollLockID: () => SCROLL_LOCK_ID,
     BreakpointScopes: () => BreakpointScopes,
@@ -299,7 +307,7 @@ export default {
   }
 
   @include breakpoint(medium, nav) {
-    width: 0 !important;
+    width: 100% !important;
     overflow: hidden;
     min-width: 0;
     max-width: 100%;
@@ -309,14 +317,13 @@ export default {
     bottom: 0;
     z-index: 9999;
     transform: translateX(-100%);
-    transition: width 0.15s linear, transform 0.15s ease-in;
+    transition: transform 0.15s ease-in;
 
     /deep/ .aside-animated-child {
       opacity: 0;
     }
 
     &.force-open {
-      width: 100% !important;
       transform: translateX(0);
 
       /deep/ .aside-animated-child {

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -351,8 +351,9 @@ export default {
   height: 100%;
 
   @include with-adjustable-sidebar {
-    border-left: 1px solid var(--color-grid);
-    border-right: 1px solid var(--color-grid);
+    @include breakpoints-from(xlarge) {
+      border-right: 1px solid var(--color-grid);
+    }
   }
 
   @include inTargetIde {

--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -202,12 +202,14 @@ export default {
   height: calc(100vh - #{$nav-height} - var(--sticky-top-offset));
   box-sizing: border-box;
   transition: height 0.3s linear;
-  border-left: 1px solid var(--color-grid);
+
+  @include breakpoints-from(xlarge) {
+    border-left: 1px solid var(--color-grid);
+  }
 
   @include breakpoint(medium, nav) {
     position: static;
     height: 100%;
-    border-left: none;
     transition: none;
   }
 }

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -337,8 +337,15 @@ export default {
 .doc-topic-aside {
   height: 100%;
   box-sizing: border-box;
+  border-right: 1px solid var(--color-grid);
+
   @include breakpoint(medium, nav) {
     background: var(--color-fill);
+    border-right: none;
+
+    .animating & {
+      border-right: 1px solid var(--color-grid);
+    }
   }
 }
 

--- a/tests/unit/components/AdjustableSidebarWidth.spec.js
+++ b/tests/unit/components/AdjustableSidebarWidth.spec.js
@@ -382,4 +382,14 @@ describe('AdjustableSidebarWidth', () => {
     expect(FocusTrap.mock.results[0].value.stop).toHaveBeenCalledTimes(1);
     expect(changeElementVOVisibility.show).toHaveBeenCalledTimes(1);
   });
+
+  it('adds a transition detection', () => {
+    const wrapper = createWrapper();
+    const aside = wrapper.find('.aside');
+    expect(aside.classes()).not.toContain('animating');
+    aside.trigger('transitionstart');
+    expect(aside.classes()).toContain('animating');
+    aside.trigger('transitionend');
+    expect(aside.classes()).not.toContain('animating');
+  });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 89638066

## Summary

Cleans up all the borders on the navigator and the content around it, so they are shown only when needed.

It adds an extra border while expanding on mobile, that is later hidden.
Open transition on mobile is slightly improved as well.

## Dependencies

NA

## Testing

Steps:
1. Serve using a doccarchive with an index
2. Assert left/right borders are not visible below 1800px
3. Assert borders are applied beyond 1800px
4. Assert on mobile, no extra borders are applied
5. Assert the aside applies a border-right, only while being toggled open

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
