### PR TITLE
Allow disabling the filter clear on FilterInput tag selection

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -195,6 +195,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    clearFilterOnTagSelect: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -68,6 +68,7 @@
             :placeholder="`Filter in ${technology}`"
             :should-keep-open-on-blur="false"
             :position-reversed="isLargeBreakpoint"
+            :clear-filter-on-tag-select="false"
             class="filter-component"
             @clear="clearFilters"
           />

--- a/src/mixins/multipleSelection.js
+++ b/src/mixins/multipleSelection.js
@@ -55,6 +55,7 @@ export default {
 
     selectTag(tag) {
       this.updateSelectedTags([tag]);
+      if (!this.clearFilterOnTagSelect) return;
       this.setFilterInput('');
     },
 

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -565,10 +565,21 @@ describe('FilterInput', () => {
       });
     });
 
-    it('adds tag to `selectedTags` when it is clicked', () => {
+    it('adds tag to `selectedTags` when it is clicked, clearing the filter', () => {
       const selectedTag = 'Tag1';
       suggestedTags.vm.$emit('click-tags', { tagName: selectedTag });
       expect(wrapper.emitted('update:selectedTags')).toEqual([[[selectedTag]]]);
+      expect(wrapper.emitted('input')).toEqual([['']]);
+    });
+
+    it('adds tag to `selectedTags` when it is clicked, without clearing the filter', () => {
+      wrapper.setProps({
+        clearFilterOnTagSelect: false,
+      });
+      const selectedTag = 'Tag1';
+      suggestedTags.vm.$emit('click-tags', { tagName: selectedTag });
+      expect(wrapper.emitted('update:selectedTags')).toEqual([[[selectedTag]]]);
+      expect(wrapper.emitted('input')).toBeFalsy();
     });
 
     describe('when a tag is selected', () => {

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -191,6 +191,7 @@ describe('NavigatorCard', () => {
         'Articles',
       ],
       value: '',
+      clearFilterOnTagSelect: false,
     });
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 89796778

## Summary

Allows disabling the `clear on tag selection` feature in the FilterInput. This should allow the Navigator filter to apply tags, without clearing your query.

## Dependencies

NA

## Testing

Steps:
1. Go to a page with a navigator
2. Apply a title filter
3. Pick a Tag
4. Assert the filter is not removed

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
