### PR TITLE
Highlight current item in Navigator, when there is a trailing slash in the URL

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -105,6 +105,9 @@ export default {
     },
     // splits out the top-level technology crumb
     activePath({ parentTopicReferences, $route: { path } }) {
+      // Ensure the path does not have a trailing slash
+      // eslint-disable-next-line no-param-reassign
+      path = path.replace(/\/$/, '');
       // route's path is activePath on root
       if (!parentTopicReferences.length) return [path];
       let itemsToSlice = 1;

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import Navigator from '@/components/Navigator.vue';
 import { shallowMount } from '@vue/test-utils';

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import Navigator from '@/components/Navigator.vue';
 import { shallowMount } from '@vue/test-utils';
@@ -178,6 +178,21 @@ describe('Navigator', () => {
     });
     expect(wrapper.find(NavigatorCard).props('activePath')).toEqual([
       references.first.url, references.second.url, mocks.$route.path,
+    ]);
+  });
+
+  it('strips out trailing slashes from the last activePath item', () => {
+    const wrapper = createWrapper({
+      mocks: {
+        ...mocks,
+        $route: {
+          ...mocks.$route,
+          path: '/documentation/foo/bar/',
+        },
+      },
+    });
+    expect(wrapper.find(NavigatorCard).props('activePath')).toEqual([
+      references.first.url, references.second.url, '/documentation/foo/bar',
     ]);
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 91443710

## Summary

This PR fixes a bug Ethan found on [Argument Parser docs](https://ethan-kusters.github.io/swift-argument-parser/documentation/argumentparser/argumenthelp/shoulddisplay/), where docc-render would not highlight the current page in the navigator. 

This turns out to be caused by the trailing slash in the URL, which was causing the current page matching to fail.

## Dependencies

NA

## Testing

Steps:
1. Using any docc-archive, visit a page and just add a trailing slash at the end of the URL
2. Make sure you clear any SessionStorage cache
3. Assert the current page gets highlighted

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
