### PR TITLE
Expose an above-hero-content slot

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -12,6 +12,9 @@
   <div class="doc-topic">
     <main class="main" id="main" role="main" tabindex="0">
       <DocumentationHero :type="role" :enhanceBackground="enhanceBackground">
+        <template #above-content>
+          <slot name="above-hero-content" />
+        </template>
         <slot name="above-title" />
         <LanguageSwitcher
           v-if="shouldShowLanguageSwitcher"

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -24,6 +24,9 @@
       v-if="enhanceBackground" :type="type"
       key="second" class="background-icon second-icon" with-colors
     />
+    <div class="documentation-hero__above-content">
+      <slot name="above-content" />
+    </div>
     <div class="documentation-hero__content">
       <slot />
     </div>
@@ -72,8 +75,6 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
   color: dark-color(figure-gray);
   overflow: hidden;
   text-align: left;
-  padding-top: rem(40px);
-  padding-bottom: 40px;
   position: relative;
 
   // gradient
@@ -136,7 +137,14 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
   &__content {
     position: relative;
     z-index: 1;
+    padding-top: rem(40px);
+    padding-bottom: 40px;
     @include dynamic-content-container;
+  }
+
+  &__above-content {
+    position: relative;
+    z-index: 1;
   }
 }
 

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -559,6 +559,19 @@ describe('DocumentationTopic', () => {
     expect(wrapper.find(DocumentationHero).contains('.above-title')).toBe(true);
   });
 
+  it('renders content in the `above-hero-content` slot', () => {
+    wrapper = shallowMount(DocumentationTopic, {
+      propsData,
+      slots: {
+        'above-hero-content': '<div class="above-hero-content">Above Hero Content</div>',
+      },
+      stubs: {
+        DocumentationHero,
+      },
+    });
+    expect(wrapper.contains('.above-hero-content')).toBe(true);
+  });
+
   describe('lifecycle hooks', () => {
     it('calls `store.reset()`', () => {
       const store = {

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -30,6 +30,7 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(Documentat
   },
   slots: {
     default: '<div class="default-slot">Default Slot</div>',
+    'above-content': '<div class="above-content-slot">Above Content Slot</div>',
   },
   ...others,
 });
@@ -63,6 +64,7 @@ describe('DocumentationHero', () => {
     expect(allIcons.at(1).classes()).toEqual(['background-icon', 'second-icon']);
     // assert slot
     expect(wrapper.find('.default-slot').text()).toBe('Default Slot');
+    expect(wrapper.find('.above-content-slot').text()).toBe('Above Content Slot');
     expect(wrapper.vm.styles).toEqual({
       '--accent-color': `var(--color-type-icon-${TopicTypeColorsMap[defaultProps.type]}, var(--color-figure-gray-secondary))`,
     });


### PR DESCRIPTION
Bug/issue #, if applicable: 89151255

## Summary

Adds an optional above-hero-content slot so third parties can render content outside the hero content container and padding.

## Dependencies

NA

## Testing

Steps:
1. Assert the styling of the hero is untouched by the changes

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
