### PR TITLE
[5.7] Enable the sidebar only for schema versions above certain value

### DIFF
--- a/app/public/theme-settings.json
+++ b/app/public/theme-settings.json
@@ -54,9 +54,6 @@
   },
   "features": {
     "docs": {
-      "navigator": {
-        "enable": false
-      }
     }
   }
 }

--- a/src/utils/schema-version-check.js
+++ b/src/utils/schema-version-check.js
@@ -10,12 +10,41 @@
 
 export const CURRENT_SUPPORTED_SCHEMA = {
   major: 0,
-  minor: 2,
+  minor: 3,
   patch: 0,
 };
 
 export function combineVersions({ major, minor, patch }) {
   return [major, minor, patch].join('.');
+}
+
+function versionNumberToArray(versionString) {
+  const [major = 0, minor = 0, patch = 0] = versionString.split('.');
+  return [Number(major), Number(minor), Number(patch)];
+}
+
+/**
+ * Compares two version strings
+ * @param {string} v1 - first version to compare
+ * @param {string} v2 - second version to compare
+ * @returns {Number<-1|0|1>}
+ */
+export function compareVersions(v1, v2) {
+  const v1parts = versionNumberToArray(v1);
+  const v2parts = versionNumberToArray(v2);
+
+  // iterate over each item
+  for (let i = 0; i < v1parts.length; i += 1) {
+    if (v1parts[i] > v2parts[i]) {
+      return 1;
+    }
+    if (v1parts[i] < v2parts[i]) {
+      return -1;
+    }
+  }
+
+  // they are identical
+  return 0;
 }
 
 export const CURRENT_SCHEMA_STRING = combineVersions(CURRENT_SUPPORTED_SCHEMA);

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -70,7 +70,6 @@
 
 <script>
 import { apply } from 'docc-render/utils/json-patch';
-import { getSetting } from 'docc-render/utils/theme-settings';
 import { TopicRole } from 'docc-render/constants/roles';
 import {
   clone,
@@ -88,9 +87,13 @@ import NavigatorDataProvider from 'theme/components/Navigator/NavigatorDataProvi
 import AdjustableSidebarWidth from 'docc-render/components/AdjustableSidebarWidth.vue';
 import Navigator from 'docc-render/components/Navigator.vue';
 import DocumentationNav from 'theme/components/DocumentationTopic/DocumentationNav.vue';
+import { compareVersions, combineVersions } from 'docc-render/utils/schema-version-check';
+
+const MIN_RENDER_JSON_VERSION_WITH_INDEX = '0.3.0';
 
 export default {
   name: 'DocumentationTopicView',
+  constants: { MIN_RENDER_JSON_VERSION_WITH_INDEX },
   components: {
     Navigator,
     AdjustableSidebarWidth,
@@ -246,11 +249,12 @@ export default {
           && platforms.every(platform => platform.deprecatedAt)
         )
       ),
-    // Always disable the navigator for IDE targets. For other targets, allow
-    // this feature to be enabled through the `features.docs.navigator.enable`
-    // setting in `theme-settings.json`
-    enableNavigator: ({ isTargetIDE }) => !isTargetIDE && (
-      getSetting(['features', 'docs', 'navigator', 'enable'], false)
+    // Always disable the navigator for IDE targets. For other targets, detect whether the
+    // RenderJSON version is in the required range.
+    enableNavigator: ({ isTargetIDE, topicDataDefault }) => !isTargetIDE && (
+      compareVersions(
+        combineVersions(topicDataDefault.schemaVersion), MIN_RENDER_JSON_VERSION_WITH_INDEX,
+      ) >= 0
     ),
     sidebarProps: ({ isSideNavOpen, enableNavigator }) => (
       enableNavigator

--- a/tests/unit/utils/schema-version-check.spec.js
+++ b/tests/unit/utils/schema-version-check.spec.js
@@ -8,7 +8,11 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import emitWarningForSchemaVersionMismatch, { CURRENT_SUPPORTED_SCHEMA, combineVersions, CURRENT_SCHEMA_STRING } from 'docc-render/utils/schema-version-check';
+import emitWarningForSchemaVersionMismatch, {
+  CURRENT_SUPPORTED_SCHEMA,
+  combineVersions,
+  CURRENT_SCHEMA_STRING, compareVersions,
+} from 'docc-render/utils/schema-version-check';
 
 const warnSpy = jest.spyOn(console, 'warn').mockReturnValue('');
 
@@ -74,5 +78,30 @@ describe('schema-version-check', () => {
   it('does not do anything, if no version is provided', () => {
     emitWarningForSchemaVersionMismatch();
     expect(warnSpy).toHaveBeenCalledTimes(0);
+  });
+
+  describe('compareVersions', () => {
+    it.each([
+      ['1.1.1', '1.1.10', -1],
+      ['1.1.1', '1.2.10', -1],
+      ['1.1.20', '1.2.10', -1],
+      ['1.1.1', '2.1.1', -1],
+      ['1.1', '1.2.0', -1],
+      ['1.1', '1.1.1', -1],
+
+      ['1.1.10', '1.1.1', 1],
+      ['1.1.10', '1.0.1', 1],
+      ['1.1.10', '1.0.20', 1],
+      ['2.1.0', '1.1.0', 1],
+      ['1.2.0', '1.1', 1],
+      ['1.2', '1.1', 1],
+
+      ['1.1.1', '1.1.1', 0],
+      ['1.1', '1.1', 0],
+      ['1.1', '1.1.0', 0],
+      ['1.1.0', '1.1', 0],
+    ])('compares %s to %s and gets %s', (one, two, result) => {
+      expect(compareVersions(one, two)).toBe(result);
+    });
   });
 });


### PR DESCRIPTION
- Rationale: Removes the global feature flag and dynamically enables the navigator for compatible Render JSON versions.
- Risk: Medium
- Risk Detail: Impacts all documentation pages, updates logic to show/hide major UX feature.
- Reward: High
- Reward Details: Enables the navigator by default for compatible DocC output.
- Original PR: https://github.com/apple/swift-docc-render/pull/78
- Issue: rdar://89089597
- Code Reviewed By: @mportiz08 
- Testing Details: Updated unit tests, tested that the sidebar is enabled as expected for pages compiled with the appropriate DocC version, tested that the sidebar is not enabled as expected for pages with older DocC output.

\cc @dobromir-hristov 