### PR TITLE
Don't override button link color in doc hero. (#114)

### DIFF
--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -153,7 +153,7 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
   }
 }
 
-.theme-dark /deep/ a {
+.theme-dark /deep/ a:not(.button-cta) {
   color: dark-color(figure-blue);
 }
 </style>


### PR DESCRIPTION
* **Rationale**: Fixes a visual regression where the sample code download button is difficult to read and appears disabled.
* **Risk**: Low
* **Risk Detail**: Only a single CSS selector change.
* **Reward**: High
* **Reward Details**: Fixes noticeable UX issue with all sample code pages.
* **Original PR**: https://github.com/apple/swift-docc-render/pull/114
* **Issue**: rdar://90999537
* **Code Reviewed By**: @dobromir-hristov, @hqhhuang 
* **Testing Details**: Visually tested example sample code pages impacted by bug.