### PR TITLE
Add sidenav tag filtering

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -563,6 +563,7 @@ $input-height: rem(28px);
     z-index: 1;
     // Text indent is needed instead of padding so text inside <input> doesn't get cut off
     text-indent: rem(7px);
+    text-overflow: ellipsis;
 
     @include breakpoint(small) {
       text-indent: rem(3px);

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -711,12 +711,6 @@ $navigator-card-vertical-spacing: 8px !default;
     /deep/ .filter__input {
       @include font-styles(body);
     }
-
-    //border: 1px solid var(--color-grid);
-    //padding: 10px 25px 10px 40px;
-    //width: 100%;
-    //box-sizing: border-box;
-    //border-radius: $tiny-border-radius;
   }
 }
 

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -343,10 +343,9 @@ export default {
       // if the activePath items change, we navigated to another page
       const pageChange = activePathChildrenBefore !== activePathChildren;
 
-      const filteredNodes = nodes
-        .map(({ uid }) => [uid, true]);
       // create a map to track open items - `{ [UID]: true }`
-      const newOpenNodes = Object.fromEntries(filteredNodes);
+      const newOpenNodes = Object.fromEntries(nodes
+        .map(({ uid }) => [uid, true]));
       // if we navigate across pages, persist the previously open nodes
       this.openNodes = Object.assign(pageChange ? this.openNodes : {}, newOpenNodes);
       this.generateNodesToRender();

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -69,11 +69,7 @@
             position-reversed
             class="filter-component"
             @clear="clearFilters"
-          >
-            <template #icon>
-              <FilterIcon class="icon-inline filter-icon" />
-            </template>
-          </FilterInput>
+          />
         </div>
       </div>
     </div>
@@ -91,7 +87,6 @@ import { safeHighlightPattern } from 'docc-render/utils/search-utils';
 import NavigatorLeafIcon from 'docc-render/components/Navigator/NavigatorLeafIcon.vue';
 import NavigatorCardItem from 'docc-render/components/Navigator/NavigatorCardItem.vue';
 import SidenavIcon from 'theme/components/Icons/SidenavIcon.vue';
-import FilterIcon from 'theme/components/Icons/FilterIcon.vue';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
 import { TopicTypes } from 'docc-render/constants/TopicTypes';
 import FilterInput from 'docc-render/components/Filter/FilterInput.vue';
@@ -149,7 +144,6 @@ export default {
   },
   components: {
     FilterInput,
-    FilterIcon,
     SidenavIcon,
     NavigatorCardItem,
     NavigatorLeafIcon,
@@ -708,10 +702,6 @@ $filter-height: 64px;
     position: relative;
     flex: 1;
     min-width: 0;
-  }
-
-  .filter-icon {
-    width: 1em;
   }
 
   .filter-component {

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -185,7 +185,6 @@ export default {
       // debounced filter value, to reduce the computed property computations. Used in filter logic.
       debouncedFilter: '',
       selectedTags: [],
-      availableTags: Object.values(FILTER_TAGS_TO_LABELS),
       /** @type {Object.<string, boolean>} */
       openNodes: {},
       /** @type {NavigatorFlatItem[]} */
@@ -194,6 +193,11 @@ export default {
   },
   computed: {
     INDEX_ROOT_KEY: () => INDEX_ROOT_KEY,
+    availableTags: ({ selectedTags }) => (
+      selectedTags.length
+        ? []
+        : Object.values(FILTER_TAGS_TO_LABELS)
+    ),
     selectedTagsModelValue: {
       get: ({ selectedTags }) => selectedTags.map(tag => FILTER_TAGS_TO_LABELS[tag]),
       set(values) {

--- a/src/constants/TopicTypes.js
+++ b/src/constants/TopicTypes.js
@@ -52,6 +52,7 @@ export const TopicTypeAliases = {
   [TopicTypes.init]: TopicTypes.method,
   [TopicTypes.case]: TopicTypes.enum,
   [TopicTypes.propertyListKeyReference]: TopicTypes.propertyListKey,
+  [TopicTypes.project]: TopicTypes.tutorial,
 };
 
 export const TopicTypeColors = {

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -167,7 +167,8 @@ describe('NavigatorCard', () => {
     // assert filter
     const filter = wrapper.find(FilterInput);
     expect(filter.props()).toEqual({
-      focusInputOnValueChange: false,
+      disabled: false,
+      focusInputWhenCreated: false,
       placeholder: 'Filter in TestKit',
       positionReversed: true,
       preventedBlur: false,

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -619,4 +619,15 @@ describe('NavigatorCard', () => {
     // so the filter does not trigger re-calculations
     expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(2);
   });
+
+  it('removes other tag suggestions, when picking one', async () => {
+    sessionStorage.get.mockImplementation((key, def) => def);
+    const wrapper = createWrapper();
+    await flushPromises();
+    const filter = wrapper.find(FilterInput);
+    expect(filter.props('tags')).toHaveLength(3);
+    filter.vm.$emit('update:selectedTags', [FILTER_TAGS_TO_LABELS.articles]);
+    await flushPromises();
+    expect(filter.props('tags')).toEqual([]);
+  });
 });

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -8,7 +8,7 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import NavigatorCard, { STORAGE_KEYS } from '@/components/Navigator/NavigatorCard.vue';
+import NavigatorCard from '@/components/Navigator/NavigatorCard.vue';
 import { shallowMount } from '@vue/test-utils';
 import { TopicTypes } from '@/constants/TopicTypes';
 import { RecycleScroller } from 'vue-virtual-scroller';
@@ -17,13 +17,16 @@ import { INDEX_ROOT_KEY, SIDEBAR_ITEM_SIZE } from '@/constants/sidebar';
 import NavigatorCardItem from '@/components/Navigator/NavigatorCardItem.vue';
 import { sessionStorage } from 'docc-render/utils/storage';
 import Reference from '@/components/ContentNode/Reference.vue';
+import FilterInput from '@/components/Filter/FilterInput.vue';
 import { flushPromises } from '../../../../test-utils';
 
 jest.mock('docc-render/utils/debounce', () => jest.fn(fn => fn));
 jest.mock('docc-render/utils/storage');
 jest.mock('docc-render/utils/loading');
 
-sessionStorage.get.mockImplementation((key, fallback) => fallback);
+sessionStorage.get.mockImplementation((key, def) => def);
+
+const { STORAGE_KEYS, FILTER_TAGS, FILTER_TAGS_TO_LABELS } = NavigatorCard.constants;
 
 const RecycleScrollerStub = {
   props: RecycleScroller.props,
@@ -161,13 +164,29 @@ describe('NavigatorCard', () => {
     });
     // assert no-items-wrapper
     expect(wrapper.find('.no-items-wrapper').exists()).toBe(false);
+    // assert filter
+    const filter = wrapper.find(FilterInput);
+    expect(filter.props()).toEqual({
+      focusInputOnValueChange: false,
+      placeholder: 'Filter in TestKit',
+      positionReversed: true,
+      preventedBlur: false,
+      selectedTags: [],
+      shouldTruncateTags: false,
+      tags: [
+        'Sample Code',
+        'Tutorials',
+        'Articles',
+      ],
+      value: '',
+    });
   });
 
   it('hides the RecycleScroller, if no items to show', async () => {
     const wrapper = createWrapper();
     const scroller = wrapper.find(RecycleScroller);
     expect(scroller.isVisible()).toBe(true);
-    wrapper.find('input').setValue('bad-query');
+    wrapper.find(FilterInput).vm.$emit('input', 'bad-query');
     await wrapper.vm.$nextTick();
     expect(scroller.isVisible()).toBe(false);
   });
@@ -176,7 +195,7 @@ describe('NavigatorCard', () => {
     const wrapper = createWrapper();
     const scroller = wrapper.find(RecycleScroller);
     expect(scroller.isVisible()).toBe(true);
-    wrapper.find('input').setValue('bad-query');
+    wrapper.find(FilterInput).vm.$emit('input', 'bad-query');
     await wrapper.vm.$nextTick();
     expect(scroller.props('items')).toEqual([]);
     expect(scroller.isVisible()).toBe(false);
@@ -270,10 +289,10 @@ describe('NavigatorCard', () => {
 
   it('allows filtering the items, opening all items, that have matches in children', async () => {
     const wrapper = createWrapper();
-    const filter = wrapper.find('input');
+    const filter = wrapper.find(FilterInput);
     await flushPromises();
     expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(1);
-    filter.setValue(root0Child1GrandChild0.title);
+    filter.vm.$emit('input', root0Child1GrandChild0.title);
     await flushPromises();
     expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(2);
     // assert only the parens of the match are visible
@@ -285,11 +304,69 @@ describe('NavigatorCard', () => {
     expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledWith(0);
   });
 
+  it('allows filtering the items using Tags, opening all items, that have matches in children', async () => {
+    const wrapper = createWrapper();
+    const filter = wrapper.find(FilterInput);
+    await flushPromises();
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(1);
+    filter.vm.$emit('update:selectedTags', [FILTER_TAGS_TO_LABELS.articles]);
+    await flushPromises();
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(2);
+    // assert only the parens of the match are visible
+    const all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(1);
+    expect(all.at(0).props('item')).toEqual(root1);
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledWith(0);
+  });
+
+  it('aliases `project` to `tutorial`, when filtering using tags', async () => {
+    const wrapper = createWrapper();
+    const filter = wrapper.find(FilterInput);
+    await flushPromises();
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(1);
+    filter.vm.$emit('update:selectedTags', [FILTER_TAGS_TO_LABELS.tutorials]);
+    await flushPromises();
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(2);
+    // assert only the parens of the match are visible
+    const all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(4);
+    expect(all.at(0).props('item')).toEqual(root0);
+    expect(all.at(1).props('item')).toEqual(root0Child0);
+    expect(all.at(2).props('item')).toEqual(root0Child1);
+    expect(all.at(3).props('item')).toEqual(root0Child1GrandChild0);
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledWith(0);
+  });
+
+  it('allows filtering the items with filter and Tags, opening all items, that have matches in children', async () => {
+    const wrapper = createWrapper();
+    const filter = wrapper.find(FilterInput);
+    await flushPromises();
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(1);
+    filter.vm.$emit('update:selectedTags', [FILTER_TAGS_TO_LABELS.tutorials]);
+    await flushPromises();
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(2);
+    // assert only the parens of the match are visible
+    let all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(4);
+    expect(all.at(0).props('item')).toEqual(root0);
+    expect(all.at(1).props('item')).toEqual(root0Child0);
+    expect(all.at(2).props('item')).toEqual(root0Child1);
+    expect(all.at(3).props('item')).toEqual(root0Child1GrandChild0);
+    // add filtering in top
+    filter.vm.$emit('input', root0Child0.title);
+    await flushPromises();
+    all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(2);
+    expect(all.at(0).props('item')).toEqual(root0);
+    expect(all.at(1).props('item')).toEqual(root0Child0);
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledWith(0);
+  });
+
   it('allows opening an item, that has a filter match', async () => {
     const wrapper = createWrapper();
-    const filter = wrapper.find('input');
+    const filter = wrapper.find(FilterInput);
     await flushPromises();
-    filter.setValue(root0Child1.title);
+    filter.vm.$emit('input', root0Child1.title);
     await flushPromises();
     // assert match and all if it's parents are visible
     let all = wrapper.findAll(NavigatorCardItem);
@@ -312,9 +389,9 @@ describe('NavigatorCard', () => {
 
   it('removes duplicate items, when multiple items with the same parent match the filter', async () => {
     const wrapper = createWrapper();
-    const filter = wrapper.find('input');
+    const filter = wrapper.find(FilterInput);
     // make sure both child elements match
-    filter.setValue('Child');
+    filter.vm.$emit('input', 'Child');
     await flushPromises();
     // assert only the parens of the match are visible
     const all = wrapper.findAll(NavigatorCardItem);
@@ -411,12 +488,12 @@ describe('NavigatorCard', () => {
   it('clears previously open items, when filtering and clearing the filter', async () => {
     const wrapper = createWrapper();
     await flushPromises();
-    wrapper.find('input').setValue('First Child, Depth 2');
+    wrapper.find(FilterInput).vm.$emit('input', 'First Child, Depth 2');
     await flushPromises();
     let all = wrapper.findAll(NavigatorCardItem);
     expect(all).toHaveLength(3);
     expect(all.at(2).props('item')).toEqual(root0Child1GrandChild0);
-    wrapper.find('input').setValue('');
+    wrapper.find(FilterInput).vm.$emit('input', '');
     await flushPromises();
     all = wrapper.findAll(NavigatorCardItem);
     expect(all).toHaveLength(4);
@@ -443,9 +520,14 @@ describe('NavigatorCard', () => {
     expect(sessionStorage.set)
       .toHaveBeenCalledWith(STORAGE_KEYS.nodesToRender, [0, 1, 2, 4]);
     await flushPromises();
-    wrapper.find('input').setValue(root0Child1GrandChild0.title);
+    wrapper.find(FilterInput).vm.$emit('input', root0Child1GrandChild0.title);
+    wrapper.find(FilterInput).vm.$emit('update:selectedTags', [FILTER_TAGS_TO_LABELS.tutorials]);
     await flushPromises();
-    expect(sessionStorage.set).toHaveBeenCalledTimes(7);
+    expect(sessionStorage.set).toHaveBeenCalledTimes(8);
+    expect(sessionStorage.set)
+      .toHaveBeenCalledWith(STORAGE_KEYS.filter, root0Child1GrandChild0.title);
+    expect(sessionStorage.set)
+      .toHaveBeenCalledWith(STORAGE_KEYS.selectedTags, [FILTER_TAGS.tutorials]);
     expect(sessionStorage.set)
       .toHaveBeenCalledWith(STORAGE_KEYS.openNodes, [0, 1]);
     expect(sessionStorage.set)
@@ -458,6 +540,7 @@ describe('NavigatorCard', () => {
       if (key === STORAGE_KEYS.technology) return defaultProps.technology;
       if (key === STORAGE_KEYS.nodesToRender) return [root0.uid];
       if (key === STORAGE_KEYS.openNodes) return [root0.uid];
+      if (key === STORAGE_KEYS.selectedTags) return [FILTER_TAGS.tutorials];
       return '';
     });
 
@@ -465,6 +548,8 @@ describe('NavigatorCard', () => {
     const all = wrapper.findAll(NavigatorCardItem);
     expect(all).toHaveLength(1);
     expect(all.at(0).props('item')).toEqual(root0);
+    expect(wrapper.find(FilterInput).props('selectedTags'))
+      .toEqual([FILTER_TAGS_TO_LABELS.tutorials]);
   });
 
   it('does not restore the state, if the technology is different', () => {
@@ -501,13 +586,31 @@ describe('NavigatorCard', () => {
     expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(4);
   });
 
-  it('keeps the open state, even if there is a filter', async () => {
+  it('keeps the open state, even if there is a title filter', async () => {
     sessionStorage.get.mockImplementation((key) => {
       if (key === STORAGE_KEYS.filter) return root0Child1GrandChild0.title;
       if (key === STORAGE_KEYS.technology) return defaultProps.technology;
       // simulate we have collapses all, but the top item
       if (key === STORAGE_KEYS.nodesToRender) return [root0.uid, root0Child1.uid];
       if (key === STORAGE_KEYS.openNodes) return [root0.uid];
+      if (key === STORAGE_KEYS.selectedTags) return [];
+      return '';
+    });
+    const wrapper = createWrapper();
+    await flushPromises();
+    // assert we are render more than just whats in the store,
+    // so the filter does not trigger re-calculations
+    expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(2);
+  });
+
+  it('keeps the open state, even if there is a Tag filter applied', async () => {
+    sessionStorage.get.mockImplementation((key) => {
+      if (key === STORAGE_KEYS.filter) return '';
+      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
+      // simulate we have collapses all, but the top item
+      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid, root0Child1.uid];
+      if (key === STORAGE_KEYS.openNodes) return [root0.uid];
+      if (key === STORAGE_KEYS.selectedTags) return [FILTER_TAGS.tutorials];
       return '';
     });
     const wrapper = createWrapper();


### PR DESCRIPTION
Bug/issue #, if applicable: 88001866

## Summary

Allows filtering in the sidebar, using a pre-defined list of Tags

## Dependencies

NA

## Testing

Steps:
1. Serve a doccarchive that has articles or tutorials
2. Click on the filter and select Tutorial or Article tag
3. Assert only those are shown + their parents are open

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
