### PR TITLE
Simplify navigator filter placeholder text

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -76,7 +76,7 @@
             v-model="filter"
             :tags="availableTags"
             :selected-tags.sync="selectedTagsModelValue"
-            :placeholder="`Filter in ${technology}`"
+            :placeholder="Filter"
             :should-keep-open-on-blur="false"
             :position-reversed="isLargeBreakpoint"
             :clear-filter-on-tag-select="false"

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -190,7 +190,7 @@ describe('NavigatorCard', () => {
     expect(filter.props()).toEqual({
       disabled: false,
       focusInputWhenCreated: false,
-      placeholder: 'Filter in TestKit',
+      placeholder: 'Filter',
       positionReversed: true,
       preventedBlur: false,
       selectedTags: [],


### PR DESCRIPTION
Bug/issue #, if applicable: 90289411

## Summary

It will now simply read:

> Filter

instead of

> Filter in [technology]

## Testing

Steps:
1. Enable the navigator feature flag and preview some documentation.
2. Verify that the placeholder text for the navigator filter now says "Filter" instead of "Filter in [technology]"

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
