### PR TITLE
Fix selecting tags with the keyboard on Navigator (#120)

### DIFF
--- a/src/mixins/keyboardNavigation.js
+++ b/src/mixins/keyboardNavigation.js
@@ -40,8 +40,11 @@ export default {
         this.endingPointHook();
       }
     },
-    focusFirst() {
+    async focusFirst() {
       this.externalFocusChange = false;
+      // reset focus index so we can focus on value 0 too
+      this.focusIndex(null);
+      await this.$nextTick();
       this.focusIndex(0);
       this.scrollToFocus();
     },

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -298,6 +298,7 @@ describe('NavigatorCard', () => {
       key: 'ArrowUp',
       altKey: true,
     });
+    await flushPromises();
     expect(wrapper.vm.focusedIndex).toBe(0);
   });
 

--- a/tests/unit/mixins/keyboardNavigation.spec.js
+++ b/tests/unit/mixins/keyboardNavigation.spec.js
@@ -48,12 +48,23 @@ describe('keyboardNavigation', () => {
     expect(wrapper.vm.focusedIndex).toBe(totalItemsToNavigate - 1);
   });
 
-  it('allows the user to navigate to the first item on the list when pressing cmd + up key', () => {
+  it('allows the user to navigate to the first item on the list when pressing cmd + up key', async () => {
     const wrapper = createWrapper();
+    // simulate going down a few times
+    wrapper.trigger('keydown', {
+      key: 'ArrowDown',
+    });
+    wrapper.trigger('keydown', {
+      key: 'ArrowDown',
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.focusedIndex).toBe(2);
+    // now go to the top
     wrapper.trigger('keydown', {
       key: 'ArrowUp',
       metaKey: true,
     });
+    await wrapper.vm.$nextTick();
     expect(wrapper.vm.focusedIndex).toBe(0);
   });
 


### PR DESCRIPTION
- **Rationale:** Fixes the keyboard related actions for the tagging component in the Navigator
- **Risk:** Low
- **Risk Detail:** Changes some of the internals, but the change is scoped only to the tagging input.
- **Reward:** High
- **Reward Details:** Fixes an issue where the filter tags cannot be navigated to with the keyboard
- **Original PR:** https://github.com/apple/swift-docc-render/pull/120
- **Issue:** rdar://90973785
- **Code Reviewed By:** @hqhhuang 
- **Testing Details:** Added Unit tests and verified manually in the browser