### PR TITLE
Fix to not highlight Tutorials, when navigating to them from the navigator links, then going back.

### DIFF
--- a/app/public/theme-settings.json
+++ b/app/public/theme-settings.json
@@ -58,7 +58,7 @@
         "hide": false
       },
       "navigator": {
-        "enable": true
+        "enable": false
       }
     }
   }

--- a/app/public/theme-settings.json
+++ b/app/public/theme-settings.json
@@ -58,7 +58,7 @@
         "hide": false
       },
       "navigator": {
-        "enable": false
+        "enable": true
       }
     }
   }

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -104,7 +104,7 @@ import { TopicTypes } from 'docc-render/constants/TopicTypes';
 import FilterInput from 'docc-render/components/Filter/FilterInput.vue';
 import { BreakpointName } from 'docc-render/utils/breakpoints';
 import keyboardNavigation from 'docc-render/mixins/keyboardNavigation';
-import { last } from '@/utils/arrays';
+import { last } from 'docc-render/utils/arrays';
 
 const STORAGE_KEYS = {
   filter: 'navigator.filter',

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -104,6 +104,7 @@ import { TopicTypes } from 'docc-render/constants/TopicTypes';
 import FilterInput from 'docc-render/components/Filter/FilterInput.vue';
 import { BreakpointName } from 'docc-render/utils/breakpoints';
 import keyboardNavigation from 'docc-render/mixins/keyboardNavigation';
+import { last } from '@/utils/arrays';
 
 const STORAGE_KEYS = {
   filter: 'navigator.filter',
@@ -650,6 +651,11 @@ export default {
       }
       // make sure all nodes exist in the childrenMap
       const allNodesMatch = nodesToRender.every(uid => this.childrenMap[uid]);
+      // check if activeUID node matches the current page path
+      const activeUIDMatchesCurrentPath = (activeUID && this.activePath.length)
+        ? (this.childrenMap[activeUID] || {}).path === last(this.activePath)
+        // if there is no activeUID this check is not relevant
+        : true;
       // take a second pass at validating data
       if (
         // if the technology is different
@@ -658,6 +664,7 @@ export default {
         || !allNodesMatch
         // if API the existence of apiChanges differs
         || (hasAPIChanges !== Boolean(this.apiChanges))
+        || !activeUIDMatchesCurrentPath
         // if there is an activeUID and its not in the nodesToRender
         || (activeUID && !filter && !selectedTags.length && !nodesToRender.includes(activeUID))
       ) {
@@ -774,7 +781,7 @@ export default {
       // get current active item's node, if any
       const currentActiveItem = this.childrenMap[this.activeUID];
       // get the current path
-      const lastActivePathItem = activePath[activePath.length - 1];
+      const lastActivePathItem = last(activePath);
       // check if there is an active item to start looking from
       if (currentActiveItem) {
         // Return early, if the current path matches the current active node.

--- a/src/utils/arrays.js
+++ b/src/utils/arrays.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const last = array => array[array.length - 1];

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -933,7 +933,11 @@ describe('NavigatorCard', () => {
       return '';
     });
 
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({
+      propsData: {
+        activePath: [root0.path],
+      },
+    });
     await flushPromises();
     const all = wrapper.findAll(NavigatorCardItem);
     expect(all).toHaveLength(1);
@@ -977,6 +981,31 @@ describe('NavigatorCard', () => {
     expect(clearPersistedStateSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('does not restore the state, if the activeUID path does not match the current last path', async () => {
+    sessionStorage.get.mockImplementation((key) => {
+      if (key === STORAGE_KEYS.filter) return root0.title;
+      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
+      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid];
+      if (key === STORAGE_KEYS.openNodes) return [root0.uid];
+      if (key === STORAGE_KEYS.selectedTags) return [FILTER_TAGS.tutorials];
+      if (key === STORAGE_KEYS.apiChanges) return false;
+      if (key === STORAGE_KEYS.activeUID) return root0.uid;
+      return '';
+    });
+
+    const wrapper = createWrapper({
+      propsData: {
+        activePath: [root0.path, root0Child0.path],
+      },
+    });
+    await flushPromises();
+    // assert we are render more than just the single item in the store
+    const all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(4);
+    expect(all.at(3).props('item')).not.toEqual(root0Child1GrandChild0);
+    expect(clearPersistedStateSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('restores the state, if the activeUID is not in the rendered items, but there is a filter', async () => {
     sessionStorage.get.mockImplementation((key) => {
       if (key === STORAGE_KEYS.filter) return root0Child1.title;
@@ -988,7 +1017,11 @@ describe('NavigatorCard', () => {
       if (key === STORAGE_KEYS.activeUID) return root0Child1GrandChild0.uid;
       return '';
     });
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({
+      propsData: {
+        activePath: [root0.path, root0Child1.path, root0Child1GrandChild0.path],
+      },
+    });
     await flushPromises();
     // assert we are render more than just the single item in the store
     const all = wrapper.findAll(NavigatorCardItem);
@@ -1092,7 +1125,11 @@ describe('NavigatorCard', () => {
       if (key === STORAGE_KEYS.activeUID) return root0.uid;
       return '';
     });
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({
+      propsData: {
+        activePath: [root0.path],
+      },
+    });
     await flushPromises();
     // assert we are render more than just whats in the store,
     // so the filter does not trigger re-calculations
@@ -1111,7 +1148,11 @@ describe('NavigatorCard', () => {
       if (key === STORAGE_KEYS.activeUID) return root0.uid;
       return '';
     });
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({
+      propsData: {
+        activePath: [root0.path],
+      },
+    });
     await flushPromises();
     // assert we are render more than just whats in the store,
     // so the filter does not trigger re-calculations

--- a/tests/unit/utils/arrays.spec.js
+++ b/tests/unit/utils/arrays.spec.js
@@ -8,5 +8,14 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-// eslint-disable-next-line import/prefer-default-export
-export const last = array => array[array.length - 1];
+import { last } from '@/utils/arrays';
+
+describe('arrays', () => {
+  describe('last', () => {
+    it('returns the last item in an array', () => {
+      expect(last([1, 2, 3])).toEqual(3);
+      expect(last([1])).toEqual(1);
+      expect(last([])).toEqual(undefined);
+    });
+  });
+});


### PR DESCRIPTION
Bug/issue #, if applicable: 90840717

## Summary

This fix prevents keeping tutorials highlighted, when clicking on them in the Navigator, then going back.

This was caused because we kept an activeUID for that item upon clicking, but it navigates you to a different page type altogether. 

The fix is a more generic one, to clear the cached state, if the activeUID path is NOT the same as the current route path.

**Alternative**
An alt fix could be to not emit a click event for Tutorial types, but that is a slippery slope I think.

## Dependencies

NA

## Testing

Steps:
1. Open an archive with a tutorial
2. Click on a none-tutorial item
3. Then click on a tutorial
4. Assert you get navigated to the tutorial
5. Go back with browser Back
6. Assert the tutorial is no longer highlighted, but the current page is.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
