### PR TITLE
Make sure that changing the language does not break the activePath tracking

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -277,8 +277,11 @@ export default {
      * Returns an array of {NavigatorFlatItem}, from the current active UUID
      * @return NavigatorFlatItem[]
      */
-    activePathChildren({ activeUID }) {
-      return activeUID ? this.getParents(activeUID) : [];
+    activePathChildren({ activeUID, childrenMap }) {
+      // if we have an activeUID and its not stale by any chance, fetch its parents
+      return activeUID && childrenMap[activeUID]
+        ? this.getParents(activeUID)
+        : [];
     },
     activePathMap: ({ activePathChildren }) => (
       Object.fromEntries(activePathChildren.map(({ uid }) => [uid, true]))
@@ -500,6 +503,9 @@ export default {
         current = stack.pop();
         // find the object
         const obj = this.childrenMap[current];
+        if (!obj) {
+          return [];
+        }
         // push the object to the results
         arr.unshift(obj);
         // if the current object has a parent and its not the root, add it to the stack

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -81,6 +81,7 @@ const root0Child1 = {
     3,
   ],
 };
+
 const root0Child1GrandChild0 = {
   type: 'tutorial',
   path: '/tutorials/fookit/second-child-depth-1/first-child-depth-2',
@@ -1100,6 +1101,67 @@ describe('NavigatorCard', () => {
       // assert new active item
       expect(allItems.at(2).props('item')).toEqual(root0Child1);
       expect(allItems.at(2).props('isActive')).toEqual(true);
+    });
+
+    it('does not break, if the children change, while we already have an activeUID', async () => {
+      const root0Dupe = {
+        ...root0,
+        uid: root0.uid + 10,
+        childUIDs: [
+          root0Child0.uid + 10,
+          root0Child1.uid + 10,
+        ],
+      };
+      const root0Child0Dupe = {
+        ...root0Child0,
+        uid: root0Child0.uid + 10,
+        parent: root0Dupe.uid,
+      };
+      const root0Child1Dupe = {
+        ...root0Child1,
+        uid: root0Child1.uid + 10,
+        parent: root0Dupe.uid,
+        childUIDs: [],
+      };
+      // mount with the root item being active
+      const wrapper = createWrapper({
+        propsData: {
+          children: [root1],
+          activePath: [
+            root1.path,
+          ],
+        },
+      });
+      await flushPromises();
+      expect(wrapper.findAll(NavigatorCardItem).at(0).props()).toMatchObject({
+        item: root1,
+        isActive: true,
+        isBold: true,
+      });
+      // change children
+      wrapper.setProps({
+        children: [
+          root0Dupe,
+          root0Child0Dupe,
+          root0Child1Dupe,
+        ],
+      });
+
+      // simulate its taking time to fetch the items
+      await flushPromises();
+      // change the activePath later
+      wrapper.setProps({
+        activePath: [
+          root0Dupe.path,
+          root0Child0Dupe.path,
+        ],
+      });
+      await flushPromises();
+      // assert no errors
+      const all = wrapper.findAll(NavigatorCardItem);
+      expect(all).toHaveLength(3);
+      expect(all.at(0).props('item')).toEqual(root0Dupe);
+      expect(all.at(1).props('item')).toEqual(root0Child0Dupe);
     });
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 90843143

## Summary

Fixes errors when changing the page language.

Errors were caused by the `children` changing, but the `activeUID` that is stored was updated after the fact, when the RenderJSON gets updated, so we had a stale activeUID.

The fix is a simple guard, as the component handles the rest gradually.

## Dependencies

NA

## Testing

You need an archive that has a language variants and the `index`.

Steps:
1. Change the language
2. Assert it does not throw errors in the console.
3. Assert that navigating back and forth does not break anything.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
