### PR TITLE
Fix language toggle overflowing, when zooming in on iOS

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
+++ b/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
@@ -120,19 +120,17 @@ export default {
   },
   mounted() {
     // on resize, re-calculate the width of the select.
-    const cb = debounce(() => {
-      this.calculateSelectWidth();
-    }, 150, true);
-    const orientationChangeCallback = async () => {
-      // we wait for 3 frames, as that is the minimum it takes for the transitions to finish
+    const cb = debounce(async () => {
+      // we wait for 3 frames, as that is the minimum it takes
+      // for the browser orientation-change transitions to finish
       await waitFrames(3);
       this.calculateSelectWidth();
-    };
+    }, 150, true);
     window.addEventListener('resize', cb);
-    window.addEventListener('orientationchange', orientationChangeCallback);
+    window.addEventListener('orientationchange', cb);
     this.$once('hook:beforeDestroy', () => {
       window.removeEventListener('resize', cb);
-      window.removeEventListener('orientationchange', orientationChangeCallback);
+      window.removeEventListener('orientationchange', cb);
     });
   },
   watch: {

--- a/tests/unit/components/DocumentationTopic/DocumentationNav/LanguageToggle.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationNav/LanguageToggle.spec.js
@@ -114,6 +114,7 @@ describe('LanguageToggle', () => {
     const resizeEvent = createEvent('resize');
     window.dispatchEvent(resizeEvent);
     await wrapper.vm.$nextTick();
+    await waitFrames(3);
     expect(toggle.attributes()).toHaveProperty('style', 'width: 26px;');
   });
 


### PR DESCRIPTION
Bug #: 90289062

## Summary

Fixes an issue with zooming in/out and the language toggle getting cutoff.

## Dependencies

NA

## Testing

Steps:
1. Zoom in with `cmd +` until you see the mobile localnav
2. Zoom out with `cmd -` or do `cmd 0` to zoom 100% out.
3. Assert the toggle is no longer cutoff

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Add tests
- [ ] Add a release note in the radar
- [ ] Assign the bug to the primary reviewer
