### PR TITLE
Fix Navigator item right horizontal spacing

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -217,7 +217,7 @@ $nesting-spacing: $card-horizontal-spacing + $card-horizontal-spacing-small;
 }
 
 .head-wrapper {
-  padding: 0 $card-horizontal-spacing;
+  padding: 0 $card-horizontal-spacing-large 0 $card-horizontal-spacing;
   position: relative;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Bug/issue #, if applicable: 91070240

## Summary

Changes the horizontal spacing on the navigator items from 10 to 20px, to match the root technology header

![image](https://user-images.githubusercontent.com/9863944/161008228-1d1f47be-399b-4a4b-92ad-f9bf74412bd2.png)

## Dependencies

NA

## Testing

Steps:
1. Open enough child items, so they start getting truncated
2. Assert the right padding is 20px, while the rest are untouched.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
