### PR TITLE
Fix duplicate path navigation

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -60,6 +60,7 @@
           class="leaf-link"
           :aria-describedby="ariaDescribedBy"
           :tabindex="isRendered ? null : '-1'"
+          @click.native="$emit('navigate', item.uid)"
         >
           <HighlightMatches
             :text="item.title"

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1059,7 +1059,7 @@ describe('NavigatorCard', () => {
       const scroller = wrapper.find({ ref: 'scroller' });
       expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(1);
       // mock the bounding rects
-      const scrollerRect = jest.spyOn(scroller.element, 'getBoundingClientRect').mockReturnValue({
+      jest.spyOn(scroller.element, 'getBoundingClientRect').mockReturnValue({
         y: 10,
         height: 200,
       });

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -13,7 +13,7 @@ import { RouterLinkStub, shallowMount } from '@vue/test-utils';
 import { TopicTypes } from '@/constants/TopicTypes';
 import NavigatorLeafIcon from '@/components/Navigator/NavigatorLeafIcon.vue';
 import HighlightMatches from '@/components/Navigator/HighlightMatches.vue';
-import Reference from '@/components/ContentNode/Reference';
+import Reference from '@/components/ContentNode/Reference.vue';
 
 const {
   Badge,

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -6,13 +6,14 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import NavigatorCardItem from '@/components/Navigator/NavigatorCardItem.vue';
 import { RouterLinkStub, shallowMount } from '@vue/test-utils';
 import { TopicTypes } from '@/constants/TopicTypes';
 import NavigatorLeafIcon from '@/components/Navigator/NavigatorLeafIcon.vue';
 import HighlightMatches from '@/components/Navigator/HighlightMatches.vue';
+import Reference from '@/components/ContentNode/Reference';
 
 const {
   Badge,
@@ -54,13 +55,16 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.find('.navigator-card-item').exists()).toBe(true);
     expect(wrapper.find('button.tree-toggle').exists()).toBe(true);
     expect(wrapper.find(NavigatorLeafIcon).props('type')).toBe(defaultProps.item.type);
-    expect(wrapper.find('.leaf-link').props('url')).toEqual(defaultProps.item.path);
-    expect(wrapper.find('.leaf-link').attributes('id')).toBe(`${defaultProps.item.uid}`);
+    const leafLink = wrapper.find('.leaf-link');
+    expect(leafLink.is(Reference)).toBe(true);
+    expect(leafLink.props('url')).toEqual(defaultProps.item.path);
+    expect(leafLink.attributes('id')).toBe(`${defaultProps.item.uid}`);
     expect(wrapper.find(HighlightMatches).props()).toEqual({
       text: defaultProps.item.title,
       matcher: defaultProps.filterPattern,
     });
-    expect(wrapper.find('.navigator-card-item').attributes('id')).toBe(`container-${defaultProps.item.uid}`);
+    expect(wrapper.find('.navigator-card-item').attributes('id'))
+      .toBe(`container-${defaultProps.item.uid}`);
   });
 
   it('renders a deprecated badge when item is deprecated', () => {
@@ -136,6 +140,12 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.emitted('toggle')).toEqual([[defaultProps.item]]);
   });
 
+  it('emits an event, when clicking on the leaf-link', () => {
+    const wrapper = createWrapper();
+    wrapper.find('.leaf-link').trigger('click');
+    expect(wrapper.emitted('navigate')).toEqual([[defaultProps.item.uid]]);
+  });
+
   describe('AX', () => {
     it('applies aria-hidden to NavigatorCardItem if isRendered is false', () => {
       const wrapper = createWrapper({
@@ -201,7 +211,8 @@ describe('NavigatorCardItem', () => {
       const wrapper = createWrapper();
       const label = wrapper.find(`#label-${defaultProps.item.uid}`);
       expect(label.attributes('hidden')).toBe('hidden');
-      expect(label.text()).toBe(`${defaultProps.item.index + 1} of ${defaultProps.item.siblingsCount} symbols inside`);
+      expect(label.text())
+        .toBe(`${defaultProps.item.index + 1} of ${defaultProps.item.siblingsCount} symbols inside`);
     });
 
     it('renders a hidden span telling the containing number of symbols', () => {
@@ -220,12 +231,14 @@ describe('NavigatorCardItem', () => {
           },
         },
       });
-      expect(wrapper.find('.leaf-link').attributes('aria-describedby')).toBe(`label-${defaultProps.item.uid} ${defaultProps.item.parent}`);
+      expect(wrapper.find('.leaf-link').attributes('aria-describedby'))
+        .toBe(`label-${defaultProps.item.uid} ${defaultProps.item.parent}`);
     });
 
     it('renders a aria-describedby in the leaf-link including the parent label if is parent', () => {
       const wrapper = createWrapper();
-      expect(wrapper.find('.leaf-link').attributes('aria-describedby')).toBe(`label-${defaultProps.item.uid} ${defaultProps.item.parent} label-parent-${defaultProps.item.uid}`);
+      expect(wrapper.find('.leaf-link').attributes('aria-describedby'))
+        .toBe(`label-${defaultProps.item.uid} ${defaultProps.item.parent} label-parent-${defaultProps.item.uid}`);
     });
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 89718125

## Summary

Allows navigating to items in the navigator, that have the same path as the currently open item.

## Dependencies

NA

## Testing

You need a doccarchive that has duplication in the children, inside the tree. You can use the attached one.

[SlothCreator.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8244846/SlothCreator.doccarchive.zip)

Steps:
1. Serve the app using the above doccarchive
2. Navigate to `Sloth > Sloth Generator > func generateSloth`
3. Assert item is highlighted, and its parents
4. Navigate to `Sloth Generator > func generateSloth`
5. Assert item is highlighted and its parents. The previous item is not collapsed. 
6. Navigate back/forward and assert they are properly highlighted
7. Refresh the page
8. Assert highlighting continues
9. Assert that open items are kept open
10. Assert that when navigating links in the page content, the sidebar properly highlights them.
11. Assert that links that are in the viewport and dont need scrolling to get highlighted, do not cause the navigator to adjust scroll position.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
