### PR TITLE
When a query doesn't match results in the sidebar, the feedback text should be different

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -117,9 +117,9 @@ const STORAGE_KEYS = {
   activeUID: 'navigator.activeUID',
 };
 
-const NO_RESULTS = 'No results matching your filter';
-const NO_CHILDREN = 'No data available';
-const ERROR_FETCHING = 'There was an error fetching the data';
+const NO_RESULTS = 'No results found. Try changing or removing text and tags.';
+const NO_CHILDREN = 'No data available.';
+const ERROR_FETCHING = 'There was an error fetching the data.';
 const ITEMS_FOUND = 'items were found. Tab back to navigate through them.';
 
 const FILTER_TAGS = {


### PR DESCRIPTION
Bug/issue #89368692, if applicable: 

## Summary

When a query doesn't match results in the sidebar, the feedback text should be:
“No results found. Try changing or removing text and tags.”

## Dependencies

NA

## Testing

Steps:
1. Run any documentation with sidenav
2. Type a random query that has no matches on the navbar's filter input
3. Assert that feedback text is correct

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
