### PR TITLE
Expose an above-hero-content slot in DocumentationTopic.vue (#132)

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -12,6 +12,9 @@
   <div class="doc-topic">
     <main class="main" id="main" role="main" tabindex="0">
       <DocumentationHero :type="role" :enhanceBackground="enhanceBackground">
+        <template #above-content>
+          <slot name="above-hero-content" />
+        </template>
         <slot name="above-title" />
         <LanguageSwitcher
           v-if="shouldShowLanguageSwitcher"

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -22,6 +22,9 @@
         key="first" class="background-icon first-icon" with-colors
       />
     </div>
+    <div class="documentation-hero__above-content">
+      <slot name="above-content" />
+    </div>
     <div class="documentation-hero__content">
       <slot />
     </div>
@@ -128,6 +131,11 @@ $doc-hero-icon-dimension: 250px;
     position: relative;
     z-index: 1;
     @include dynamic-content-container;
+  }
+
+  &__above-content {
+    position: relative;
+    z-index: 1;
   }
 }
 

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -559,6 +559,19 @@ describe('DocumentationTopic', () => {
     expect(wrapper.find(DocumentationHero).contains('.above-title')).toBe(true);
   });
 
+  it('renders content in the `above-hero-content` slot', () => {
+    wrapper = shallowMount(DocumentationTopic, {
+      propsData,
+      slots: {
+        'above-hero-content': '<div class="above-hero-content">Above Hero Content</div>',
+      },
+      stubs: {
+        DocumentationHero,
+      },
+    });
+    expect(wrapper.contains('.above-hero-content')).toBe(true);
+  });
+
   describe('lifecycle hooks', () => {
     it('calls `store.reset()`', () => {
       const store = {

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -30,6 +30,7 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(Documentat
   },
   slots: {
     default: '<div class="default-slot">Default Slot</div>',
+    'above-content': '<div class="above-content-slot">Above Content Slot</div>',
   },
   ...others,
 });
@@ -62,6 +63,7 @@ describe('DocumentationHero', () => {
     expect(allIcons.at(0).classes()).toEqual(['background-icon', 'first-icon']);
     // assert slot
     expect(wrapper.find('.default-slot').text()).toBe('Default Slot');
+    expect(wrapper.find('.above-content-slot').text()).toBe('Above Content Slot');
     expect(wrapper.vm.styles).toEqual({
       '--accent-color': `var(--color-type-icon-${TopicTypeColorsMap[defaultProps.type]}, var(--color-figure-gray-secondary))`,
     });


### PR DESCRIPTION
- **Rationale:** Adds an extra slot above the documentation topic hero, for third party toolings to insert UI elements.
- **Risk:** Low
- **Risk Detail:** The change just adds a slot, no visual changes for default theme.
- **Reward:** Medium
- **Reward Details:** Adds extra flexibility to third party tooling
- **Original PR:** https://github.com/apple/swift-docc-render/pull/132
- **Issue:** rdar://89151255
- **Code Reviewed By:** @marinaaisa
- **Testing Details:** Manually tested in the browser and added unit tests