### PR TITLE
[5.7] Update navigator spacing to better respect safe area insets

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -907,6 +907,9 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
     @include breakpoint(small, nav) {
       padding: 12px $card-horizontal-spacing-large;
     }
+
+    @include safe-area-left-set(padding-left, $card-horizontal-spacing-large);
+    @include safe-area-right-set(padding-right, $card-horizontal-spacing-large);
   }
 
   .card-icon {
@@ -933,6 +936,8 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
     display: flex;
     left: 0;
     height: 100%;
+
+    @include safe-area-left-set(left, 0px);
   }
 
   @include breakpoint(small, nav) {
@@ -971,11 +976,17 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
   display: flex;
   align-items: flex-end;
 
+  @include safe-area-left-set(padding-left, 30px);
+  @include safe-area-right-set(padding-right, 30px);
+
   @include breakpoint(medium, nav) {
     border: none;
     padding: 10px 20px;
     align-items: flex-start;
     height: 62px;
+
+    @include safe-area-left-set(padding-left, 20px);
+    @include safe-area-right-set(padding-right, 20px);
   }
 
   .input-wrapper {

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -256,6 +256,9 @@ $nesting-spacing: $card-horizontal-spacing + $card-horizontal-spacing-small;
   min-width: 0;
   height: 100%;
 
+  @include safe-area-left-set(padding-left, $card-horizontal-spacing);
+  @include safe-area-right-set(padding-right, $card-horizontal-spacing-large);
+
   &.active {
     background: var(--color-fill-gray-quaternary);
   }

--- a/src/styles/core/_helpers.scss
+++ b/src/styles/core/_helpers.scss
@@ -266,3 +266,19 @@
     }
   }
 }
+
+@mixin safe-area-set($inset, $property, $value) {
+  // unquote is used to ensure that we are using the CSS Level 4 `max` function
+  // instead of the builtin `max` function provided by the Sass preprocessor
+  @supports(padding: unquote('max(0px)')) {
+    #{$property}: unquote('max(#{$value}, env(safe-area-inset-#{$inset}))');
+  }
+}
+
+@mixin safe-area-left-set($property, $value) {
+  @include safe-area-set(left, $property, $value);
+}
+
+@mixin safe-area-right-set($property, $value) {
+  @include safe-area-set(right, $property, $value);
+}


### PR DESCRIPTION
- **Rationale:** Updates the navigator styles to respect device safe area insets.
- **Risk:** Low
- **Risk Detail:** Only a few small CSS additions scoped to new navigator components.
- **Reward:** High
- **Reward Details:** Fixes an issue where UI text may be obstructed by safe area insets in certain devices.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/129
- **Issue:** rdar://89775264
- **Code Reviewed By:** @marinaaisa, @dobromir-hristov
- **Testing Details:** Visually inspected in simulator with problematic devices and checked to ensure no regressions were introduced with spacing on other devices.