### PR TITLE
Prevent arrows from animating, when scrolling too fast

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -196,8 +196,8 @@ export default {
       }
     },
     async expanded() {
-      // wait a few frames for animations queues to finish
-      await waitFrames(8);
+      // wait for 9 frames (60hz * 0.15ms = 9), for animations queues to finish.
+      await waitFrames(9);
       // set the opening animation as ended
       this.idState.isOpening = false;
     },

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -179,6 +179,7 @@ export default {
       this.$emit('toggle-full', this.item);
     },
     toggleSiblings() {
+      this.idState.isOpening = true;
       this.$emit('toggle-siblings', this.item);
     },
     clickReference() {

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -197,6 +197,19 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.find('.icon-inline').classes()).not.toContain('animating');
   });
 
+  it('adds a temporary `animating` class, on `@toggle-siblings`', async () => {
+    const wrapper = createWrapper();
+    wrapper.find('.tree-toggle').trigger('click', { metaKey: true });
+    expect(wrapper.emitted('toggle-siblings')).toEqual([[defaultProps.item]]);
+    // assert it adds the animating class
+    expect(wrapper.find('.icon-inline').classes()).toContain('animating');
+    wrapper.setProps({ expanded: true });
+    expect(wrapper.find('.icon-inline').classes()).toContain('animating');
+    await flushPromises();
+    // assert we have waited a few frames
+    expect(wrapper.find('.icon-inline').classes()).not.toContain('animating');
+  });
+
   it('renders the API change icon instead of the leaf icon', () => {
     const wrapper = createWrapper({
       propsData: {

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -14,6 +14,10 @@ import { TopicTypes } from '@/constants/TopicTypes';
 import NavigatorLeafIcon from '@/components/Navigator/NavigatorLeafIcon.vue';
 import HighlightMatches from '@/components/Navigator/HighlightMatches.vue';
 import Reference from '@/components/ContentNode/Reference.vue';
+import { waitFrames } from 'docc-render/utils/loading';
+import { flushPromises } from '../../../../test-utils';
+
+jest.mock('docc-render/utils/loading');
 
 const {
   Badge,
@@ -50,6 +54,9 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(NavigatorC
 });
 
 describe('NavigatorCardItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it('renders the NavigatorCardItem', () => {
     const wrapper = createWrapper();
     expect(wrapper.find('.navigator-card-item').exists()).toBe(true);
@@ -134,10 +141,38 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.find('.extended-content').exists()).toBe(false);
   });
 
-  it('emits an even, when clicking the tree-toggle button', () => {
+  it('adds a temporary `animating` class, on `@toggle`', async () => {
     const wrapper = createWrapper();
     wrapper.find('.tree-toggle').trigger('click');
     expect(wrapper.emitted('toggle')).toEqual([[defaultProps.item]]);
+    // assert it adds the animating class
+    expect(wrapper.find('.icon-inline').classes()).toContain('animating');
+    wrapper.setProps({
+      expanded: true,
+    });
+    expect(wrapper.find('.icon-inline').classes()).toContain('animating');
+    await flushPromises();
+    // assert we have waited a few frames
+    expect(waitFrames).toHaveBeenCalledTimes(1);
+    expect(waitFrames).toHaveBeenCalledWith(8);
+    expect(wrapper.find('.icon-inline').classes()).not.toContain('animating');
+  });
+
+  it('adds a temporary `animating` class, on `@toggle-full`', async () => {
+    const wrapper = createWrapper();
+    wrapper.find('.tree-toggle').trigger('click', { altKey: true });
+    expect(wrapper.emitted('toggle-full')).toEqual([[defaultProps.item]]);
+    // assert it adds the animating class
+    expect(wrapper.find('.icon-inline').classes()).toContain('animating');
+    wrapper.setProps({
+      expanded: true,
+    });
+    expect(wrapper.find('.icon-inline').classes()).toContain('animating');
+    await flushPromises();
+    // assert we have waited a few frames
+    expect(waitFrames).toHaveBeenCalledTimes(1);
+    expect(waitFrames).toHaveBeenCalledWith(8);
+    expect(wrapper.find('.icon-inline').classes()).not.toContain('animating');
   });
 
   it('renders the API change icon instead of the leaf icon', () => {

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -176,7 +176,7 @@ describe('NavigatorCardItem', () => {
     await flushPromises();
     // assert we have waited a few frames
     expect(waitFrames).toHaveBeenCalledTimes(1);
-    expect(waitFrames).toHaveBeenCalledWith(8);
+    expect(waitFrames).toHaveBeenCalledWith(9);
     expect(wrapper.find('.icon-inline').classes()).not.toContain('animating');
   });
 
@@ -193,7 +193,7 @@ describe('NavigatorCardItem', () => {
     await flushPromises();
     // assert we have waited a few frames
     expect(waitFrames).toHaveBeenCalledTimes(1);
-    expect(waitFrames).toHaveBeenCalledWith(8);
+    expect(waitFrames).toHaveBeenCalledWith(9);
     expect(wrapper.find('.icon-inline').classes()).not.toContain('animating');
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 89840827

## Summary

This PR prevents the arrows from animating open/closed, when scrolling long lists too fast.

## Dependencies

NA

## Testing

Steps:
1. Open a few levels in a tree in different hierarchies.
2. Start scrolling fast up/down
3. Assert it does not animate the arrows upon rendering on the screen.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
