### PR TITLE
Fix - Vertical divider line gets 10px stroke in thickness

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -13,7 +13,6 @@
     <div
       ref="sidebar"
       class="sidebar"
-      :class="{ 'fully-open': isMaxWidth }"
     >
       <div
         :class="asideClasses"
@@ -134,7 +133,6 @@ export default {
     ),
     minWidth: ({ minWidthPercent, windowWidth }) => calcWidthPercent(minWidthPercent, windowWidth),
     widthInPx: ({ width }) => `${width}px`,
-    isMaxWidth: ({ width, maxWidth }) => width === maxWidth,
     events: ({ isTouch }) => (isTouch ? eventsMap.touch : eventsMap.mouse),
     asideClasses: ({
       isDragging, openExternally, noTransition, isTransitioning,
@@ -357,10 +355,6 @@ export default {
   z-index: 1;
   transition: background-color .15s;
   transform: translateX(50%);
-
-  .fully-closed &, .fully-open & {
-    width: 10px;
-  }
 
   @include breakpoint(medium, nav) {
     display: none;

--- a/tests/unit/components/AdjustableSidebarWidth.spec.js
+++ b/tests/unit/components/AdjustableSidebarWidth.spec.js
@@ -249,13 +249,6 @@ describe('AdjustableSidebarWidth', () => {
     assertWidth(wrapper, 250); // 20% out of 1000, as that is the min percentage
   });
 
-  it('sets helper classes when `fully open`', () => {
-    storage.get.mockReturnValueOnce(window.innerWidth);
-    const wrapper = createWrapper();
-    expect(wrapper.find('.sidebar').classes()).toContain('fully-open');
-    assertWidth(wrapper, maxWidth);
-  });
-
   it('allows dragging the handle to expand/contract the sidebar, with the mouse', () => {
     const wrapper = createWrapper();
     const aside = wrapper.find('.aside');


### PR DESCRIPTION
Bug/issue #, if applicable: 89828514

## Summary

Removes a class helper, that adds extra width to the resize handler of the sidebar. This is so it can be gripped when at the far left/right. This is no longer needed, as we have hard limits on the sidebar to never go 100% open/closed.

<img width="178" alt="image" src="https://user-images.githubusercontent.com/9863944/157215460-94aff4ef-f226-4ea9-a2bb-d6e42e79317f.png">


## Dependencies

NA

## Testing

Steps:
1. Expand the sidebar as much as it will go
2. Hover over the resize handler
3. Assert it's width is 5px and not more

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
