### PR TITLE
[5.7] Indicate readonly properties when possible for REST APIs

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/PossiblyChangedTextAttribute.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/PossiblyChangedTextAttribute.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -9,8 +9,8 @@
 -->
 
 <template>
-  <RenderChanged renderSingleChange :value="required" :changes="changes">
-    <span slot-scope="{ value }" v-if="value" class="property-required">(Required) </span>
+  <RenderChanged renderSingleChange :value="value" :changes="changes">
+    <span slot-scope="{ value }" v-if="value" class="property-text"><slot /></span>
   </RenderChanged>
 </template>
 
@@ -18,16 +18,16 @@
 import RenderChanged from 'docc-render/components/DocumentationTopic/PrimaryContent/RenderChanged.vue';
 
 export default {
-  name: 'PossiblyChangedRequiredAttribute',
+  name: 'PossiblyChangedTextAttribute',
   components: { RenderChanged },
   props: {
-    required: {
-      type: Boolean,
-      default: false,
-    },
     changes: {
       type: Object,
       required: false,
+    },
+    value: {
+      type: Boolean,
+      default: false,
     },
   },
 };
@@ -36,7 +36,7 @@ export default {
 <style lang='scss'>
 @import 'docc-render/styles/_core.scss';
 
-.property-required {
+.property-text {
   font-weight: $font-weight-bold;
 }
 </style>

--- a/src/components/DocumentationTopic/PrimaryContent/PropertyTable.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/PropertyTable.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -31,7 +31,8 @@
           content,
           required,
           changes,
-          deprecated
+          deprecated,
+          readOnly,
         }"
       >
         <PossiblyChangedType
@@ -42,10 +43,14 @@
         <template v-if="deprecated">
           <Badge variant="deprecated" class="property-deprecated" />&nbsp;
         </template>
-        <PossiblyChangedRequiredAttribute
-          :required="required"
+        <PossiblyChangedTextAttribute
           :changes="changes.required"
-        />
+          :value="required"
+        >(Required) </PossiblyChangedTextAttribute>
+        <PossiblyChangedTextAttribute
+          :changes="changes.readOnly"
+          :value="readOnly"
+        >(Read only) </PossiblyChangedTextAttribute>
         <ContentNode v-if="content" :content="content" />
         <ParameterAttributes :attributes="attributes" :changes="changes.attributes" />
       </template>
@@ -63,7 +68,7 @@ import apiChangesProvider from 'docc-render/mixins/apiChangesProvider';
 import Badge from 'docc-render/components/Badge.vue';
 import ParametersTable from './ParametersTable.vue';
 import ParameterAttributes from './ParameterAttributes.vue';
-import PossiblyChangedRequiredAttribute from './PossiblyChangedRequiredAttribute.vue';
+import PossiblyChangedTextAttribute from './PossiblyChangedTextAttribute.vue';
 import PossiblyChangedType from './PossiblyChangedType.vue';
 
 export default {
@@ -72,7 +77,7 @@ export default {
   components: {
     Badge,
     WordBreak,
-    PossiblyChangedRequiredAttribute,
+    PossiblyChangedTextAttribute,
     PossiblyChangedType,
     ParameterAttributes,
     ContentNode,

--- a/src/components/DocumentationTopic/PrimaryContent/RestBody.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestBody.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -49,7 +49,7 @@
         </template>
         <template
           slot="description"
-          slot-scope="{ content, mimeType, required, type, attributes, changes }"
+          slot-scope="{ content, mimeType, required, type, attributes, changes, readOnly }"
         >
           <div>
             <PossiblyChangedType
@@ -57,10 +57,14 @@
               :type="type"
               :changes="changes.type"
             />
-            <PossiblyChangedRequiredAttribute
-              :required="required"
+            <PossiblyChangedTextAttribute
               :changes="changes.required"
-            />
+              :value="required"
+            >(Required) </PossiblyChangedTextAttribute>
+            <PossiblyChangedTextAttribute
+              :changes="changes.readOnly"
+              :value="readOnly"
+            >(Read only) </PossiblyChangedTextAttribute>
             <ContentNode v-if="content" :content="content" />
             <PossiblyChangedMimetype
               v-if="mimeType"
@@ -87,7 +91,7 @@ import ParametersTable from './ParametersTable.vue';
 import ParameterAttributes from './ParameterAttributes.vue';
 import PossiblyChangedType from './PossiblyChangedType.vue';
 import PossiblyChangedMimetype from './PossiblyChangedMimetype.vue';
-import PossiblyChangedRequiredAttribute from './PossiblyChangedRequiredAttribute.vue';
+import PossiblyChangedTextAttribute from './PossiblyChangedTextAttribute.vue';
 
 const ChangesKey = 'restRequestBody';
 
@@ -96,7 +100,7 @@ export default {
   mixins: [apiChangesProvider],
   components: {
     PossiblyChangedMimetype,
-    PossiblyChangedRequiredAttribute,
+    PossiblyChangedTextAttribute,
     PossiblyChangedType,
     WordBreak,
     ParameterAttributes,

--- a/src/components/DocumentationTopic/PrimaryContent/RestParameters.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestParameters.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -24,7 +24,7 @@
       </template>
       <template
         slot="description"
-        slot-scope="{ name, type, content, required, attributes, changes, deprecated }"
+        slot-scope="{ name, type, content, required, attributes, changes, deprecated, readOnly }"
       >
         <div>
           <PossiblyChangedType
@@ -35,10 +35,14 @@
           <template v-if="deprecated">
             <Badge variant="deprecated" class="param-deprecated" />&nbsp;
           </template>
-          <PossiblyChangedRequiredAttribute
-            :required="required"
+          <PossiblyChangedTextAttribute
             :changes="changes.required"
-          />
+            :value="required"
+          >(Required) </PossiblyChangedTextAttribute>
+          <PossiblyChangedTextAttribute
+            :changes="changes.readOnly"
+            :value="readOnly"
+          >(Read only) </PossiblyChangedTextAttribute>
           <ContentNode v-if="content" :content="content" />
           <ParameterAttributes :attributes="attributes" :changes="changes" />
         </div>
@@ -57,7 +61,7 @@ import apiChangesProvider from 'docc-render/mixins/apiChangesProvider';
 import Badge from 'docc-render/components/Badge.vue';
 import ParametersTable from './ParametersTable.vue';
 import ParameterAttributes from './ParameterAttributes.vue';
-import PossiblyChangedRequiredAttribute from './PossiblyChangedRequiredAttribute.vue';
+import PossiblyChangedTextAttribute from './PossiblyChangedTextAttribute.vue';
 import PossiblyChangedType from './PossiblyChangedType.vue';
 
 export default {
@@ -66,7 +70,7 @@ export default {
   components: {
     Badge,
     PossiblyChangedType,
-    PossiblyChangedRequiredAttribute,
+    PossiblyChangedTextAttribute,
     ParameterAttributes,
     WordBreak,
     ContentNode,

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/PossiblyChangedTextAttribute.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/PossiblyChangedTextAttribute.spec.js
@@ -8,11 +8,11 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import PossiblyChangedRequiredAttribute
-  from 'docc-render/components/DocumentationTopic/PrimaryContent/PossiblyChangedRequiredAttribute.vue';
+import PossiblyChangedTextAttribute
+  from 'docc-render/components/DocumentationTopic/PrimaryContent/PossiblyChangedTextAttribute.vue';
 import { shallowMount } from '@vue/test-utils';
 
-const { RenderChanged } = PossiblyChangedRequiredAttribute.components;
+const { RenderChanged } = PossiblyChangedTextAttribute.components;
 
 const changes = {
   new: false,
@@ -20,20 +20,24 @@ const changes = {
 };
 
 const defaultProps = {
-  required: true,
+  value: true,
 };
 
-const createWrapper = ({ propsData } = {}) => (shallowMount(PossiblyChangedRequiredAttribute, {
+const createWrapper = ({ propsData, slots } = {}) => (shallowMount(PossiblyChangedTextAttribute, {
   propsData: {
     ...defaultProps,
     ...propsData,
+  },
+  slots: {
+    default: '(Required) ',
+    ...slots,
   },
   stubs: {
     RenderChanged,
   },
 }));
 
-describe('PossiblyChangedRequiredAttribute', () => {
+describe('PossiblyChangedTextAttribute', () => {
   it('renders a `RenderChanged`', () => {
     const wrapper = createWrapper({
       propsData: {
@@ -43,32 +47,41 @@ describe('PossiblyChangedRequiredAttribute', () => {
     expect(wrapper.find(RenderChanged).props()).toEqual(expect.objectContaining({
       changes,
       renderSingleChange: true,
-      value: defaultProps.required,
+      value: defaultProps.value,
     }));
-    expect(wrapper.find('.property-required').exists()).toBe(true);
+    expect(wrapper.find('.property-text').exists()).toBe(true);
   });
 
   it('renders a text node, if value is false but has changes', () => {
     const wrapper = createWrapper({
       propsData: {
-        required: false,
+        value: false,
         changes,
       },
     });
-    expect(wrapper.find('.property-required').exists()).toBe(true);
+    expect(wrapper.find('.property-text').exists()).toBe(true);
   });
 
   it('does not render a text node, if value is false and no changes', () => {
     const wrapper = createWrapper({
       propsData: {
-        required: false,
+        value: false,
       },
     });
-    expect(wrapper.find('.property-required').exists()).toBe(false);
+    expect(wrapper.find('.property-text').exists()).toBe(false);
   });
 
   it('renders a `Required` text', () => {
     const wrapper = createWrapper();
-    expect(wrapper.find('.property-required').element.textContent).toEqual('(Required) ');
+    expect(wrapper.find('.property-text').element.textContent).toEqual('(Required) ');
+  });
+
+  it('renders slot content', () => {
+    const wrapper = createWrapper({
+      slots: {
+        default: '(Read only) ',
+      },
+    });
+    expect(wrapper.find('.property-text').element.textContent).toEqual('(Read only) ');
   });
 });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyTable.spec.js
@@ -190,7 +190,7 @@ describe('PropertyTable', () => {
     const wrapper = mountComponent();
     expect(
       wrapper
-        .findAll('.property-required')
+        .findAll('.property-text')
         .at(0)
         .text(),
     ).toBe('(Required)');

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestBody.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestBody.spec.js
@@ -19,7 +19,7 @@ const {
   ParameterAttributes,
   PossiblyChangedMimetype,
   WordBreak,
-  PossiblyChangedRequiredAttribute,
+  PossiblyChangedTextAttribute,
 } = RestBody.components;
 
 const { ChangesKey } = RestBody.constants;
@@ -361,7 +361,7 @@ describe('RestBody', () => {
       expect(table.find(PossiblyChangedMimetype).props())
         .toMatchObject({ changes: partsChange.mimetype, change: partsChange.change });
 
-      expect(table.find(PossiblyChangedRequiredAttribute).props())
+      expect(table.find(PossiblyChangedTextAttribute).props())
         .toHaveProperty('changes', partsChange.required);
 
       expect(table.find(ParameterAttributes).props())

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestParameters.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestParameters.spec.js
@@ -18,7 +18,7 @@ const {
   OnThisPageSection,
   WordBreak,
   ParameterAttributes,
-  PossiblyChangedRequiredAttribute,
+  PossiblyChangedTextAttribute,
 } = RestParameters.components;
 
 const { AttributeKind } = RestParameters.components.ParameterAttributes.constants;
@@ -165,7 +165,7 @@ describe('RestParameters', () => {
       },
     });
     expect(wrapper.find('.param-name').text()).toBe('lastname');
-    expect(wrapper.find(PossiblyChangedRequiredAttribute).exists()).toBe(true);
+    expect(wrapper.find(PossiblyChangedTextAttribute).exists()).toBe(true);
     expect(wrapper.find(PossiblyChangedType).text()).toBe('string');
     expect(wrapper.find({ name: 'ContentNode' }).props('content')).toEqual(
       parameters[0].content,
@@ -222,7 +222,7 @@ describe('RestParameters', () => {
     });
 
     expect(wrapper.find(PossiblyChangedType).props()).toHaveProperty('changes', changes.name.type);
-    expect(wrapper.find(PossiblyChangedRequiredAttribute).props())
+    expect(wrapper.find(PossiblyChangedTextAttribute).props())
       .toHaveProperty('changes', changes.name.required);
     expect(wrapper.find(ParameterAttributes).props()).toHaveProperty('changes', changes.name);
   });


### PR DESCRIPTION
- **Rationale:** Adds support for rendering "(Readonly)" text when relevant for REST API properties.
- **Risk:** Low
- **Risk Detail:** Narrow focus on less common UI element, only adds some minor text output.
- **Reward:** High
- **Reward Details:** Adds important clarifying detail to specific API properties.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/142
- **Issue:** rdar://89264865
- **Code Reviewed By:** @dobromir-hristov
- **Testing Details:** Updated unit tests, verified that the new "(Readonly)" text looks correct visually.