### PR TITLE
Change styling of selected/hover item states for sidenav items

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -865,7 +865,6 @@ $filter-height: 64px;
   --card-horizontal-spacing: #{$navigator-card-horizontal-spacing};
   --card-vertical-spacing: #{$navigator-card-vertical-spacing};
 
-  padding: 0 var(--card-horizontal-spacing);
   // right padding is added by the items, so visually the scroller is stuck to the side
   padding-right: 0;
   flex: 1 1 auto;
@@ -920,7 +919,6 @@ $filter-height: 64px;
   height: 100%;
   box-sizing: border-box;
   padding: var(--card-vertical-spacing) 0;
-  padding-right: var(--card-horizontal-spacing);
 }
 
 .filter-wrapper {

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -211,7 +211,7 @@ $item-height: 32px;
   position: relative;
   display: flex;
   align-items: center;
-  border-radius: $border-radius;
+  padding-left: calc(var(--card-horizontal-spacing) / 2);
   flex: 1;
   min-width: 0;
   height: 100%;

--- a/src/styles/core/_nav.scss
+++ b/src/styles/core/_nav.scss
@@ -13,7 +13,7 @@ $nav-height: rem(52px);
 $nav-height-small: rem(48px);
 $nav-padding: rem(22px);
 $nav-padding-small: rem(16px);
-$nav-padding-wide: rem(30px);
+$nav-padding-wide: rem(20px);
 $nav-menu-item-left-margin: rem(24px);
 $nav-timingfunction: ease-in !default;
 $nav-menu-tray-transition: max-height 0.4s $nav-timingfunction 0s, visibility 0s linear 1s !default;


### PR DESCRIPTION
Bug/issue #89558736, if applicable: 

## Summary

- [x] We should no longer aim for a rounded radius.
- [x] Selected and hover state of items should span the full width of the sidebar.
- [x] The top level items in the sidebar should also be aligned with the top level technology title.

## Dependencies

NA

## Testing

Steps:
1. Run `npm run serve` with your documentation
2. Enable sidenav
3. Assert that summary list is correct  

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests (not needed)
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary