### PR TITLE
Make the sidenav toggle easier to click on mobile

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -187,6 +187,14 @@ $sidenav-icon-size: 19px;
   }
 }
 
+.sidenav-toggle {
+  $space: 14px;
+  margin-left: -$space;
+  margin-right: -$space;
+  padding-left: $space;
+  padding-right: $space;
+}
+
 .sidenav-icon {
   width: $sidenav-icon-size;
   height: $sidenav-icon-size;

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -650,18 +650,22 @@ $filter-height: 64px;
 .close-card-mobile {
   display: none;
   position: absolute;
-  top: 50%;
   z-index: 1;
-  transform: translateY(-50%);
   color: var(--color-link);
+  align-items: center;
+  justify-content: center;
 
   @include breakpoint(medium, nav) {
     display: flex;
-    left: $nav-padding-wide;
+    left: 0;
+    height: 100%;
+    padding-left: $nav-padding-wide;
+    padding-right: $nav-padding-wide;
   }
 
   @include breakpoint(small, nav) {
-    left: $nav-padding-small;
+    padding-left: $nav-padding-small;
+    padding-right: $nav-padding-small;
   }
 
   .close-icon {


### PR DESCRIPTION
Bug/issue #, if applicable: 89903890

## Summary

Changes clickable area of the sidenav toggles, so its easier to click on mobile devices.

## Dependencies

NA

## Testing

Steps:
1. Serve a doccarchive with sidebar index
2. Assert that the toggles to open/close the nav on mobile devices are larger and easier to click, while the icons are in the same place and size.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
