### PR TITLE
Make sure the navigator mobile overlay does not hide potential custom top navigators

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -17,7 +17,7 @@
     >
       <div
         :class="asideClasses"
-        :style="{ width: widthInPx }"
+        :style="{ width: widthInPx, '--top-offset': `${mobileTopOffset}px` }"
         class="aside"
         ref="aside"
         @transitionstart="isTransitioning = true"
@@ -53,6 +53,7 @@ import scrollLock from 'docc-render/utils/scroll-lock';
 import FocusTrap from 'docc-render/utils/FocusTrap';
 import changeElementVOVisibility from 'docc-render/utils/changeElementVOVisibility';
 import throttle from 'docc-render/utils/throttle';
+import { baseNavStickyAnchorId } from 'docc-render/constants/nav';
 
 export const STORAGE_KEY = 'sidebar';
 
@@ -125,6 +126,7 @@ export default {
       noTransition: false,
       isTransitioning: false,
       focusTrapInstance: null,
+      mobileTopOffset: 0,
     };
   },
   computed: {
@@ -256,6 +258,13 @@ export default {
       this.$emit('width-change', width);
     },
     handleExternalOpen(isOpen) {
+      if (isOpen) {
+        const stickyNavAnchor = document.getElementById(baseNavStickyAnchorId);
+        if (stickyNavAnchor) {
+          const { y } = stickyNavAnchor.getBoundingClientRect();
+          this.mobileTopOffset = Math.max(y, 0);
+        }
+      }
       this.toggleScrollLock(isOpen);
     },
     /**
@@ -313,11 +322,11 @@ export default {
     overflow: hidden;
     min-width: 0;
     max-width: 100%;
-    height: 100vh;
+    height: calc(100vh - var(--top-offset));
     position: fixed;
-    top: 0;
+    top: var(--top-offset);
     bottom: 0;
-    z-index: 9999;
+    z-index: $nav-z-index;
     transform: translateX(-100%);
     transition: transform 0.15s ease-in;
 

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -319,7 +319,7 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   top: 0;
   width: 100%;
   height: $nav-height;
-  z-index: 9997;
+  z-index: $nav-z-index;
   --nav-padding: #{$nav-padding};
 
   @include breakpoint(small, $scope: nav) {

--- a/src/styles/core/_nav.scss
+++ b/src/styles/core/_nav.scss
@@ -24,6 +24,7 @@ $nav-menu-item-stagger-delay: 0s !default;
 $nav-bg-color-transition: 0.5s $nav-timingfunction !default;
 $nav-space-between-elements: rem(10px);
 $nav-space-hierarchy-elements: rem(3px);
+$nav-z-index: 9997;
 
 @mixin nav-in-breakpoint($nested: false) {
   @include unify-selector('.nav--in-breakpoint-range', $nested) {

--- a/tests/unit/components/AdjustableSidebarWidth.spec.js
+++ b/tests/unit/components/AdjustableSidebarWidth.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import AdjustableSidebarWidth, {
   eventsMap,

--- a/tests/unit/components/AdjustableSidebarWidth.spec.js
+++ b/tests/unit/components/AdjustableSidebarWidth.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import AdjustableSidebarWidth, {
   eventsMap,
@@ -22,6 +22,7 @@ import FocusTrap from '@/utils/FocusTrap';
 import scrollLock from 'docc-render/utils/scroll-lock';
 import changeElementVOVisibility from 'docc-render/utils/changeElementVOVisibility';
 import { BreakpointName, BreakpointScopes } from '@/utils/breakpoints';
+import { baseNavStickyAnchorId } from '@/constants/nav';
 import { createEvent, flushPromises } from '../../../test-utils';
 
 jest.mock('docc-render/utils/debounce');
@@ -154,6 +155,13 @@ describe('AdjustableSidebarWidth', () => {
   });
 
   describe('external open', () => {
+    const navStickyElement = document.createElement('DIV');
+    navStickyElement.id = baseNavStickyAnchorId;
+    const boundingClientSpy = jest.spyOn(navStickyElement, 'getBoundingClientRect')
+      .mockReturnValue({ y: 22 });
+
+    document.body.appendChild(navStickyElement);
+
     it('allows opening the sidebar externally', async () => {
       const wrapper = createWrapper();
       await flushPromises();
@@ -168,6 +176,9 @@ describe('AdjustableSidebarWidth', () => {
       await flushPromises();
       // assert open class attached
       expect(aside.classes()).toContain('force-open');
+      // assert `mobileTopOffset` is the same as the `navStickyElement` `y` offset.
+      expect(wrapper.vm.mobileTopOffset).toBe(22);
+      expect(boundingClientSpy).toHaveBeenCalledTimes(1);
       // assert scroll lock and other helpers initiated
       expect(scrollLock.lockScroll).toHaveBeenCalledWith(scrollLockTarget);
       expect(changeElementVOVisibility.hide).toHaveBeenCalledWith(aside.element);
@@ -183,6 +194,22 @@ describe('AdjustableSidebarWidth', () => {
       expect(changeElementVOVisibility.show).toHaveBeenCalledWith(aside.element);
       expect(FocusTrap.mock.results[0].value.start).toHaveBeenCalledTimes(1);
       expect(FocusTrap.mock.results[0].value.stop).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not set a negative `mobileTopOffset`, if scrolled passed the nav', async () => {
+      boundingClientSpy.mockReturnValue({ y: -50 });
+      const wrapper = createWrapper();
+      await flushPromises();
+      // assert not open
+      const aside = wrapper.find('.aside');
+      // trigger opening externally
+      wrapper.setProps({ openExternally: true });
+      await flushPromises();
+      // assert open class attached
+      expect(aside.classes()).toContain('force-open');
+      // assert `mobileTopOffset` is 0, if `navStickyElement.y` is negative
+      expect(wrapper.vm.mobileTopOffset).toBe(0);
+      expect(boundingClientSpy).toHaveBeenCalledTimes(1);
     });
 
     it('allows closing the sidebar, with Esc', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 89903794

## Summary

This fix prevents the navigator mobile overlay from overlaying potential third party content, above the nav.

## Dependencies

NA

## Testing

Steps:
1. Open/close the navigator on mobile screen size
2. Assert it's not cutoff at the top/bottom, nothing from the background is shining through.
3. Try to add a custom element in the `header` slot in App.vue and assert the overlay does not step over it.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
