### PR TITLE
Keyboard navigation should scroll instead of jumping back to center the view

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -922,6 +922,7 @@ $filter-height: 64px;
   box-sizing: border-box;
   padding: var(--card-vertical-spacing) 0;
   padding-right: var(--card-horizontal-spacing);
+  scroll-behavior: smooth;
 }
 
 .filter-wrapper {


### PR DESCRIPTION
Bug/issue #90601877, if applicable: 

## Summary

Keyboard navigation should scroll instead of jumping back to center the view

## Dependencies

NA

## Testing

Steps:
1. Open a documentation with sidenav and enable sidenav
2. Tab and move with the keyboard thought the items
3. Assert that it smoothly scroll the sidenav

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests (Not needed)
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
