### PR TITLE
Fix sidebar filter position on mobile

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -27,6 +27,7 @@
           name="aside"
           animationClass="aside-animated-child"
           :scrollLockID="scrollLockID"
+          :breakpoint="breakpoint"
         />
       </div>
       <div

--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -19,6 +19,7 @@
       :active-path="activePath"
       :scrollLockID="scrollLockID"
       :error-fetching="errorFetching"
+      :breakpoint="breakpoint"
       @close="$emit('close')"
     />
     <div v-else class="loading-placeholder">
@@ -79,6 +80,10 @@ export default {
     errorFetching: {
       type: Boolean,
       default: false,
+    },
+    breakpoint: {
+      type: String,
+      default: '',
     },
   },
   computed: {

--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -32,6 +32,7 @@
 import NavigatorCard from 'docc-render/components/Navigator/NavigatorCard.vue';
 import { INDEX_ROOT_KEY } from 'docc-render/constants/sidebar';
 import { TopicTypes } from 'docc-render/constants/TopicTypes';
+import { BreakpointName } from '@/utils/breakpoints';
 
 /**
  * @typedef NavigatorFlatItem
@@ -83,7 +84,7 @@ export default {
     },
     breakpoint: {
       type: String,
-      default: '',
+      default: BreakpointName.large,
     },
   },
   computed: {

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -70,7 +70,6 @@
             :selected-tags.sync="selectedTagsModelValue"
             :placeholder="`Filter in ${technology}`"
             :should-keep-open-on-blur="false"
-            position-reversed
             :position-reversed="isLargeBreakpoint"
             class="filter-component"
             @clear="clearFilters"

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -69,7 +69,7 @@
             :tags="availableTags"
             :selected-tags.sync="selectedTagsModelValue"
             :placeholder="`Filter in ${technology}`"
-            :position-reversed="isDesktop"
+            :position-reversed="isLargeBreakpoint"
             class="filter-component"
             @clear="clearFilters"
           />
@@ -299,7 +299,7 @@ export default {
     hasFilter({ debouncedFilter, selectedTags }) {
       return Boolean(debouncedFilter.length || selectedTags.length);
     },
-    isDesktop: ({ breakpoint }) => breakpoint === BreakpointName.large,
+    isLargeBreakpoint: ({ breakpoint }) => breakpoint === BreakpointName.large,
   },
   created() {
     this.restorePersistedState();

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -69,7 +69,7 @@
             :tags="availableTags"
             :selected-tags.sync="selectedTagsModelValue"
             :placeholder="`Filter in ${technology}`"
-            position-reversed
+            :position-reversed="isDesktop"
             class="filter-component"
             @clear="clearFilters"
           />
@@ -93,6 +93,7 @@ import SidenavIcon from 'theme/components/Icons/SidenavIcon.vue';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
 import { TopicTypes } from 'docc-render/constants/TopicTypes';
 import FilterInput from 'docc-render/components/Filter/FilterInput.vue';
+import { BreakpointName } from '@/utils/breakpoints';
 
 const STORAGE_KEYS = {
   filter: 'navigator.filter',
@@ -181,6 +182,10 @@ export default {
     errorFetching: {
       type: Boolean,
       default: false,
+    },
+    breakpoint: {
+      type: String,
+      default: '',
     },
   },
   data() {
@@ -294,6 +299,7 @@ export default {
     hasFilter({ debouncedFilter, selectedTags }) {
       return Boolean(debouncedFilter.length || selectedTags.length);
     },
+    isDesktop: ({ breakpoint }) => breakpoint === BreakpointName.large,
   },
   created() {
     this.restorePersistedState();
@@ -703,6 +709,7 @@ $filter-height: 64px;
   @include breakpoint(medium, nav) {
     border: none;
     padding: 10px 20px;
+    align-items: flex-start;
   }
 
   .input-wrapper {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -31,7 +31,7 @@
         v-bind="sidebarProps"
         v-on="sidebarListeners"
       >
-        <template #aside="{ scrollLockID }">
+        <template #aside="{ scrollLockID, breakpoint }">
           <aside class="doc-topic-aside">
             <NavigatorDataProvider
               :interface-language="topicProps.interfaceLanguage"
@@ -45,6 +45,7 @@
                   :error-fetching="slotProps.errorFetching"
                   :references="topicProps.references"
                   :scrollLockID="scrollLockID"
+                  :breakpoint="breakpoint"
                   @close="isSideNavOpen = false"
                 />
               </template>

--- a/tests/unit/components/AdjustableSidebarWidth.spec.js
+++ b/tests/unit/components/AdjustableSidebarWidth.spec.js
@@ -86,6 +86,7 @@ describe('AdjustableSidebarWidth', () => {
     expect(slotProps).toEqual({
       animationClass: 'aside-animated-child',
       scrollLockID: 'sidebar-scroll-lock',
+      breakpoint: 'large',
     });
   });
 

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import Navigator from '@/components/Navigator.vue';
 import { shallowMount } from '@vue/test-utils';
@@ -89,6 +89,7 @@ const defaultProps = {
   technology,
   references,
   scrollLockID: 'foo',
+  breakpoint: 'large',
 };
 
 const fauxAnchor = document.createElement('DIV');
@@ -117,6 +118,7 @@ describe('Navigator', () => {
       technology: technology.title,
       technologyPath: technology.path,
       scrollLockID: defaultProps.scrollLockID,
+      breakpoint: defaultProps.breakpoint,
       errorFetching: false,
     });
     expect(wrapper.find('.loading-placeholder').exists()).toBe(false);
@@ -147,6 +149,7 @@ describe('Navigator', () => {
       technology: fallbackTechnology.title,
       technologyPath: fallbackTechnology.url,
       scrollLockID: defaultProps.scrollLockID,
+      breakpoint: defaultProps.breakpoint,
       errorFetching: false,
     });
   });

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import Navigator from '@/components/Navigator.vue';
 import { shallowMount } from '@vue/test-utils';

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import NavigatorCard from '@/components/Navigator/NavigatorCard.vue';
 import { shallowMount } from '@vue/test-utils';
@@ -19,6 +19,7 @@ import { sessionStorage } from 'docc-render/utils/storage';
 import Reference from '@/components/ContentNode/Reference.vue';
 import FilterInput from '@/components/Filter/FilterInput.vue';
 import { flushPromises } from '../../../../test-utils';
+import { BreakpointName } from '@/utils/breakpoints';
 
 jest.mock('docc-render/utils/debounce', () => jest.fn(fn => fn));
 jest.mock('docc-render/utils/storage');
@@ -113,6 +114,7 @@ const defaultProps = {
   activePath,
   type: TopicTypes.module,
   scrollLockID: 'foo',
+  breakpoint: 'large',
 };
 
 const createWrapper = ({ propsData, ...others } = {}) => shallowMount(NavigatorCard, {
@@ -181,6 +183,15 @@ describe('NavigatorCard', () => {
       ],
       value: '',
     });
+  });
+
+  it('reverses the FilterInput, on mobile', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        breakpoint: BreakpointName.medium,
+      },
+    });
+    expect(wrapper.find(FilterInput).props('positionReversed')).toBe(false);
   });
 
   it('hides the RecycleScroller, if no items to show', async () => {

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import NavigatorCard from '@/components/Navigator/NavigatorCard.vue';
 import { shallowMount } from '@vue/test-utils';
@@ -18,8 +18,8 @@ import NavigatorCardItem from '@/components/Navigator/NavigatorCardItem.vue';
 import { sessionStorage } from 'docc-render/utils/storage';
 import Reference from '@/components/ContentNode/Reference.vue';
 import FilterInput from '@/components/Filter/FilterInput.vue';
-import { flushPromises } from '../../../../test-utils';
 import { BreakpointName } from '@/utils/breakpoints';
+import { flushPromises } from '../../../../test-utils';
 
 jest.mock('docc-render/utils/debounce', () => jest.fn(fn => fn));
 jest.mock('docc-render/utils/storage');

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -165,6 +165,7 @@ describe('DocumentationTopic', () => {
       parentTopicIdentifiers: topicData.hierarchy.paths[0],
       references: topicData.references,
       scrollLockID: AdjustableSidebarWidth.constants.SCROLL_LOCK_ID,
+      breakpoint: 'large',
       // assert we are passing the default technology, if we dont have the children yet
       technology,
     });
@@ -174,6 +175,7 @@ describe('DocumentationTopic', () => {
       errorFetching: false,
       isFetching: false,
       scrollLockID: AdjustableSidebarWidth.constants.SCROLL_LOCK_ID,
+      breakpoint: 'large',
       parentTopicIdentifiers: topicData.hierarchy.paths[0],
       references: topicData.references,
       technology: TechnologyWithChildren,


### PR DESCRIPTION
Bug/issue #, if applicable: 89956881

## Summary

Fixes an issue with the sidebar filter going on top of the header, on mobile sizes.

Before
<img width="958" alt="image" src="https://user-images.githubusercontent.com/9863944/157213600-4cd9001a-4662-4cac-aba0-982ac4ebeb88.png">

After
<img width="929" alt="image" src="https://user-images.githubusercontent.com/9863944/157213632-a13e9919-5b40-401d-9f33-fffcb6047532.png">


## Dependencies

NA

## Testing

Steps:
1. Go to any page with a navigator
2. Resize the screen to a mobile size and open the navigator
3. Inspect the filter at the top

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
