### PR TITLE
[5.7] Suggest only tags in the Navigator, that can return results

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -250,11 +250,35 @@ export default {
       if (errorFetching) return ERROR_FETCHING;
       return NO_CHILDREN;
     },
-    availableTags: ({ selectedTags }) => (
-      selectedTags.length
-        ? []
-        : Object.values(FILTER_TAGS_TO_LABELS)
-    ),
+    /**
+     * Generates an array of tag labels for filtering.
+     * Shows only tags, that have children matches.
+     */
+    availableTags: ({ selectedTags, children }) => {
+      const tagLabels = selectedTags.length ? [] : Object.values(FILTER_TAGS_TO_LABELS);
+      if (!tagLabels.length) return tagLabels;
+      const tagLabelsSet = new Set(tagLabels);
+      const availableTags = [];
+      const len = children.length;
+      let i;
+      // iterate over the nodes to render
+      for (i = 0; i < len; i += 1) {
+        // if there are no more tags to iterate over, end early
+        if (!tagLabelsSet.size) return availableTags;
+        // extract the type
+        const { type } = children[i];
+        // grab the tagLabel
+        const tagLabel = FILTER_TAGS_TO_LABELS[TOPIC_TYPE_TO_TAG[type]];
+        // try to match a tag
+        if (tagLabelsSet.has(tagLabel)) {
+          // if we have a match, store it
+          availableTags.push(tagLabel);
+          // remove the match, so we can end the filter early
+          tagLabelsSet.delete(tagLabel);
+        }
+      }
+      return availableTags;
+    },
     selectedTagsModelValue: {
       get: ({ selectedTags }) => selectedTags.map(tag => FILTER_TAGS_TO_LABELS[tag]),
       set(values) {

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -198,7 +198,7 @@ describe('NavigatorCard', () => {
       selectedTags: [],
       shouldTruncateTags: false,
       tags: [
-        'Sample Code',
+        // Sample Code is missing, because no sample code in test data
         'Tutorials',
         'Articles',
       ],
@@ -1209,10 +1209,34 @@ describe('NavigatorCard', () => {
     const wrapper = createWrapper();
     await flushPromises();
     const filter = wrapper.find(FilterInput);
-    expect(filter.props('tags')).toHaveLength(3);
+    expect(filter.props('tags')).toHaveLength(2);
     filter.vm.$emit('update:selectedTags', [FILTER_TAGS_TO_LABELS.articles]);
     await flushPromises();
     expect(filter.props('tags')).toEqual([]);
+  });
+
+  it('shows only tags, that have matching children', async () => {
+    sessionStorage.get.mockImplementation((key, def) => def);
+    const sampleCode = {
+      type: 'sampleCode',
+      path: '/documentation/fookit/sample-code',
+      title: 'Sample Code',
+      uid: 5,
+      parent: INDEX_ROOT_KEY,
+      depth: 0,
+      index: 1,
+      childUIDs: [],
+    };
+    const wrapper = createWrapper({
+      propsData: {
+        children: [root0, root0Child0, sampleCode],
+        activePath: [root0.path],
+      },
+    });
+    await flushPromises();
+    const filter = wrapper.find(FilterInput);
+    // assert there are no Articles for example
+    expect(filter.props('tags')).toEqual(['Tutorials', 'Sample Code']);
   });
 
   describe('navigating', () => {


### PR DESCRIPTION
- **Rationale:** We should only suggest tags that can yield results
- **Risk:** Low
- **Risk Detail:** The change is only scoped to the Navigator filters, but it does need to iterate over all items of a technology.
- **Reward:** High
- **Reward Details:** Users will not see tags, that would not yield any results
- **Original PR:** https://github.com/apple/swift-docc-render/pull/122
- **Issue:** rdar://89482723
- **Code Reviewed By:** @hqhhuang 
- **Testing Details:** Added Unit Tests + manually tested in the browser