### PR TITLE
[5.7] Make sure items are always scrollable in the navigator 

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1057,6 +1057,7 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
   height: 100%;
   box-sizing: border-box;
   padding: var(--card-vertical-spacing) 0;
+  padding-bottom: calc(var(--top-offset, 0px) + var(--card-vertical-spacing));
 
   @include breakpoint(medium, nav) {
     padding-bottom: $nav-menu-items-ios-bottom-spacing;


### PR DESCRIPTION
- **Rationale:** Adds extra padding on the bottom of the navigator, so extra navs dont obscure the last items in the list
- **Risk:** Low
- **Risk Detail:** Only a few small CSS additions scoped to new navigator components.
- **Reward:** High
- **Reward Details:** Fixes an issue where UI elements may be obstructed by extra header items in custom tempaltes
- **Original PR:** https://github.com/apple/swift-docc-render/pull/139
- **Issue:** rdar://91400301
- **Code Reviewed By:** @marinaaisa
- **Testing Details:** Visually inspected on themes with custom header.