### PR TITLE
Properly limit the tags on the FilterInput

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -237,8 +237,8 @@ export default {
       const suggestedTags = tags.filter(tag => !selectedTags.includes(tag));
 
       return shouldTruncateTags
-        ? suggestedTags
-        : suggestedTags.slice(0, TagLimit);
+        ? suggestedTags.slice(0, TagLimit)
+        : suggestedTags;
     },
     displaySuggestedTags: ({ showSuggestedTags, suggestedTags }) => (
       showSuggestedTags && suggestedTags.length > 0

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -36,6 +36,7 @@ jest.mock('@/utils/input-helper', () => ({
 const {
   SuggestedTagsId,
   FilterInputId,
+  TagLimit,
 } = FilterInput.constants;
 
 describe('FilterInput', () => {
@@ -435,6 +436,18 @@ describe('FilterInput', () => {
 
       suggestedTags = wrapper.find({ ref: 'suggestedTags' });
       deleteButton = wrapper.find('.filter__delete-button');
+    });
+
+    it('limits the amount of rendered, if `shouldTruncateTags` is `true`', () => {
+      const newTags = ['a', 'b', 'c', 'd', 'e', 'f'];
+      wrapper.setProps({
+        tags: newTags,
+      });
+      expect(suggestedTags.props('tags')).toEqual(newTags);
+      wrapper.setProps({
+        shouldTruncateTags: true,
+      });
+      expect(suggestedTags.props('tags')).toEqual(newTags.slice(0, TagLimit));
     });
 
     it('renders `deleteButton` when there are tags and they are shown', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 90383936

## Summary

This fixes the logic to truncate the suggestedTags inside the FilterInput.

## Dependencies

NA

## Testing

Steps:
1. Make sure the FilterInput should never show more than 5 items, when ShouldTruncateTags is true.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
