### PR TITLE
Fix the assumed filter height for the NavigatorCard

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -775,7 +775,8 @@ export default {
 
 $navigator-card-horizontal-spacing: 20px !default;
 $navigator-card-vertical-spacing: 8px !default;
-$filter-height: 64px;
+// unfortunately we need to hard-code the filter height
+$filter-height: 71px;
 
 .navigator-card {
   display: flex;
@@ -888,7 +889,7 @@ $filter-height: 64px;
   box-sizing: border-box;
   padding: 14px 30px;
   border-top: 1px solid var(--color-grid);
-  height: 71px;
+  height: $filter-height;
   display: flex;
   align-items: flex-end;
 


### PR DESCRIPTION
Bug/issue #, if applicable: 90601855

## Summary

Fixes a small spacing issue with the cutoff from the filter height.

## Dependencies

NA

## Testing

Steps:
1. Serve the app and go to a page with a navigator
2. Assert that when scrolling to the bottom of the navigator (you need a few expanded children), all items are fully visible.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - no need, CSS only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
