### PR TITLE
Use dynamic light/dark availability change icons

### DIFF
--- a/src/components/DocumentationTopic/Summary/Availability.vue
+++ b/src/components/DocumentationTopic/Summary/Availability.vue
@@ -150,18 +150,48 @@ export default {
   }
 
   &::before {
-    @include coin($modified-dark-svg, $-coin-size);
+    @include coin($modified-svg, $-coin-size);
     left: $-coin-spacer;
+
+    @include prefers-dark {
+      background-image: $modified-dark-svg;
+    }
+
+    .theme-dark & {
+      background-image: $modified-dark-svg;
+    }
   }
 
   &-added {
     border-color: var(--color-changes-added);
-    &::before { background-image: $added-dark-svg; }
+
+    &::before {
+      background-image: $added-svg;
+
+      @include prefers-dark {
+        background-image: $added-dark-svg;
+      }
+
+      .theme-dark & {
+        background-image: $added-dark-svg;
+      }
+    }
   }
 
   &-deprecated {
     border-color: var(--color-changes-deprecated);
-    &::before { background-image: $deprecated-dark-svg; }
+
+    &::before {
+      background-image: $deprecated-svg;
+
+      @include prefers-dark {
+        background-image: $deprecated-dark-svg;
+      }
+
+      .theme-dark & {
+        background-image: $deprecated-dark-svg;
+      }
+    }
   }
 
   &-modified {


### PR DESCRIPTION
Bug/issue #, if applicable: 91417090

## Summary

This fixes an issue where the change icons for availability badges are always the "dark" version, regardless of the background color behind them.

For symbol pages, these icons should change to the light/dark mode as appropriate as the color scheme toggle is changed. For other pages with a static dark background, these icons should always remain the dark version regardless of the color scheme preference.

## Testing

Steps:
* Find an example page where there has been changed availability for a _symbol_:
  * In "Light" mode, verify that the light mode of the icon is used
  * In "Dark" mode, verify that the dark mode of the icon is used
  * In "Auto" mode, verify that the light/dark mode of the icon is used depending on the OS level setting
* Find an example _framework_ page with changed availability (or other page with an always dark background):
  * Verify that the dark mode version of the icon is always used regardless of the toggle or OS setting

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~, CSS only change
- [X] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
