### PR TITLE
Fix selecting a tag in the sidebar

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -195,10 +195,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    shouldKeepOpenOnBlur: {
-      type: Boolean,
-      default: true,
-    },
   },
   data() {
     return {
@@ -359,9 +355,9 @@ export default {
       this.setSelectedTags(this.selectedTags.filter(tag => !array.includes(tag)));
     },
     async handleBlur(event) {
-      // if the blur came from clicking a link
+      // if the blur came from clicking a button or the input
       const target = event.relatedTarget;
-      if (this.shouldKeepOpenOnBlur && target && target.matches && target.matches('button, input, ul')) return;
+      if (target && target.matches && target.matches('button, input, ul') && this.$el.contains(target)) return;
       // Wait for mousedown to send event listeners
       await this.$nextTick();
 

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -492,29 +492,21 @@ describe('FilterInput', () => {
       expect(suggestedTags.exists()).toBe(false);
     });
 
-    it('does not hide the tags, if the new focus target matches `input, button`', () => {
-      const buttonTarget = document.createElement('button');
-      const inputTarget = document.createElement('input');
-
+    it('does not hide the tags, if the new focus target matches `input, button`, inside the main component', async () => {
+      const buttonTarget = wrapper.find('button'); // find a button component
       input.trigger('blur', {
-        relatedTarget: buttonTarget,
+        relatedTarget: buttonTarget.element,
       });
-      input.trigger('blur', {
-        relatedTarget: inputTarget,
-      });
-
+      await flushPromises();
       expect(suggestedTags.exists()).toBe(true);
       expect(wrapper.emitted('show-suggested-tags')).toEqual([[true]]);
     });
 
-    it('hides the tags, if new focus matches button or input, if shouldKeepOpenOnBlur=false', async () => {
-      wrapper.setProps({
-        shouldKeepOpenOnBlur: false,
-      });
+    it('hides the tags, if new focus outside component', async () => {
       const inputTarget = document.createElement('input');
 
       input.trigger('blur', {
-        relatedTarget: inputTarget,
+        relatedTarget: inputTarget.element,
       });
 
       await flushPromises();

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -183,7 +183,6 @@ describe('NavigatorCard', () => {
       placeholder: 'Filter in TestKit',
       positionReversed: true,
       preventedBlur: false,
-      shouldKeepOpenOnBlur: false,
       selectedTags: [],
       shouldTruncateTags: false,
       tags: [


### PR DESCRIPTION
Bug/issue #, if applicable: 90162555

## Summary

Fixes a bug with selecting tags with the mouse in the sidebar navigator

## Dependencies

NA

## Testing

Steps:
1. Just try to select a tag in the sidebar

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
