### PR TITLE
Fix navigation gutter spacing on Medium

### DIFF
--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -336,6 +336,10 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
 
   @include nav-is-wide-format($nested: true) {
     --nav-padding: #{$nav-padding-wide};
+
+    @include breakpoint-exact(medium, nav) {
+      --nav-padding: #{$nav-padding};
+    }
   }
 
   &__wrapper {


### PR DESCRIPTION
Bug/issue #, if applicable: 90172898

## Summary

Fixes the nav spacing on Medium.

## Dependencies

NA

## Testing

Steps:
1. Assert the spacing on the Nav on Medium is 22px

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
