### PR TITLE
Fix issue where fast scrolling shows empty spaces

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -38,6 +38,7 @@
             aria-label="Sidebar Tree Navigator"
             :items="nodesToRender"
             :item-size="itemSize"
+            :buffer="1000"
             emit-update
             key-field="uid"
             v-slot="{ item, active, index }"

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -162,6 +162,7 @@ describe('NavigatorCard', () => {
       ],
       itemSize: SIDEBAR_ITEM_SIZE,
       keyField: 'uid',
+      buffer: 1000,
     });
     expect(wrapper.find(RecycleScroller).attributes('aria-label')).toBe('Sidebar Tree Navigator');
     expect(scroller.attributes('id')).toEqual(defaultProps.scrollLockID);


### PR DESCRIPTION
Bug/issue #, if applicable: 90845143

## Summary

Fixes an issue where scrolling fast in the navigator, shows empty spaces.

## Dependencies

NA

## Testing

Steps:
1. Open a few large trees
2. Assert that scrolling fast shows little to now empty spaces. (It is still possible to see these if you are very fast with the scroll :D )

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
