### PR TITLE
Allow the FilterInput to loose focus when the blur target is an action item

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -281,7 +281,10 @@ export default {
   watch: {
     async selectedTags() {
       if (!this.resetedTagsViaDeleteButton) {
-        await this.focusInput();
+        // make sure we are inside the component, if we are moving the focus
+        if (this.$el.contains(document.activeElement)) {
+          await this.focusInput();
+        }
       } else {
         this.resetedTagsViaDeleteButton = false;
       }

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -195,6 +195,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    shouldKeepOpenOnBlur: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {
@@ -354,7 +358,7 @@ export default {
     async handleBlur(event) {
       // if the blur came from clicking a link
       const target = event.relatedTarget;
-      if (target && target.matches && target.matches('button, input, ul')) return;
+      if (this.shouldKeepOpenOnBlur && target && target.matches && target.matches('button, input, ul')) return;
       // Wait for mousedown to send event listeners
       await this.$nextTick();
 

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -69,6 +69,7 @@
             :tags="availableTags"
             :selected-tags.sync="selectedTagsModelValue"
             :placeholder="`Filter in ${technology}`"
+            :should-keep-open-on-blur="false"
             position-reversed
             class="filter-component"
             @clear="clearFilters"

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import { prepareDataForHTMLClipboard } from '@/utils/clipboard';
 import { shallowMount } from '@vue/test-utils';
@@ -584,6 +584,10 @@ describe('FilterInput', () => {
       const selectedTag = 'Tag1';
 
       beforeEach(async () => {
+        // make sure focus is inside the wrapper
+        wrapper.find('button').element.focus();
+        await wrapper.vm.$nextTick();
+
         wrapper.setProps({ selectedTags: [selectedTag] });
         await wrapper.vm.$nextTick();
         selectedTagsComponent = wrapper.find({ ref: 'selectedTags' });
@@ -610,13 +614,22 @@ describe('FilterInput', () => {
         expect(filterButton.classes('blue')).toBe(true);
       });
 
-      it('focuses input, when selectedTags changes', async () => {
+      it('focuses input, when selectedTags changes, if focus is inside', async () => {
         expect(document.activeElement).toBe(input.element);
         input.element.blur();
         expect(document.activeElement).not.toBe(input.element);
+        wrapper.find('button').element.focus();
         wrapper.setProps({ selectedTags: [] });
         await flushPromises();
         expect(document.activeElement).toBe(input.element);
+      });
+
+      it('does not focus the input, if the initial focus is NOT inside', async () => {
+        document.activeElement.blur();
+        await wrapper.vm.$nextTick();
+        wrapper.setProps({ selectedTags: [] });
+        await wrapper.vm.$nextTick();
+        expect(document.activeElement).not.toEqual(input.element);
       });
 
       it('changes the input placeholder to empty', () => {
@@ -624,17 +637,14 @@ describe('FilterInput', () => {
       });
 
       it('resets scroll on `suggestedTags` when selectedTags changes if there is suggested tags', async () => {
-        const spy = jest.spyOn(TagList.methods, 'resetScroll');
-        wrapper = shallowMount(FilterInput, {
-          propsData,
-          stubs: { TagList },
-        });
-
+        const spy = jest.spyOn(wrapper.find({ ref: 'suggestedTags' }).vm, 'resetScroll');
         wrapper.setProps({
           selectedTags: [selectedTag],
         });
-        // wait for the watcher to kick in
-        await flushPromises();
+        // once for the watcher to kick in
+        await wrapper.vm.$nextTick();
+        // once for the `focusInput` to pass
+        await wrapper.vm.$nextTick();
         expect(spy).toHaveBeenCalledTimes(1);
         spy.mockRestore();
       });

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import { prepareDataForHTMLClipboard } from '@/utils/clipboard';
 import { shallowMount } from '@vue/test-utils';
@@ -505,6 +505,22 @@ describe('FilterInput', () => {
 
       expect(suggestedTags.exists()).toBe(true);
       expect(wrapper.emitted('show-suggested-tags')).toEqual([[true]]);
+    });
+
+    it('hides the tags, if new focus matches button or input, if shouldKeepOpenOnBlur=false', async () => {
+      wrapper.setProps({
+        shouldKeepOpenOnBlur: false,
+      });
+      const inputTarget = document.createElement('input');
+
+      input.trigger('blur', {
+        relatedTarget: inputTarget,
+      });
+
+      await flushPromises();
+
+      expect(suggestedTags.exists()).toBe(false);
+      expect(wrapper.emitted('show-suggested-tags')).toEqual([[true], [false]]);
     });
 
     it('hides the tags, if the new focus target is a link, outside the FilterInput', async () => {

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -172,6 +172,7 @@ describe('NavigatorCard', () => {
       placeholder: 'Filter in TestKit',
       positionReversed: true,
       preventedBlur: false,
+      shouldKeepOpenOnBlur: false,
       selectedTags: [],
       shouldTruncateTags: false,
       tags: [


### PR DESCRIPTION
Bug/issue #, if applicable: 89502803

## Summary

Adds a toggle to the FilterInput (tagging component), to allow it to lose it's focus when moving focus from it to an Input or a button. Should make re-use of the component easier in forms.

## Dependencies

NA

## Testing

Steps:
1. While focused on the input, click on a button or other input on the same page
2. Assert that the input is no longer focused/blue/open

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
