### PR TITLE
Fix regression with page layout where it can wrap horizontally in certain scenarios

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -351,7 +351,7 @@ export default {
   @include inTargetIde {
     min-height: 100vh;
     display: flex;
-    flex-flow: column wrap;
+    flex-flow: column nowrap;
     border: none;
 
     & > .contenttable:last-of-type {


### PR DESCRIPTION
Bug/issue #, if applicable: 89837079

## Summary

This fixes a regression with the page layout that was introduced in #51.

In certain edge cases for IDE targets, top level elements of documentation pages like the "Relationships" section may occasionally break out horizontally into a second column, which should never happen.

This seems to only happen in WebKit based browsers.

## Testing

Steps:
1. Configure `VUE_APP_TARGET=ide` when running the dev server with `npm run serve`.
2. Using Safari, find examples of problematic pages and verify that they now look normal as the window is resized from large to small.
3. View other pages and ensure that there are no new regressions with the layout.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
