### PR TITLE
Make sure navigator properly highlights the current page

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -40,7 +40,7 @@
             >
               <template #default="slotProps">
                 <Navigator
-                  :parent-topic-identifiers="navigatorParentTopicIdentifiers"
+                  :parent-topic-identifiers="parentTopicIdentifiers"
                   :technology="slotProps.technology || technology"
                   :is-fetching="slotProps.isFetching"
                   :error-fetching="slotProps.errorFetching"
@@ -197,9 +197,6 @@ export default {
     // hierarchy/breadcrumb for a given topic. We choose to render only the
     // first one.
     parentTopicIdentifiers: ({ topicProps: { hierarchy: { paths: [ids = []] = [] } } }) => ids,
-    navigatorParentTopicIdentifiers: ({ topicProps: { hierarchy: { paths = [] } } }) => (
-      paths.slice(-1)[0]
-    ),
     technology: ({
       $route,
       topicProps: {

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import * as dataUtils from 'docc-render/utils/data';
 import { shallowMount } from '@vue/test-utils';
@@ -92,6 +92,10 @@ const topicData = {
         'topic://foo',
         'topic://bar',
       ],
+      [
+        'topic://baz',
+        'topic://baq',
+      ],
     ],
   },
   variants: [
@@ -163,6 +167,7 @@ describe('DocumentationTopic', () => {
     expect(navigator.props()).toEqual({
       errorFetching: false,
       isFetching: true,
+      // assert we are passing the first set of paths always
       parentTopicIdentifiers: topicData.hierarchy.paths[0],
       references: topicData.references,
       scrollLockID: AdjustableSidebarWidth.constants.SCROLL_LOCK_ID,

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import * as dataUtils from 'docc-render/utils/data';
 import { shallowMount } from '@vue/test-utils';


### PR DESCRIPTION
Bug/issue #, if applicable: 90717877

## Summary

Fixes an issue, where the navigator cannot highlight the current page.

This was because I was passing the last, more detailed set of paths from the `hierarchy`, but that may not always point to the same technology as we are on now.

This means that if a page is linked to from many places in your docs, upon first visit of the page, we will try to match it with the shortest path, which matches the nav breadcrumbs.

## Dependencies

NA

## Testing

[SlothCreator.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8339480/SlothCreator.doccarchive.zip)



Steps:
1. Mount with the provided archive
2. Go to http://localhost:8080/documentation/slothcreator/namegenerator/generatename(seed:)
3. Assert the page is properly highlighted in the navigator, using the same path as the breadcrumbs.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
