### PR TITLE
[5.7] Fix bug with Safari not pre-filling tagging input when going back (#140)

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -134,7 +134,6 @@ const SuggestedTagsId = 'suggested-tags';
 const AXinputProperties = {
   autocorrect: 'off',
   autocapitalize: 'off',
-  autocomplete: 'off',
   spellcheck: 'false',
   role: 'combobox',
   'aria-haspopup': 'true',


### PR DESCRIPTION
- **Rationale:** Removes an attribute, that is causing a Safari bug when going back from another website to docc-render
- **Risk:** Low
- **Risk Detail:** The change removes a helper attribute
- **Reward:** Medium
- **Reward Details:** Fixes an issue where tagging input would not get pre-filled in Safari, when going to another website , then back.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/140
- **Issue:** rdar://91100473
- **Code Reviewed By:** @marinaaisa
- **Testing Details:** Manually tested in Safari