### PR TITLE
Remove duplicate languagePaths and fix issue with variants being undefined

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -221,9 +221,9 @@ export default {
       type: Array,
       required: false,
     },
-    variants: {
-      type: Array,
-      default: () => ([]),
+    languagePaths: {
+      type: Object,
+      default: () => ({}),
     },
     extendsTechnology: {
       type: String,
@@ -283,14 +283,6 @@ export default {
     hasOverview: ({ primaryContentSections = [] }) => primaryContentSections.filter(section => (
       section.kind === PrimaryContent.constants.SectionKind.content
     )).length > 0,
-    // Use `variants` data to build a map of paths associated with each unique
-    // `interfaceLanguage` trait.
-    languagePaths: ({ variants }) => variants.reduce((memo, variant) => (
-      variant.traits.reduce((_memo, trait) => (!trait.interfaceLanguage ? _memo : ({
-        ..._memo,
-        [trait.interfaceLanguage]: (_memo[trait.interfaceLanguage] || []).concat(variant.paths),
-      })), memo)
-    ), {}),
     onThisPageSections() {
       return this.topicState.onThisPageSections;
     },

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -57,6 +57,7 @@
           :swiftPath="swiftPath"
           :isSymbolDeprecated="isSymbolDeprecated"
           :isSymbolBeta="isSymbolBeta"
+          :languagePaths="languagePaths"
         />
       </component>
     </template>
@@ -158,7 +159,6 @@ export default {
         topicSections,
         seeAlsoSections,
         variantOverrides,
-        variants,
       } = this.topicData;
       return {
         abstract,
@@ -183,7 +183,6 @@ export default {
         topicSections,
         seeAlsoSections,
         variantOverrides,
-        variants,
         extendsTechnology,
         symbolKind,
         tags: tags.slice(0, 1), // make sure we only show the first tag
@@ -218,7 +217,7 @@ export default {
     },
     // Use `variants` data to build a map of paths associated with each unique
     // `interfaceLanguage` trait.
-    languagePaths: ({ topicProps: { variants } }) => variants.reduce((memo, variant) => (
+    languagePaths: ({ topicData: { variants = [] } }) => variants.reduce((memo, variant) => (
       variant.traits.reduce((_memo, trait) => (!trait.interfaceLanguage ? _memo : ({
         ..._memo,
         [trait.interfaceLanguage]: (_memo[trait.interfaceLanguage] || []).concat(variant.paths),

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -130,16 +130,10 @@ const propsData = {
   references: {},
   roleHeading: 'Thing',
   title: 'FooKit',
-  variants: [
-    {
-      traits: [{ interfaceLanguage: 'occ' }],
-      paths: ['documentation/objc'],
-    },
-    {
-      traits: [{ interfaceLanguage: 'swift' }],
-      paths: ['documentation/swift'],
-    },
-  ],
+  languagePaths: {
+    occ: ['documentation/objc'],
+    swift: ['documentation/swift'],
+  },
   tags: [
     {
       type: 'foo',
@@ -382,8 +376,8 @@ describe('DocumentationTopic', () => {
       expect(switcher.exists()).toBe(true);
       expect(switcher.props()).toEqual({
         interfaceLanguage: propsData.interfaceLanguage,
-        objcPath: propsData.variants[0].paths[0],
-        swiftPath: propsData.variants[1].paths[0],
+        objcPath: propsData.languagePaths.occ[0],
+        swiftPath: propsData.languagePaths.swift[0],
       });
     });
 
@@ -611,7 +605,7 @@ describe('DocumentationTopic', () => {
       });
       await wrapper.vm.$nextTick();
       expect($router.replace).toBeCalledWith({
-        path: `/${propsData.variants[0].paths[0]}`,
+        path: `/${propsData.languagePaths.occ[0]}`,
         query: { language: Language.objectiveC.key.url },
       });
     });

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -276,7 +276,24 @@ describe('DocumentationTopic', () => {
       isSymbolDeprecated: false,
       objcPath: topicData.variants[0].paths[0],
       swiftPath: topicData.variants[1].paths[0],
+      languagePaths: {
+        occ: ['documentation/objc'],
+        swift: ['documentation/swift'],
+      },
     });
+  });
+
+  it('provides an empty languagePaths, even if no variants', () => {
+    wrapper.setData({
+      topicData: {
+        ...topicData,
+        variants: undefined,
+      },
+    });
+
+    const topic = wrapper.find(Topic);
+    expect(topic.exists()).toBe(true);
+    expect(topic.props('languagePaths')).toEqual({});
   });
 
   it('computes isSymbolBeta', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 89691775

## Summary

This fixes potential issues when there are no language `variants` in the RenderJSON for a technology.

## Dependencies

NA

## Testing

[SlothCreator 2.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8172001/SlothCreator.2.doccarchive.zip)


Steps:
1. Use the attached archive
2. Go to http://localhost:8080/documentation/slothcreator
3. Make sure it does not error out anymore

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
