### PR TITLE
[5.7] Update Hero Icon Placement - pin to the right (#131)

### DIFF
--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -16,14 +16,12 @@
     }]"
     :style="styles"
   >
-    <NavigatorLeafIcon
-      v-if="enhanceBackground" :type="type"
-      key="first" class="background-icon first-icon" with-colors
-    />
-    <NavigatorLeafIcon
-      v-if="enhanceBackground" :type="type"
-      key="second" class="background-icon second-icon" with-colors
-    />
+    <div class="icon">
+      <NavigatorLeafIcon
+        v-if="enhanceBackground" :type="type"
+        key="first" class="background-icon first-icon" with-colors
+      />
+    </div>
     <div class="documentation-hero__content">
       <slot />
     </div>
@@ -66,14 +64,14 @@ $doc-hero-gradient-background: dark-color(fill-tertiary) !default;
 $doc-hero-overlay-background: transparent !default;
 $doc-hero-icon-opacity: 1 !default;
 $doc-hero-icon-color: dark-color(fill-secondary) !default;
+$doc-hero-icon-spacing: 25px;
+$doc-hero-icon-dimension: 250px;
 
 .documentation-hero {
   background: dark-color(fill);
   color: dark-color(figure-gray);
   overflow: hidden;
   text-align: left;
-  padding-top: rem(40px);
-  padding-bottom: 40px;
   position: relative;
 
   // gradient
@@ -100,40 +98,33 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
     top: 0;
   }
 
+  .icon {
+    position: absolute;
+    margin-top: 10px;
+    margin-right: $doc-hero-icon-spacing;
+    right: 0;
+
+    @include breakpoint(small) {
+      display: none;
+    }
+  }
+
   .background-icon {
     color: $doc-hero-icon-color;
-    position: absolute;
     display: block;
-    width: 250px;
-    height: 250px;
+    width: $doc-hero-icon-dimension;
+    height: auto;
     opacity: $doc-hero-icon-opacity;
 
     /deep/ svg {
       width: 100%;
       height: 100%;
     }
-
-    &.first-icon {
-      left: 0;
-      top: 100%;
-      transform: translateY(-50%);
-      @include breakpoint(small) {
-        left: -15%;
-        top: 80%;
-      }
-    }
-
-    &.second-icon {
-      right: 0;
-      top: -10%;
-      transform: translateY(-50%);
-      @include breakpoint(small) {
-        display: none;
-      }
-    }
   }
 
   &__content {
+    padding-top: rem(40px);
+    padding-bottom: 40px;
     position: relative;
     z-index: 1;
     @include dynamic-content-container;

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -54,13 +54,12 @@ describe('DocumentationHero', () => {
   it('renders the DocumentationHero, enabled', () => {
     const wrapper = createWrapper();
     const allIcons = wrapper.findAll(NavigatorLeafIcon);
-    expect(allIcons).toHaveLength(2);
+    expect(allIcons).toHaveLength(1);
     expect(allIcons.at(0).props()).toEqual({
       withColors: true,
       type: defaultProps.type,
     });
     expect(allIcons.at(0).classes()).toEqual(['background-icon', 'first-icon']);
-    expect(allIcons.at(1).classes()).toEqual(['background-icon', 'second-icon']);
     // assert slot
     expect(wrapper.find('.default-slot').text()).toBe('Default Slot');
     expect(wrapper.vm.styles).toEqual({


### PR DESCRIPTION
- Rationale: Updates the hero icon placement to align with the new design. 
- Risk: Low
- Risk Detail: Only a few small CSS additions scoped to hero component.
- Reward: High
- Reward Details: Better visual in the hero section to align with the content style change and the navigator.
- Original PR: https://github.com/apple/swift-docc-render/pull/131
- Issue: rdar://89970511
- Code Reviewed By: @dobromir-hristov
- Testing Details: Visually inspected in simulator. Icons should not be visible in small viewport and should be pinned to the right on all other viewports.