### PR TITLE
Adds top-border to navigator, if it has a top-offset

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -138,12 +138,13 @@ export default {
     widthInPx: ({ width }) => `${width}px`,
     events: ({ isTouch }) => (isTouch ? eventsMap.touch : eventsMap.mouse),
     asideClasses: ({
-      isDragging, openExternally, noTransition, isTransitioning,
+      isDragging, openExternally, noTransition, isTransitioning, mobileTopOffset,
     }) => ({
       dragging: isDragging,
       'force-open': openExternally,
       'no-transition': noTransition,
       animating: isTransitioning,
+      'has-top-offset': mobileTopOffset,
     }),
     scrollLockID: () => SCROLL_LOCK_ID,
     BreakpointScopes: () => BreakpointScopes,
@@ -341,6 +342,10 @@ export default {
         transition: opacity 0.15s linear;
         transition-delay: calc(var(--index) * 0.15s + 0.15s);
       }
+    }
+
+    &.has-top-offset {
+      border-top: 1px solid var(--color-fill-gray-tertiary);
     }
   }
 }


### PR DESCRIPTION
Bug/issue #, if applicable:  89903794

## Summary

Adds a top border to the navigator, in cases where there might be an extra nav or header above it and we offset for it.

## Dependencies

NA

## Testing

Steps:
1. Open the navigator on mobile
2. Assert by default these is no border

To test out the border, just add something to the `header` slot in the `App.vue` file, to simulate a custom header.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
