### PR TITLE
Add extra bottom spacing to the bottom of mobile navigator. Fixes ios nav hiding items

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -941,6 +941,10 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
   height: 100%;
   box-sizing: border-box;
   padding: var(--card-vertical-spacing) 0;
+
+  @include breakpoint(medium, nav) {
+    padding-bottom: $nav-menu-items-ios-bottom-spacing;
+  }
 }
 
 .filter-wrapper {

--- a/src/components/Tutorial/NavigationBar/MobileDropdown.vue
+++ b/src/components/Tutorial/NavigationBar/MobileDropdown.vue
@@ -163,7 +163,7 @@ export default {
 // Add spacing below the last section in the dropdown, so that it can
 // be selected on iOS Safari.
 .chapter-list:last-child .tutorial-list:last-child {
-  padding-bottom: 10em;
+  padding-bottom: $nav-menu-items-ios-bottom-spacing;
 }
 
 .chapter-list {

--- a/src/styles/core/_nav.scss
+++ b/src/styles/core/_nav.scss
@@ -14,6 +14,7 @@ $nav-height-small: rem(48px);
 $nav-padding: rem(22px);
 $nav-padding-small: rem(16px);
 $nav-menu-item-left-margin: rem(24px);
+$nav-menu-items-ios-bottom-spacing: 10em;
 $nav-timingfunction: ease-in !default;
 $nav-menu-tray-transition: max-height 0.4s $nav-timingfunction 0s, visibility 0s linear 1s !default;
 $nav-items-timingfunction: cubic-bezier(0.07, 1.06, 0.27, 0.95) !default;


### PR DESCRIPTION
Bug/issue #, if applicable: 90950058

## Summary

Adds extra bottom spacing to the bottom of mobile navigator. Fixes the issues where iOS Safari hides the bottom most items, even upon scrolling.

## Dependencies

NA

## Testing

Steps:
1. Navigate go any page with a navigator, using iPhone or the simulator
2. Open the navigator and open a few items
3. Scroll down
4. Assert if bottom nav does not show, it does not hide any of the last items.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - no need, CSS only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
