### PR TITLE
Improve focus handling from scroller re-rendering all items and losing focus

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -614,13 +614,16 @@ export default {
         this.$refs.scroller.scrollToItem(index);
       }
     },
+    isInsideScroller(element) {
+      return this.$refs.scroller.$el.contains(element);
+    },
     handleFocusIn(event) {
       this.lastFocusTarget = event.target;
     },
     handleFocusOut(event) {
       if (!event.relatedTarget) return;
       // reset the `lastFocusTarget`, if the focsOut target is not in the scroller
-      if (!this.$refs.scroller.$el.contains(event.relatedTarget)) {
+      if (!this.isInsideScroller(event.relatedTarget)) {
         this.lastFocusTarget = null;
       }
     },
@@ -630,7 +633,7 @@ export default {
       if (
         !this.lastFocusTarget
         // check if the lastFocusTarget is inside the scroller. (can happen if we scroll to fast)
-        || !this.$refs.scroller.$el.contains(this.lastFocusTarget)
+        || !this.isInsideScroller(this.lastFocusTarget)
         // check if the activeElement is identical to the lastFocusTarget
         || document.activeElement === this.lastFocusTarget
       ) {

--- a/src/utils/loading.js
+++ b/src/utils/loading.js
@@ -30,3 +30,9 @@ export function waitFrames(numFrames) {
   });
   return promise;
 }
+
+export function waitFor(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1092,6 +1092,7 @@ describe('NavigatorCard', () => {
   describe('handles focus/blur state issues with the RecycleScroller', () => {
     it('keeps track of the currently focused item', async () => {
       const wrapper = createWrapper();
+      await flushPromises();
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
       button.trigger('focusin');
@@ -1101,6 +1102,7 @@ describe('NavigatorCard', () => {
 
     it('resets the `lastFocusTarget`, if the related target is outside the scroller', async () => {
       const wrapper = createWrapper();
+      await flushPromises();
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
       button.trigger('focusin');
@@ -1113,6 +1115,7 @@ describe('NavigatorCard', () => {
 
     it('does not do anything, if there is no `relatedTarget`, if no relatedTarget', async () => {
       const wrapper = createWrapper();
+      await flushPromises();
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
       button.trigger('focusin');
@@ -1126,6 +1129,7 @@ describe('NavigatorCard', () => {
 
     it('on RecycleScroller@update, does nothing, if there is no focusTarget', async () => {
       const wrapper = createWrapper();
+      await flushPromises();
       wrapper.find(RecycleScroller).vm.$emit('update');
       await flushPromises();
       expect(waitFor).toHaveBeenLastCalledWith(300);
@@ -1134,6 +1138,7 @@ describe('NavigatorCard', () => {
 
     it('on RecycleScroller@update, does nothing, if focusTarget is outside scroller', async () => {
       const wrapper = createWrapper();
+      await flushPromises();
       // Set the focus item to be something outside the scroller.
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
@@ -1158,6 +1163,7 @@ describe('NavigatorCard', () => {
 
     it('on RecycleScroller@update, does nothing, if `lastFocusTarget === activeElement`', async () => {
       const wrapper = createWrapper();
+      await flushPromises();
       // Set the focus item to be something outside the scroller.
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
@@ -1177,6 +1183,7 @@ describe('NavigatorCard', () => {
 
     it('on RecycleScroller@update, re-focuses the `lastFocusTarget` if not the current focus item', async () => {
       const wrapper = createWrapper();
+      await flushPromises();
       // Set the focus item to be something outside the scroller.
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
@@ -1192,6 +1199,7 @@ describe('NavigatorCard', () => {
 
     it('clears the focusTarget on filter', async () => {
       const wrapper = createWrapper();
+      await flushPromises();
       // Set the focus item to be something outside the scroller.
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
@@ -1211,6 +1219,7 @@ describe('NavigatorCard', () => {
 
     it('clears the focusTarget on page nav', async () => {
       const wrapper = createWrapper();
+      await flushPromises();
       // Set the focus item to be something outside the scroller.
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -19,6 +19,7 @@ import { sessionStorage } from 'docc-render/utils/storage';
 import Reference from '@/components/ContentNode/Reference.vue';
 import FilterInput from '@/components/Filter/FilterInput.vue';
 import { BreakpointName } from '@/utils/breakpoints';
+import { waitFor } from '@/utils/loading';
 import { flushPromises } from '../../../../test-utils';
 
 jest.mock('docc-render/utils/debounce', () => jest.fn(fn => fn));
@@ -132,6 +133,7 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(NavigatorC
   },
   stubs: {
     RecycleScroller: RecycleScrollerStub,
+    NavigatorCardItem,
   },
   sync: false,
   ...others,
@@ -833,5 +835,147 @@ describe('NavigatorCard', () => {
     filter.vm.$emit('update:selectedTags', [FILTER_TAGS_TO_LABELS.articles]);
     await flushPromises();
     expect(filter.props('tags')).toEqual([]);
+  });
+
+  describe('handles focus/blur state issues with the RecycleScroller', () => {
+    it('keeps track of the currently focused item', async () => {
+      const wrapper = createWrapper();
+      const button = wrapper.find(NavigatorCardItem).find('button');
+      // should be focus, but jsdom does not propagate that
+      button.trigger('focusin');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.lastFocusTarget).toEqual(button.element);
+    });
+
+    it('resets the `lastFocusTarget`, if the related target is outside the scroller', async () => {
+      const wrapper = createWrapper();
+      const button = wrapper.find(NavigatorCardItem).find('button');
+      // should be focus, but jsdom does not propagate that
+      button.trigger('focusin');
+      await wrapper.vm.$nextTick();
+      button.trigger('focusout', {
+        relatedTarget: document.body,
+      });
+      expect(wrapper.vm.lastFocusTarget).toEqual(null);
+    });
+
+    it('does not do anything, if there is no `relatedTarget`, if no relatedTarget', async () => {
+      const wrapper = createWrapper();
+      const button = wrapper.find(NavigatorCardItem).find('button');
+      // should be focus, but jsdom does not propagate that
+      button.trigger('focusin');
+      await wrapper.vm.$nextTick();
+      button.trigger('focusout', {
+        relatedTarget: null,
+      });
+      // assert we are still focusing the button
+      expect(wrapper.vm.lastFocusTarget).toEqual(button.element);
+    });
+
+    it('on RecycleScroller@update, does nothing, if there is no focusTarget', async () => {
+      const wrapper = createWrapper();
+      wrapper.find(RecycleScroller).vm.$emit('update');
+      await flushPromises();
+      expect(waitFor).toHaveBeenLastCalledWith(300);
+      expect(wrapper.vm.lastFocusTarget).toEqual(null);
+    });
+
+    it('on RecycleScroller@update, does nothing, if focusTarget is outside scroller', async () => {
+      const wrapper = createWrapper();
+      // Set the focus item to be something outside the scroller.
+      // This might happen if it deletes an item, that was in focus
+      const button = wrapper.find(NavigatorCardItem).find('button');
+      // should be focus, but jsdom does not propagate that
+      button.trigger('focusin');
+      const focusSpy = jest.spyOn(button.element, 'focus');
+      await flushPromises();
+      // now make the component go away
+      wrapper.setData({
+        nodesToRender: [],
+      });
+      await flushPromises();
+      // trigger an update
+      wrapper.find(RecycleScroller).vm.$emit('update');
+      await flushPromises();
+      expect(waitFor).toHaveBeenLastCalledWith(300);
+      // we may still have the lastFocusTarget, as it did not emit a focusOut
+      expect(wrapper.vm.lastFocusTarget).not.toEqual(null);
+      // but the spy will not be called, because its no longer in the DOM
+      expect(focusSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('on RecycleScroller@update, does nothing, if `lastFocusTarget === activeElement`', async () => {
+      const wrapper = createWrapper();
+      // Set the focus item to be something outside the scroller.
+      // This might happen if it deletes an item, that was in focus
+      const button = wrapper.find(NavigatorCardItem).find('button');
+      // should be focus, but jsdom does not propagate that
+      button.trigger('focusin');
+      button.element.focus();
+      // move the spy below the manual focus, so we dont count it
+      const focusSpy = jest.spyOn(button.element, 'focus');
+      await flushPromises();
+      expect(document.activeElement).toEqual(button.element);
+      // trigger an update
+      wrapper.find(RecycleScroller).vm.$emit('update');
+      await flushPromises();
+      expect(wrapper.vm.lastFocusTarget).toEqual(button.element);
+      expect(focusSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('on RecycleScroller@update, re-focuses the `lastFocusTarget` if not the current focus item', async () => {
+      const wrapper = createWrapper();
+      // Set the focus item to be something outside the scroller.
+      // This might happen if it deletes an item, that was in focus
+      const button = wrapper.find(NavigatorCardItem).find('button');
+      const focusSpy = jest.spyOn(button.element, 'focus');
+      button.trigger('focusin');
+      await flushPromises();
+      // trigger an update
+      wrapper.find(RecycleScroller).vm.$emit('update');
+      await flushPromises();
+      expect(wrapper.vm.lastFocusTarget).toEqual(button.element);
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the focusTarget on filter', async () => {
+      const wrapper = createWrapper();
+      // Set the focus item to be something outside the scroller.
+      // This might happen if it deletes an item, that was in focus
+      const button = wrapper.find(NavigatorCardItem).find('button');
+      // should be focus, but jsdom does not propagate that
+      button.trigger('focusin');
+      const focusSpy = jest.spyOn(button.element, 'focus');
+      await flushPromises();
+      // initiate a filter
+      wrapper.find(FilterInput).vm.$emit('input', 'Child');
+      await flushPromises();
+      // trigger an update
+      wrapper.find(RecycleScroller).vm.$emit('update');
+      await flushPromises();
+      expect(wrapper.vm.lastFocusTarget).toEqual(null);
+      expect(focusSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('clears the focusTarget on page nav', async () => {
+      const wrapper = createWrapper();
+      // Set the focus item to be something outside the scroller.
+      // This might happen if it deletes an item, that was in focus
+      const button = wrapper.find(NavigatorCardItem).find('button');
+      // should be focus, but jsdom does not propagate that
+      button.trigger('focusin');
+      const focusSpy = jest.spyOn(button.element, 'focus');
+      await flushPromises();
+      // simulate a page nav
+      wrapper.setProps({
+        activePath: [root1.path],
+      });
+      await flushPromises();
+      // trigger an update
+      wrapper.find(RecycleScroller).vm.$emit('update');
+      await flushPromises();
+      expect(wrapper.vm.lastFocusTarget).toEqual(null);
+      expect(focusSpy).toHaveBeenCalledTimes(0);
+    });
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 90321277

## Summary

Refactors the focus handling on the RecycleScroller, in instances where it updates the elements, from open/close events or from scrolling the virtual scroller.

## Dependencies

NA

## Testing

Serve the app with a doccarchive that has the navigator data

Steps:
1. Using only the keyboard, start navigating with Tabbing across the items.
2. Once you focus one of the last items at the end of the screen, it will jump to the next one, moving it to the center of the scrollable area
3. Assert that focus is still kept on the item. (we used to loose focus on that element here)
4. Assert that after focusing, initiating a filter (by tag or text) resets the focus order. (try to focus back into the items)
5. Assert that clicking on items and navigating to their page, focus is still kept on it.
6. Assert that after focusing, somewhere inside the content moves the focus away from the navigator.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
