### PR TITLE
Make sure items are always scrollable in the navigator

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1044,6 +1044,7 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
   height: 100%;
   box-sizing: border-box;
   padding: var(--card-vertical-spacing) 0;
+  padding-bottom: calc(var(--top-offset, 0px) + var(--card-vertical-spacing));
 
   @include breakpoint(medium, nav) {
     padding-bottom: $nav-menu-items-ios-bottom-spacing;


### PR DESCRIPTION
Bug/issue #, if applicable: 91400301

## Summary

Makes sure the items in the navigator can always be scrolled to. This fixes cases, where there can be another header above the default nav.

## Dependencies

NA

## Testing

Steps:
1. Either build using Docc and a custom header template OR just add some content to the `header` slot in `App.vue`.
2. Assert when scrolled to the top of the page, if you expand enough items in the navigator, you can scroll all of them into view.


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
