### PR TITLE
Change the no-data text on the navigator

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -116,7 +116,7 @@ const STORAGE_KEYS = {
 };
 
 const NO_RESULTS = 'No results matching your filter';
-const NO_CHILDREN = 'Technology has no children';
+const NO_CHILDREN = 'No data available';
 const ERROR_FETCHING = 'There was an error fetching the data';
 const ITEMS_FOUND = 'items were found. Tab back to navigate through them.';
 


### PR DESCRIPTION
Bug/issue #, if applicable: 90845942

## Summary

Changes the no-children text, when the navigator could not match and find any children.

![image](https://user-images.githubusercontent.com/9863944/160800043-9e9a2a3b-441d-4b2a-a751-df04eadfaa3a.png)


## Dependencies

NA

## Testing

Use the provided archive [TinyMixedLanguageLibrary.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8379204/TinyMixedLanguageLibrary.doccarchive.zip)


Steps:
1. Visit `/documentation/tinymixedlanguagelibrary`
2. Assert the no children text is updated

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
