### PR TITLE
[5.7] Navigator labels should not be clickable

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -75,7 +75,7 @@
           class="leaf-link"
           tabindex="-1"
           ref="reference"
-          @click.native="$emit('navigate', item.uid)"
+          @click.native="handleClick"
         >
           <HighlightMatches
             :text="item.title"
@@ -191,6 +191,10 @@ export default {
     },
     selfFocus() {
       this.$el.focus();
+    },
+    handleClick() {
+      if (this.isGroupMarker) return;
+      this.$emit('navigate', this.item.uid);
     },
   },
   watch: {

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -256,6 +256,19 @@ describe('NavigatorCardItem', () => {
       expect(wrapper.find('.navigator-card-item').attributes('role')).toBeFalsy();
     });
 
+    it('does not emit a `navigate` event, if is a groupMarker', () => {
+      const wrapper = createWrapper({
+        propsData: {
+          item: {
+            ...defaultProps.item,
+            type: TopicTypes.groupMarker,
+          },
+        },
+      });
+      wrapper.find('.leaf-link').trigger('click');
+      expect(wrapper.emitted('navigate')).toBeFalsy();
+    });
+
     it('does not apply aria-hidden to NavigatorCardItem if isRendered is true', () => {
       const wrapper = createWrapper();
       expect(wrapper.find('.navigator-card-item').attributes('aria-hidden')).toBeFalsy();


### PR DESCRIPTION
- **Rationale:** Navigator labels should not be clickable
- **Risk:** Low
- **Risk Detail:** We just added a check to the type of item, before emitting an event on click.
- **Reward:** Medium
- **Reward Details:** Fixes an issue with the Navigator, where a user might click on a label and highlight it, nothing breaks.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/119
- **Issue:** rdar://90633560
- **Code Reviewed By:** @hqhhuang 
- **Testing Details:** Tested with Unit tests and by manually clicking on navigator items