### PR TITLE
Fix bug with Safari not pre-filling tagging input when going back

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -134,7 +134,6 @@ const SuggestedTagsId = 'suggested-tags';
 const AXinputProperties = {
   autocorrect: 'off',
   autocapitalize: 'off',
-  autocomplete: 'off',
   spellcheck: 'false',
   role: 'combobox',
   'aria-haspopup': 'true',


### PR DESCRIPTION
Bug/issue #, if applicable: 91100473

## Summary

This fixes a bug where if you fill in a FilterInput and follow a link to another website then go back, Safari will not respect the pre-filled input, and will show it as empty, until you click into it.

## Dependencies

NA

## Testing

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
