### PR TITLE
[AX] Add aria-live regions to NavigationCard

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -47,24 +47,11 @@
               @toggle-full="toggleFullTree"
             />
           </RecycleScroller>
-          <div
-            aria-live="polite"
-            :class="hasNodes ? 'visuallyhidden' : 'no-items-wrapper'"
-          >
-            <template v-if="hasNodes">
-              {{ itemsFoundNotification }}
-            </template>
-            <template v-else>
-              <template v-if="hasFilter">
-                {{ NO_RESULTS }}
-              </template>
-              <template v-else-if="errorFetching">
-                {{ ERROR_FETCHING }}
-              </template>
-              <template v-else>
-                {{ NO_CHILDREN }}
-              </template>
-            </template>
+          <div aria-live="polite" class="visuallyhidden">
+            {{ politeAriaLive }}
+          </div>
+          <div aria-live="assertive" class="no-items-wrapper">
+            {{ assertiveAriaLive }}
           </div>
         </div>
       </div>
@@ -225,7 +212,16 @@ export default {
   },
   computed: {
     INDEX_ROOT_KEY: () => INDEX_ROOT_KEY,
-    itemsFoundNotification: ({ nodesToRender }) => ([nodesToRender.length, ITEMS_FOUND].join(' ')),
+    politeAriaLive: ({ hasNodes, nodesToRender }) => {
+      if (!hasNodes) return '';
+      return [nodesToRender.length, ITEMS_FOUND].join(' ');
+    },
+    assertiveAriaLive: ({ hasNodes, hasFilter, errorFetching }) => {
+      if (hasNodes) return '';
+      if (hasFilter) return NO_RESULTS;
+      if (errorFetching) return ERROR_FETCHING;
+      return NO_CHILDREN;
+    },
     availableTags: ({ selectedTags }) => (
       selectedTags.length
         ? []
@@ -323,7 +319,7 @@ export default {
       return Boolean(debouncedFilter.length || selectedTags.length);
     },
     isLargeBreakpoint: ({ breakpoint }) => breakpoint === BreakpointName.large,
-    hasNodes: ({ nodesToRender }) => nodesToRender.length,
+    hasNodes: ({ nodesToRender }) => !!nodesToRender.length,
   },
   created() {
     this.restorePersistedState();

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -25,7 +25,7 @@
         </div>
         <div class="card-body">
           <RecycleScroller
-            v-show="nodesToRender.length"
+            v-show="hasNodes"
             :id="scrollLockID"
             ref="scroller"
             class="scroller"
@@ -49,11 +49,12 @@
           </RecycleScroller>
           <div
             aria-live="polite"
-            :class="!nodesToRender.length ? 'no-items-wrapper' : 'visuallyhidden'"
+            :class="hasNodes ? 'visuallyhidden' : 'no-items-wrapper'"
           >
-            <template
-              v-if="!nodesToRender.length"
-            >
+            <template v-if="hasNodes">
+              {{ itemsFoundNotification }}
+            </template>
+            <template v-else>
               <template v-if="hasFilter">
                 {{ NO_RESULTS }}
               </template>
@@ -63,9 +64,6 @@
               <template v-else>
                 {{ NO_CHILDREN }}
               </template>
-            </template>
-            <template v-else>
-              {{ itemsFoundNotification }}
             </template>
           </div>
         </div>
@@ -328,6 +326,7 @@ export default {
       return Boolean(debouncedFilter.length || selectedTags.length);
     },
     isLargeBreakpoint: ({ breakpoint }) => breakpoint === BreakpointName.large,
+    hasNodes: ({ nodesToRender }) => nodesToRender.length,
   },
   created() {
     this.restorePersistedState();

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -47,15 +47,25 @@
               @toggle-full="toggleFullTree"
             />
           </RecycleScroller>
-          <div class="no-items-wrapper" v-if="!nodesToRender.length">
-            <template v-if="hasFilter">
-              No results matching your filter
-            </template>
-            <template v-else-if="errorFetching">
-              There was an error fetching the data
+          <div
+            aria-live="polite"
+            :class="!nodesToRender.length ? 'no-items-wrapper' : 'visuallyhidden'"
+          >
+            <template
+              v-if="!nodesToRender.length"
+            >
+              <template v-if="hasFilter">
+                {{ NO_RESULTS }}
+              </template>
+              <template v-else-if="errorFetching">
+                {{ ERROR_FETCHING }}
+              </template>
+              <template v-else>
+                {{ NO_CHILDREN }}
+              </template>
             </template>
             <template v-else>
-              Technology has no children
+              {{ itemsFoundNotification }}
             </template>
           </div>
         </div>
@@ -104,6 +114,11 @@ const STORAGE_KEYS = {
   selectedTags: 'navigator.selectedTags',
 };
 
+const NO_RESULTS = 'No results matching your filter';
+const NO_CHILDREN = 'Technology has no children';
+const ERROR_FETCHING = 'There was an error fetching the data';
+const ITEMS_FOUND = 'items were found. Tab back to navigate to them.';
+
 const FILTER_TAGS = {
   sampleCode: 'sampleCode',
   tutorials: 'tutorials',
@@ -146,6 +161,10 @@ export default {
     FILTER_TAGS_TO_LABELS,
     FILTER_LABELS_TO_TAGS,
     TOPIC_TYPE_TO_TAG,
+    NO_RESULTS,
+    NO_CHILDREN,
+    ERROR_FETCHING,
+    ITEMS_FOUND,
   },
   components: {
     FilterInput,
@@ -200,10 +219,18 @@ export default {
       openNodes: {},
       /** @type {NavigatorFlatItem[]} */
       nodesToRender: [],
+      NO_RESULTS,
+      NO_CHILDREN,
+      ERROR_FETCHING,
+      ITEMS_FOUND,
     };
   },
   computed: {
     INDEX_ROOT_KEY: () => INDEX_ROOT_KEY,
+    itemsFoundNotification: ({ filteredChildren, children }) => {
+      const childrenLength = filteredChildren.length || children.length;
+      return [childrenLength, ITEMS_FOUND].join(' ');
+    },
     availableTags: ({ selectedTags }) => (
       selectedTags.length
         ? []

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -115,7 +115,7 @@ const STORAGE_KEYS = {
 const NO_RESULTS = 'No results matching your filter';
 const NO_CHILDREN = 'Technology has no children';
 const ERROR_FETCHING = 'There was an error fetching the data';
-const ITEMS_FOUND = 'items were found. Tab back to navigate to them.';
+const ITEMS_FOUND = 'items were found. Tab back to navigate through them.';
 
 const FILTER_TAGS = {
   sampleCode: 'sampleCode',
@@ -225,10 +225,7 @@ export default {
   },
   computed: {
     INDEX_ROOT_KEY: () => INDEX_ROOT_KEY,
-    itemsFoundNotification: ({ filteredChildren, children }) => {
-      const childrenLength = filteredChildren.length || children.length;
-      return [childrenLength, ITEMS_FOUND].join(' ');
-    },
+    itemsFoundNotification: ({ nodesToRender }) => ([nodesToRender.length, ITEMS_FOUND].join(' ')),
     availableTags: ({ selectedTags }) => (
       selectedTags.length
         ? []

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -253,10 +253,13 @@ describe('NavigatorCard', () => {
 
   it('renders an hidden message updating aria-live, notifying how many items were found', async () => {
     const wrapper = createWrapper();
+    const unopenedItem = wrapper.findAll(NavigatorCardItem).at(2);
+    unopenedItem.vm.$emit('toggle', root0Child1);
+    await wrapper.vm.$nextTick();
     let message = [children.length, ITEMS_FOUND].join(' ');
     expect(wrapper.find('[aria-live="polite"].visuallyhidden').text()).toBe(message);
 
-    wrapper.find(FilterInput).vm.$emit('input', root0Child1.title);
+    wrapper.find(FilterInput).vm.$emit('input', root0.title);
     await wrapper.vm.$nextTick();
     message = [1, ITEMS_FOUND].join(' ');
     expect(wrapper.find('[aria-live="polite"].visuallyhidden').text()).toBe(message);

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -173,7 +173,7 @@ describe('NavigatorCard', () => {
       item: root0,
     });
     // assert no-items-wrapper
-    expect(wrapper.find('.no-items-wrapper').exists()).toBe(false);
+    expect(wrapper.find('.no-items-wrapper').exists()).toBe(true);
     // assert filter
     const filter = wrapper.find(FilterInput);
     expect(filter.props()).toEqual({
@@ -203,10 +203,10 @@ describe('NavigatorCard', () => {
     expect(wrapper.find(FilterInput).props('positionReversed')).toBe(false);
   });
 
-  it('renders aria-live', async () => {
+  it('renders aria-live regions for polite and assertive notifications', () => {
     const wrapper = createWrapper();
-    const ariaLive = wrapper.find('[aria-live="polite"]');
-    expect(ariaLive.exists()).toBe(true);
+    expect(wrapper.find('[aria-live="polite"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-live="assertive"]').exists()).toBe(true);
   });
 
   it('hides the RecycleScroller, if no items to show', async () => {
@@ -226,7 +226,7 @@ describe('NavigatorCard', () => {
     await wrapper.vm.$nextTick();
     expect(scroller.props('items')).toEqual([]);
     expect(scroller.isVisible()).toBe(false);
-    expect(wrapper.find('[aria-live="polite"].no-items-wrapper').text()).toBe(NO_RESULTS);
+    expect(wrapper.find('[aria-live="assertive"].no-items-wrapper').text()).toBe(NO_RESULTS);
   });
 
   it('renders a message updating aria-live, if no children', () => {
@@ -237,7 +237,7 @@ describe('NavigatorCard', () => {
     });
     const scroller = wrapper.find(RecycleScroller);
     expect(scroller.isVisible()).toBe(false);
-    expect(wrapper.find('[aria-live="polite"].no-items-wrapper').text()).toBe(NO_CHILDREN);
+    expect(wrapper.find('[aria-live="assertive"].no-items-wrapper').text()).toBe(NO_CHILDREN);
   });
 
   it('renders an error message updating aria-live, when there is an error in fetching', () => {
@@ -247,7 +247,7 @@ describe('NavigatorCard', () => {
         errorFetching: true,
       },
     });
-    expect(wrapper.find('[aria-live="polite"].no-items-wrapper').text()).toBe(ERROR_FETCHING);
+    expect(wrapper.find('[aria-live="assertive"].no-items-wrapper').text()).toBe(ERROR_FETCHING);
     expect(wrapper.find('.filter-wrapper').exists()).toBe(false);
   });
 

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -27,7 +27,15 @@ jest.mock('docc-render/utils/loading');
 
 sessionStorage.get.mockImplementation((key, def) => def);
 
-const { STORAGE_KEYS, FILTER_TAGS, FILTER_TAGS_TO_LABELS } = NavigatorCard.constants;
+const {
+  STORAGE_KEYS,
+  FILTER_TAGS,
+  FILTER_TAGS_TO_LABELS,
+  NO_CHILDREN,
+  NO_RESULTS,
+  ERROR_FETCHING,
+  ITEMS_FOUND,
+} = NavigatorCard.constants;
 
 const RecycleScrollerStub = {
   props: RecycleScroller.props,
@@ -195,6 +203,12 @@ describe('NavigatorCard', () => {
     expect(wrapper.find(FilterInput).props('positionReversed')).toBe(false);
   });
 
+  it('renders aria-live', async () => {
+    const wrapper = createWrapper();
+    const ariaLive = wrapper.find('[aria-live="polite"]');
+    expect(ariaLive.exists()).toBe(true);
+  });
+
   it('hides the RecycleScroller, if no items to show', async () => {
     const wrapper = createWrapper();
     const scroller = wrapper.find(RecycleScroller);
@@ -204,7 +218,7 @@ describe('NavigatorCard', () => {
     expect(scroller.isVisible()).toBe(false);
   });
 
-  it('renders a message, if no items found when filtering', async () => {
+  it('renders a message updating aria-live, if no items found when filtering', async () => {
     const wrapper = createWrapper();
     const scroller = wrapper.find(RecycleScroller);
     expect(scroller.isVisible()).toBe(true);
@@ -212,10 +226,10 @@ describe('NavigatorCard', () => {
     await wrapper.vm.$nextTick();
     expect(scroller.props('items')).toEqual([]);
     expect(scroller.isVisible()).toBe(false);
-    expect(wrapper.find('.no-items-wrapper').text()).toBe('No results matching your filter');
+    expect(wrapper.find('[aria-live="polite"].no-items-wrapper').text()).toBe(NO_RESULTS);
   });
 
-  it('renders a message, if no children', () => {
+  it('renders a message updating aria-live, if no children', () => {
     const wrapper = createWrapper({
       propsData: {
         children: [],
@@ -223,18 +237,29 @@ describe('NavigatorCard', () => {
     });
     const scroller = wrapper.find(RecycleScroller);
     expect(scroller.isVisible()).toBe(false);
-    expect(wrapper.find('.no-items-wrapper').text()).toBe('Technology has no children');
+    expect(wrapper.find('[aria-live="polite"].no-items-wrapper').text()).toBe(NO_CHILDREN);
   });
 
-  it('adds an error message, when there is an error in fetching', () => {
+  it('renders an error message updating aria-live, when there is an error in fetching', () => {
     const wrapper = createWrapper({
       propsData: {
         children: [],
         errorFetching: true,
       },
     });
-    expect(wrapper.find('.no-items-wrapper').text()).toBe('There was an error fetching the data');
+    expect(wrapper.find('[aria-live="polite"].no-items-wrapper').text()).toBe(ERROR_FETCHING);
     expect(wrapper.find('.filter-wrapper').exists()).toBe(false);
+  });
+
+  it('renders an hidden message updating aria-live, notifying how many items were found', async () => {
+    const wrapper = createWrapper();
+    let message = [children.length, ITEMS_FOUND].join(' ');
+    expect(wrapper.find('[aria-live="polite"].visuallyhidden').text()).toBe(message);
+
+    wrapper.find(FilterInput).vm.$emit('input', root0Child1.title);
+    await wrapper.vm.$nextTick();
+    message = [1, ITEMS_FOUND].join(' ');
+    expect(wrapper.find('[aria-live="polite"].visuallyhidden').text()).toBe(message);
   });
 
   it('opens an item, on @toggle', async () => {


### PR DESCRIPTION
Bug/issue #89153793, if applicable: 

## Summary

It adds aria-live regions to NavigationCard so when a VoiceOver user filters the sidenav, they instantly get notified on:
- What content has changed on Sidenav
- If there is no children
- It there is no results
- If there has been an error fetching

## Dependencies

NA

## Testing

Make sure you download and unzip the .doccarchive - [SlothCreator.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8082216/SlothCreator.doccarchive.1.zip)

Steps:

1. run VUE_APP_DEV_SERVER_PROXY=/path/to/SlothCreator.doccarchive npm run serve
2. Enable navigator on theme-settings.json file
3. Visit http://localhost:8080/documentation/slothcreator
4. Open VoiceOver
5. Use the filter input and assert that live region updates you with the correct information described in the summary depending on the sidenav results

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
