### PR TITLE
[Regression] In sidenav input loses focus after updating the results

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -55,6 +55,7 @@
               :expanded="openNodes[item.uid]"
               :api-change="apiChangesObject[item.path]"
               :isFocused="focusedIndex === index"
+              :lastFocusWasInside="lastFocusWasInside"
               @toggle="toggle"
               @toggle-full="toggleFullTree"
               @navigate="setActiveUID"
@@ -332,6 +333,9 @@ export default {
     isLargeBreakpoint: ({ breakpoint }) => breakpoint === BreakpointName.large,
     hasNodes: ({ nodesToRender }) => !!nodesToRender.length,
     totalItemsToNavigate: ({ nodesToRender }) => nodesToRender.length,
+    lastFocusWasInside: ({ isInsideScroller, lastFocusTarget }) => (
+      isInsideScroller(lastFocusTarget)
+    ),
   },
   created() {
     this.restorePersistedState();
@@ -658,7 +662,7 @@ export default {
       this.$refs.scroller.scrollToItem(index);
     },
     isInsideScroller(element) {
-      return this.$refs.scroller.$el.contains(element);
+      return this.$refs.scroller ? this.$refs.scroller.$el.contains(element) : false;
     },
     handleFocusIn(event) {
       this.lastFocusTarget = event.target;

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -136,6 +136,10 @@ export default {
       type: Boolean,
       default: () => false,
     },
+    lastFocusWasInside: {
+      type: Boolean,
+      default: () => false,
+    },
   },
   computed: {
     isGroupMarker: ({ item: { type } }) => type === TopicTypes.groupMarker,
@@ -168,7 +172,7 @@ export default {
   },
   watch: {
     isFocused(newVal) {
-      if (newVal) {
+      if (newVal && this.lastFocusWasInside) {
         this.selfFocus();
       }
     },

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -176,6 +176,7 @@ describe('NavigatorCard', () => {
       isBold: true,
       item: root0,
       apiChange: null,
+      lastFocusWasInside: false,
     });
     // assert no-items-wrapper
     expect(wrapper.find('.no-items-wrapper').exists()).toBe(true);
@@ -196,6 +197,14 @@ describe('NavigatorCard', () => {
       ],
       value: '',
     });
+  });
+
+  it('renders lastFocusWasInside as true when last focus was inside the component', async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+    const scroller = wrapper.find(RecycleScroller);
+    scroller.trigger('focusin');
+    expect(wrapper.vm.lastFocusWasInside).toBe(true);
   });
 
   it('focuses the current page', async () => {
@@ -341,6 +350,7 @@ describe('NavigatorCard', () => {
       filterPattern: null,
       isRendered: false,
       apiChange: null,
+      lastFocusWasInside: false,
     });
     unopenedItem.vm.$emit('toggle', item);
     await wrapper.vm.$nextTick();
@@ -958,6 +968,7 @@ describe('NavigatorCard', () => {
         isFocused: false,
         isRendered: false, // this is not passed in the mock
         item: root0Child1,
+        lastFocusWasInside: false,
       });
       // assert item is scrolled to
       expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenLastCalledWith(2); // 3-rd item
@@ -979,6 +990,7 @@ describe('NavigatorCard', () => {
         isFocused: false,
         isRendered: false, // this is not passed in the mock
         item: root0Child1,
+        lastFocusWasInside: false,
       });
     });
 

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -213,6 +213,23 @@ describe('NavigatorCardItem', () => {
       expect(wrapper.attributes('tabindex')).toBe('0');
     });
 
+    it('does not focus component if last focus was not inside the component', () => {
+      const wrapper = createWrapper();
+      wrapper.setProps({
+        isFocused: true,
+      });
+      expect(document.activeElement).not.toEqual(wrapper.element);
+    });
+
+    it('focus component if last focus was inside the component', () => {
+      const wrapper = createWrapper();
+      wrapper.setProps({
+        lastFocusWasInside: true,
+        isFocused: true,
+      });
+      expect(document.activeElement).toEqual(wrapper.element);
+    });
+
     it('renders tabindex -1 in button and reference', () => {
       const wrapper = createWrapper();
       const button = wrapper.find('.tree-toggle');


### PR DESCRIPTION
Bug/issue #90432388, if applicable: 

## Summary

In sidenav input loses focus after updating the results

## Dependencies

NA

## Testing

Steps:
1. Run any sidenav documentation
2. Search on filter input
3. Assert that when typing, focus doesn't go to sidenav
4. Assert that sidenav keyboard actions work properly

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
