### PR TITLE
[5.7] Fix navigator mobile toggle spacing (#121)

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -933,6 +933,8 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
     display: flex;
     left: 0;
     height: 100%;
+    padding-left: $nav-padding;
+    padding-right: $nav-padding;
   }
 
   @include breakpoint(small, nav) {


### PR DESCRIPTION
- **Rationale:** Updates the styling for the navigator toggle on Medium screen sizes
- **Risk:** Low
- **Risk Detail:** Only a few small CSS additions scoped to new navigator components.
- **Reward:** High
- **Reward Details:** Fixes an issue where the Navigator Toggle looks badly positioned and is hard to click.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/121
- **Issue:** rdar://90968150
- **Code Reviewed By:** @hqhhuang 
- **Testing Details:** Visually inspected in browser on Medium sizes mobile devices