### PR TITLE
Show child nav items, when more than 8 siblings

### DIFF
--- a/src/components/NavMenuItemBase.vue
+++ b/src/components/NavMenuItemBase.vue
@@ -62,6 +62,13 @@ export default {
     transform: $nav-menu-item-displacement;
     transition: 0.5s ease;
     transition-property: transform, opacity;
+
+    // add expanded styles
+    @include nav-is-open($nested: true) {
+      opacity: 1;
+      transform: translate3d(0, 0, 0);
+      transition-delay: $nav-menu-item-stagger-delay;
+    }
   }
   // create a staggered effect, only each settings element (language toggle, API changes)
   @for $i from 0 to 8 {
@@ -80,8 +87,6 @@ export default {
       @include nav-in-breakpoint {
         // and expanded
         @include nav-is-open($nested: true) {
-          opacity: 1;
-          transform: translate3d(0, 0, 0);
           @for $k from 1 to 8 {
             // each child should delay its reveal
             &:nth-child(#{$k}) {


### PR DESCRIPTION
Bug/issue #, if applicable: 90970180

## Summary

This PR fixes cases, where a nav has more than 8 child items on mobile, and siblings never get shown, because of an assumption we make on the CSS part.

The fix ensures any child will be visible, and the complex loops are only used to change the transition-delay, to generate the stagger effect.

**Alternative Fix**

An alternative I tried and got working was to use CSS Custom properties instead. We can add `--index` to the items and do all the math necessary using `calc` expressions. The downside of this is that we need to add `--index` to every item/place where we want staggered items. This would be the `Hierarchy`, `MobileDropdown` and maybe 1 or 2 more places in TutorialOverview. This is a much bigger change, so I am leaving it here just for a suggestion.

## Dependencies

NA

## Testing

You would need an archive with more than 8 breadcrumb items or tutorial chapters. Another way to test this is just to bump the `:data-previous-menu-children-count` in the DOM to something above 8 :)

Steps:
1. Go to the a documentation or tutorial page
2. Assert that on mobile, when you open the nav, it shows the last items as well, just without a stagger effect.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - no need, css only
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
