### PR TITLE
Fix navigator tag filtering logic - stop showing none-matching children

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -502,13 +502,11 @@ export default {
      */
     generateNodesToRender() {
       const {
-        children, filteredChildren, hasFilter, openNodes, apiChanges,
+        children, filteredChildren, hasFilter, openNodes,
       } = this;
       // create a set of all matches and their parents
       const allChildMatchesSet = new Set(filteredChildren
         .flatMap(({ uid }) => this.getParents(uid)));
-      // create a set of direct matches
-      const filteredChildrenSet = new Set(filteredChildren);
 
       // generate the list of nodes to render
       this.nodesToRender = children
@@ -518,13 +516,8 @@ export default {
             // if parent is the root or parent is open
             return child.parent === INDEX_ROOT_KEY || openNodes[child.parent];
           }
-          const isParentDirectMatch = apiChanges
-            ? false
-            : (openNodes[child.parent] && filteredChildrenSet.has(this.childrenMap[child.parent]));
           // if parent is the root and is in the child match set
           return (child.parent === INDEX_ROOT_KEY && allChildMatchesSet.has(child))
-            // if the parent is open and is a direct filter match
-            || (isParentDirectMatch)
             // if the item itself is a direct match
             || allChildMatchesSet.has(child);
         });

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -358,6 +358,39 @@ describe('NavigatorCard', () => {
     expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledWith(0);
   });
 
+  it('filters items, keeping only direct matches, removing siblings, even if parent is a direct match', async () => {
+    const root0Updated = {
+      ...root0,
+      title: `Second ${root0}`,
+    };
+    const newChildren = [
+      root0Updated,
+      root0Child0,
+      root0Child1,
+      root0Child1GrandChild0,
+      root1,
+    ];
+
+    const wrapper = createWrapper({
+      propsData: {
+        children: newChildren,
+      },
+    });
+    const filter = wrapper.find(FilterInput);
+    await flushPromises();
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(1);
+    // make sure we match at both the top item as well as one of its children
+    filter.vm.$emit('input', 'Second');
+    await flushPromises();
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(2);
+    // assert only the parens of the match are visible
+    const all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(2);
+    expect(all.at(0).props('item')).toEqual(root0Updated);
+    expect(all.at(1).props('item')).toEqual(root0Child1);
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledWith(0);
+  });
+
   it('renders all the children of a directly matched parent', async () => {
     const wrapper = createWrapper();
     const filter = wrapper.find(FilterInput);


### PR DESCRIPTION
Bug/issue #, if applicable: 89588542

## Summary

Fixes the filtering logic of the navigator, stop showing children of a parent, that is a direct match of your current query. It fixes the logic for tags and title filtering. It was already fixed for API changes.

## Dependencies

NA

## Testing

Steps:
1. Type a filter that matches a parent item directly.
2. Assert none of it's children, that dont match the same query are shown.
3. This works the same for Tags. If you pick a tag, it should only show children with the same tag. (Their parents dont count, as they have to be rendered in order to show the children).

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
