### PR TITLE
Simplify doc hero colors and use "sky" accent color for collection pages

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -11,7 +11,7 @@
 <template>
   <div class="doc-topic">
     <main class="main" id="main" role="main" tabindex="0">
-      <DocumentationHero :type="symbolKind || role" :enhanceBackground="enhanceBackground">
+      <DocumentationHero :type="role" :enhanceBackground="enhanceBackground">
         <slot name="above-title" />
         <LanguageSwitcher
           v-if="shouldShowLanguageSwitcher"

--- a/src/constants/TopicTypes.js
+++ b/src/constants/TopicTypes.js
@@ -70,6 +70,7 @@ export const TopicTypeColorsMap = {
   [TopicTypes.init]: TopicTypeColors.blue,
   [TopicTypes.case]: TopicTypeColors.orange,
   [TopicTypes.class]: TopicTypeColors.purple,
+  [TopicTypes.collection]: TopicTypeColors.sky,
   [TopicTypes.dictionarySymbol]: TopicTypeColors.purple,
   [TopicTypes.enum]: TopicTypeColors.orange,
   [TopicTypes.extension]: TopicTypeColors.orange,

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -110,6 +110,7 @@ const propsData = {
   },
   identifier: 'doc://fookit',
   interfaceLanguage: 'swift',
+  role: TopicTypes.collection,
   symbolKind: TopicTypes.module,
   objcPath: 'documentation/objc',
   swiftPath: 'documentation/swift',
@@ -211,33 +212,29 @@ describe('DocumentationTopic', () => {
   it('renders a `DocumentationHero`, enabled', () => {
     const hero = wrapper.find(DocumentationHero);
     expect(hero.exists()).toBe(true);
-    expect(hero.props()).toEqual({ type: propsData.symbolKind, enhanceBackground: true });
-  });
-
-  it('renders a `DocumentationHero`, enabled, with a the `role`, if no symbolKind', () => {
-    wrapper.setProps({
-      role: TopicTypes.article,
-      symbolKind: '',
-    });
-    const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: TopicTypes.article, enhanceBackground: true });
+    expect(hero.props()).toEqual({ type: propsData.role, enhanceBackground: true });
   });
 
   it('render a `DocumentationHero`, enabled, if top-level technology page', () => {
-    wrapper.setProps({
-      role: TopicTypes.collection,
-      symbolKind: 'module',
-    });
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: TopicTypes.module, enhanceBackground: true });
+    expect(hero.props()).toEqual({ type: TopicTypes.collection, enhanceBackground: true });
   });
 
   it('render a `DocumentationHero`, disabled, if symbol page', () => {
-    wrapper.setProps({
+    /* wrapper.setProps({
       symbolKind: 'protocol',
+    }); */
+
+    // setProps isn't working for some reason...
+    wrapper = shallowMount(DocumentationTopic, {
+      propsData: {
+        ...propsData,
+        role: 'symbol',
+        symbolKind: 'protocol',
+      },
     });
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: TopicTypes.protocol, enhanceBackground: false });
+    expect(hero.props()).toEqual({ type: 'symbol', enhanceBackground: false });
   });
 
   it('renders a `Title`', () => {

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -91,6 +91,14 @@ describe('DocumentationHero', () => {
     });
   });
 
+  it('utilizes the "sky" color for top level collection pages', () => {
+    const wrapper = createWrapper({
+      propsData: { type: TopicTypes.collection },
+    });
+    expect(wrapper.vm.styles['--accent-color'])
+      .toBe('var(--color-type-icon-sky, var(--color-figure-gray-secondary))');
+  });
+
   it('renders the DocumentationHero, disabled', () => {
     const wrapper = createWrapper();
     wrapper.setProps({


### PR DESCRIPTION
Bug/issue #, if applicable: 90502658

## Summary

This simplifies the new documentation hero to only utilize `role` data when determining the accent color used for the enhanced background.

The "sky" accent color should be used for top level collection pages and the "teal" accent color should be used for other high level pages like API collections, articles, and sample code.

## Testing

Steps:
1. Configure the `VUE_APP_DEV_SERVER_PROXY=https://ethan-kusters.github.io/swift-argument-parser` env var and run the dev server with `npm run serve`
2. Open http://localhost:8080/documentation/argumentparser and verify that the `--accent-color` CSS property for the hero is `--color-type-icon-sky`
3. Open http://localhost:8080/documentation/argumentparser/gettingstarted and verify that the `--accent-color` CSS property for the hero is `--color-type-icon-teal`

(Or use any other documentation archive to test with.)

## Checklist
Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
