### PR TITLE
Fix tutorial title truncation in nav

### DIFF
--- a/src/components/Tutorial/NavigationBar.vue
+++ b/src/components/Tutorial/NavigationBar.vue
@@ -218,6 +218,13 @@ export default {
     .mobile-dropdown-container {
       display: block;
     }
+    /deep/ .nav-title {
+      grid-area: title;
+    }
+
+    /deep/ .pre-title {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 90843609

## Summary

This PR fixes the titles on Tutorial pages navigation bar from being truncated on small viewport sizes.

This is a regression from introducing the pre-title slot for the sidenav toggle.

## Dependencies

NA

## Testing

Steps:
1. Go to a tutorial
2. Resize screen to a mobile viewport
3. Assert it does not truncate the title anymore

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
