### PR TITLE
[5.7] Limit VoiceOver cursor

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -222,6 +222,7 @@ $depth-spacer-base-spacing: (
 $nesting-spacing: $card-horizontal-spacing + $card-horizontal-spacing-small;
 
 .navigator-card-item {
+  overflow: hidden;
   height: $item-height;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Bug/issue #90845397, if applicable: 

## Summary

Limit VoiceOver cursor

| Before      | After |
| ----------- | ----------- |
| ![before](https://user-images.githubusercontent.com/8567677/161607312-3768284a-a476-4070-bf97-1f0c33d213cc.gif) | ![after](https://user-images.githubusercontent.com/8567677/161607327-d799300e-a11d-41fa-8aeb-983e4a37114b.gif) |

PR cherrypicking: https://github.com/apple/swift-docc-render/pull/118

## Scope

It affects AX on Sidenav

## Risk

Low

## Dependencies

NA

## Testing

Steps:
1. Open a documentation with sidenav and enable sidenav on it
2. Turn on VoiceOver
3. Use arrow key to navigate to the items in the sidenav
4. Assert that VoiceOver cursor is the same as the item's outline
