### PR TITLE
Close the nav, before toggling the sidenav open

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -20,8 +20,8 @@
     class="documentation-nav"
     aria-label="API Reference"
   >
-    <template slot="pre-title" v-if="isWideFormat">
-      <button class="sidenav-toggle" @click.prevent="$emit('toggle-sidenav')">
+    <template #pre-title="{ closeNav }" v-if="isWideFormat">
+      <button class="sidenav-toggle" @click.prevent="handleSidenavToggle(closeNav)">
         <SidenavIcon class="icon-inline sidenav-icon" />
       </button>
     </template>
@@ -142,6 +142,14 @@ export default {
     hierarchyItems: ({ parentTopicIdentifiers, isRootTechnologyLink }) => (
       isRootTechnologyLink ? parentTopicIdentifiers.slice(1) : parentTopicIdentifiers
     ),
+  },
+  methods: {
+    async handleSidenavToggle(closeNav) {
+      // close the navigation
+      await closeNav();
+      // toggle the sidenav
+      this.$emit('toggle-sidenav');
+    },
   },
 };
 </script>

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -19,8 +19,8 @@
       <div class="nav__background" />
       <div v-if="hasOverlay" class="nav-overlay" @click="closeNav" />
       <div class="nav-content">
-        <div class="pre-title" v-if="$slots['pre-title']">
-          <slot name="pre-title" />
+        <div class="pre-title">
+          <slot name="pre-title" :close-nav="closeNav" />
         </div>
         <div v-if="$slots.default" class="nav-title">
           <slot />
@@ -516,6 +516,11 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
 
 .pre-title {
   display: none;
+
+  &:empty {
+    display: none;
+  }
+
   @include nav-in-breakpoint() {
     display: flex;
     padding: 0;

--- a/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import {
   shallowMount,
@@ -14,6 +14,11 @@ import {
 } from '@vue/test-utils';
 import DocumentationNav from 'docc-render/components/DocumentationTopic/DocumentationNav.vue';
 import { BreakpointName } from '@/utils/breakpoints';
+import { flushPromises } from '../../../../test-utils';
+
+jest.mock('docc-render/utils/changeElementVOVisibility');
+jest.mock('docc-render/utils/scroll-lock');
+jest.mock('docc-render/utils/FocusTrap');
 
 const {
   Hierarchy,
@@ -224,8 +229,19 @@ describe('DocumentationNav', () => {
     expect(wrapper.find('.nav-title-link').exists()).toBe(false);
   });
 
-  it('renders a sidenav toggle', () => {
+  it('renders a sidenav toggle', async () => {
     wrapper.find('.sidenav-toggle').trigger('click');
+    await flushPromises();
+    expect(wrapper.emitted('toggle-sidenav')).toBeTruthy();
+  });
+
+  it('closes the nav, if open and clicking on the sidenavtoggle', async () => {
+    wrapper.find('.nav-menucta').trigger('click');
+    expect(wrapper.classes()).toContain('nav--is-open');
+    wrapper.find('.sidenav-toggle').trigger('click');
+    expect(wrapper.classes()).not.toContain('nav--is-open');
+    expect(wrapper.emitted('toggle-sidenav')).toBeFalsy();
+    await flushPromises();
     expect(wrapper.emitted('toggle-sidenav')).toBeTruthy();
   });
 

--- a/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import {
   shallowMount,

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import NavBase from 'docc-render/components/NavBase.vue';
 import { shallowMount } from '@vue/test-utils';
@@ -145,20 +145,22 @@ describe('NavBase', () => {
     expect(wrapper.find('.after-title').exists()).toBe(true);
   });
 
-  it('does not render a pre-title, if not provided via slot', async () => {
-    wrapper = await createWrapper({});
-    expect(wrapper.find('.pre-title').exists()).toBe(false);
-  });
-
   it('renders a pre-title slot', async () => {
+    let preTitleProps;
     wrapper = await createWrapper({
-      slots: {
-        'pre-title': '<div class="pre-title-slot">Pre Title</div>',
+      scopedSlots: {
+        'pre-title': function (props) {
+          preTitleProps = props;
+          return this.$createElement('div', { class: 'pre-title-slot' }, 'Pre Title');
+        },
       },
     });
     const preTitle = wrapper.find('.pre-title');
     expect(preTitle.exists()).toBe(true);
     expect(preTitle.find('.pre-title-slot').text()).toBe('Pre Title');
+    expect(preTitleProps).toEqual({
+      closeNav: expect.any(Function),
+    });
   });
 
   it('renders a dedicated AX toggle', async () => {

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import NavBase from 'docc-render/components/NavBase.vue';
 import { shallowMount } from '@vue/test-utils';
@@ -149,7 +149,7 @@ describe('NavBase', () => {
     let preTitleProps;
     wrapper = await createWrapper({
       scopedSlots: {
-        'pre-title': function (props) {
+        'pre-title': function preTitle(props) {
           preTitleProps = props;
           return this.$createElement('div', { class: 'pre-title-slot' }, 'Pre Title');
         },


### PR DESCRIPTION
Bug/issue #, if applicable: 89774411

## Summary

Closes the nav, if it was open and trying to open the sidenav. This fixes a bug where the sidenav is not scrollable, when the nav is toggled open.

## Dependencies

NA

## Testing

Steps:
1. On a mobile device, toggle the nav open
2. While open, click on the sidebar toggle
3. Assert you can scroll the sidenav. Open a few items if there are not enough items for a scrollbar.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x]  Updated documentation if necessary
