### PR TITLE
[5.7] Fix single letter icon spacing

### DIFF
--- a/src/components/Icons/SingleLetterSymbolIcon.vue
+++ b/src/components/Icons/SingleLetterSymbolIcon.vue
@@ -10,16 +10,14 @@
 
 <template>
   <SVGIcon
-    class="reset-circle-icon"
+    class="single-letter-icon"
     width="16px" height="16px" viewBox="0 0 16 16"
   >
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-      <g transform="translate(1.000000, 1.000000)">
-        <rect stroke="currentColor" x="0.5" y="0.5" width="13" height="13"></rect>
-        <text font-size="11" font-weight="bold" fill="currentColor">
-          <tspan text-anchor="middle" x="7" y="11">{{ symbol }}</tspan>
-        </text>
-      </g>
+      <rect stroke="currentColor" x="1" y="1" width="14" height="14"></rect>
+      <text font-size="11" font-weight="bold" fill="currentColor" x="49%" y="12" text-anchor="middle">
+        <tspan>{{ symbol }}</tspan>
+      </text>
     </g>
   </SVGIcon>
 </template>

--- a/src/components/Icons/TwoLetterSymbolIcon.vue
+++ b/src/components/Icons/TwoLetterSymbolIcon.vue
@@ -10,7 +10,7 @@
 
 <template>
   <SVGIcon
-    class="reset-circle-icon"
+    class="two-letter-icon"
     width="16px" height="16px" viewBox="0 0 16 16"
   >
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">


### PR DESCRIPTION
- **Rationale:** Minor spacing refactor on the single letter icon SVGs
- **Risk:** Low
- **Risk Detail:** Changes are only in that icon's SVG
- **Reward:** Medium
- **Reward Details:** Fixes some minor visual issues, where the letters were not centered in the icon
- **Original PR:** https://github.com/apple/swift-docc-render/pull/127
- **Issue:** rdar://89653708
- **Code Reviewed By:** @marinaaisa @SamLanier 
- **Testing Details:** Visually inspected