### PR TITLE
Fix the sidebar filter sticky animation

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <div class="navigator" :style="{ '--sticky-top-offset': topOffset }">
+  <div class="navigator">
     <NavigatorCard
       v-if="!isFetching"
       :technology="technology.title"
@@ -28,9 +28,7 @@
 
 <script>
 import NavigatorCard from 'docc-render/components/Navigator/NavigatorCard.vue';
-import throttle from 'docc-render/utils/throttle';
 import { INDEX_ROOT_KEY } from 'docc-render/constants/sidebar';
-import { baseNavStickyAnchorId } from 'docc-render/constants/nav';
 import { TopicTypes } from 'docc-render/constants/TopicTypes';
 
 /**
@@ -77,14 +75,6 @@ export default {
       type: String,
       default: '',
     },
-  },
-  data() {
-    return {
-      topOffset: '0px',
-    };
-  },
-  mounted() {
-    this.setupStickyFilterTrack();
   },
   computed: {
     // gets the paths for each parent in the breadcrumbs
@@ -166,29 +156,6 @@ export default {
         return items.concat(node);
       }, []);
     },
-    /**
-     * Moves the sticky filter as you scroll, so it does not get hidden,
-     * when you have extra components above the navigation.
-     */
-    setupStickyFilterTrack() {
-      // get the navigation sticky anchor
-      const anchor = document.getElementById(baseNavStickyAnchorId);
-      // Check if there are more components, above the navigation
-      if (anchor.offsetTop === 0) return;
-      const cb = throttle(() => {
-        // get the top position of the anchor, or 0 if its negative
-        const y = Math.max(anchor.getBoundingClientRect().y, 0);
-        this.topOffset = `${y}px`;
-      }, 150);
-      // start listening to scroll events
-      window.addEventListener('scroll', cb);
-      // fire the callback
-      cb();
-      // unbind on beforeDestroy
-      this.$once('hook:beforeDestroy', () => {
-        window.removeEventListener('scroll', cb);
-      });
-    },
   },
 };
 </script>
@@ -197,11 +164,10 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .navigator {
-  position: sticky;
-  top: $nav-height;
-  height: calc(100vh - #{$nav-height} - var(--sticky-top-offset));
-  box-sizing: border-box;
-  transition: height 0.3s linear;
+  height: 100%;
+  border-left: 1px solid var(--color-grid);
+  display: flex;
+  flex-flow: column;
 
   @include breakpoints-from(xlarge) {
     border-left: 1px solid var(--color-grid);
@@ -209,7 +175,7 @@ export default {
 
   @include breakpoint(medium, nav) {
     position: static;
-    height: 100%;
+    border-left: none;
     transition: none;
   }
 }

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -10,48 +10,52 @@
 
 <template>
   <div class="navigator-card">
-    <div class="head-wrapper">
-      <button class="close-card-mobile" @click="$emit('close')">
-        <SidenavIcon class="icon-inline close-icon" />
-      </button>
-      <Reference :url="technologyPath" class="navigator-head" :id="INDEX_ROOT_KEY">
-        <NavigatorLeafIcon :type="type" with-colors class="card-icon" />
-        <div class="card-link">
-          {{ technology }}
+    <div class="navigator-card-full-height">
+      <div class="navigator-card-inner">
+        <div class="head-wrapper">
+          <button class="close-card-mobile" @click="$emit('close')">
+            <SidenavIcon class="icon-inline close-icon" />
+          </button>
+          <Reference :url="technologyPath" class="navigator-head" :id="INDEX_ROOT_KEY">
+            <NavigatorLeafIcon :type="type" with-colors class="card-icon" />
+            <div class="card-link">
+              {{ technology }}
+            </div>
+          </Reference>
         </div>
-      </Reference>
-    </div>
-    <div class="card-body">
-      <RecycleScroller
-        v-show="nodesToRender.length"
-        :id="scrollLockID"
-        ref="scroller"
-        class="scroller"
-        aria-label="Sidebar Tree Navigator"
-        :items="nodesToRender"
-        :item-size="itemSize"
-        key-field="uid"
-        v-slot="{ item, active }"
-        @blur.capture.native="handleBlur"
-      >
-        <NavigatorCardItem
-          :item="item"
-          :isRendered="active"
-          :filter-pattern="filterPattern"
-          :is-active="item.uid === activeUID"
-          :is-bold="activePathMap[item.uid]"
-          :expanded="openNodes[item.uid]"
-          @toggle="toggle"
-          @toggle-full="toggleFullTree"
-        />
-      </RecycleScroller>
-      <div class="no-items-wrapper" v-if="!nodesToRender.length">
-        <template v-if="filterPattern">
-          No results matching your filter
-        </template>
-        <template v-else>
-          Technology has no children
-        </template>
+        <div class="card-body">
+          <RecycleScroller
+            v-show="nodesToRender.length"
+            :id="scrollLockID"
+            ref="scroller"
+            class="scroller"
+            aria-label="Sidebar Tree Navigator"
+            :items="nodesToRender"
+            :item-size="itemSize"
+            key-field="uid"
+            v-slot="{ item, active }"
+            @blur.capture.native="handleBlur"
+          >
+            <NavigatorCardItem
+              :item="item"
+              :isRendered="active"
+              :filter-pattern="filterPattern"
+              :is-active="item.uid === activeUID"
+              :is-bold="activePathMap[item.uid]"
+              :expanded="openNodes[item.uid]"
+              @toggle="toggle"
+              @toggle-full="toggleFullTree"
+            />
+          </RecycleScroller>
+          <div class="no-items-wrapper" v-if="!nodesToRender.length">
+            <template v-if="filterPattern">
+              No results matching your filter
+            </template>
+            <template v-else>
+              Technology has no children
+            </template>
+          </div>
+        </div>
       </div>
     </div>
     <div class="filter-wrapper">
@@ -198,7 +202,7 @@ export default {
     ),
     /**
      * Returns the current page uid
-     * @return string
+     * @return number
      */
     activeUID({ activePathChildren }) {
       return (activePathChildren[activePathChildren.length - 1] || {}).uid;
@@ -498,12 +502,29 @@ export default {
 
 $navigator-card-horizontal-spacing: 20px !default;
 $navigator-card-vertical-spacing: 8px !default;
+$filter-height: 64px;
 
 .navigator-card {
-  overflow: hidden auto;
-  height: 100%;
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+
+  .navigator-card-full-height {
+    height: 100%;
+  }
+
+  .navigator-card-inner {
+    position: sticky;
+    top: $nav-height;
+    height: calc(100vh - #{$nav-height} - #{$filter-height});
+    display: flex;
+    flex-flow: column;
+    @include breakpoint(medium, nav) {
+      position: static;
+      height: 100%;
+    }
+  }
 
   .head-wrapper {
     position: relative;
@@ -532,15 +553,6 @@ $navigator-card-vertical-spacing: 8px !default;
   .card-icon {
     width: 19px;
     height: 19px;
-  }
-
-  @include breakpoint(medium, nav) {
-    .filter-wrapper {
-      order: 2;
-    }
-    .card-body {
-      order: 3;
-    }
   }
 }
 
@@ -585,6 +597,7 @@ $navigator-card-vertical-spacing: 8px !default;
   @include breakpoint(medium, nav) {
     --card-horizontal-spacing: 20px;
     --card-vertical-spacing: 0px;
+    padding-top: $filter-height;
   }
 }
 
@@ -663,4 +676,20 @@ $navigator-card-vertical-spacing: 8px !default;
   padding: var(--card-vertical-spacing) 0;
   padding-right: var(--card-horizontal-spacing);
 }
+
+.filter-wrapper {
+  position: sticky;
+  bottom: 0;
+  background: var(--color-fill);
+  @include breakpoint(medium, nav) {
+    position: absolute;
+    top: $nav-height;
+    bottom: auto;
+    width: 100%;
+  }
+  @include breakpoint(small, nav) {
+    top: $nav-height-small;
+  }
+}
+
 </style>

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -12,10 +12,8 @@ import Navigator from '@/components/Navigator.vue';
 import { shallowMount } from '@vue/test-utils';
 import NavigatorCard from '@/components/Navigator/NavigatorCard.vue';
 import { baseNavStickyAnchorId } from 'docc-render/constants/nav';
-import throttle from '@/utils/throttle';
 import { TopicTypes } from '@/constants/TopicTypes';
 import { INDEX_ROOT_KEY } from '@/constants/sidebar';
-import { createEvent } from '../../../test-utils';
 
 jest.mock('@/utils/throttle', () => jest.fn(v => v));
 
@@ -175,30 +173,6 @@ describe('Navigator', () => {
     const wrapper = createWrapper();
     wrapper.find(NavigatorCard).vm.$emit('close');
     expect(wrapper.emitted('close')).toHaveLength(1);
-  });
-
-  it('does not add scroll listeners, if the anchor is at the top already', () => {
-    const wrapper = createWrapper();
-    expect(throttle).toHaveBeenCalledTimes(0);
-    expect(wrapper.vm.topOffset).toBe('0px');
-  });
-
-  it('adds a scroll listener and stores the `y` offset of the anchor, if offsetTop is above 0', () => {
-    Object.defineProperty(fauxAnchor, 'offsetTop', { value: 50, writable: true });
-    const getBoundingClientRect = jest.fn().mockReturnValue({ y: 33 });
-    Object.defineProperty(fauxAnchor, 'getBoundingClientRect', { value: getBoundingClientRect });
-    const wrapper = createWrapper();
-    expect(throttle).toHaveBeenCalledTimes(1);
-    expect(wrapper.vm.topOffset).toBe('33px');
-    // simulate a scroll and sticky element
-    getBoundingClientRect.mockReturnValueOnce({ y: 44 });
-    window.dispatchEvent(createEvent('scroll'));
-    expect(wrapper.vm.topOffset).toBe('44px');
-    // assert destroy removes event listener
-    wrapper.destroy();
-    window.dispatchEvent(createEvent('scroll'));
-    // not called again
-    expect(getBoundingClientRect).toHaveBeenCalledTimes(2);
   });
 
   it('generates a unique hash', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 89376072

## Summary

This fixes the sticky filter in the sidebar to not be choppy on Safari

## Dependencies

NA

## Testing

Steps:
1. Serve with a doccarchive with index
2. Scroll pages, open/close the items. Open on mobile. Everything should look OK without out of place components. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
