### PR TITLE
[5.7] Highlight current item in Navigator, when there is a trailing slash i…

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -105,6 +105,9 @@ export default {
     },
     // splits out the top-level technology crumb
     activePath({ parentTopicReferences, $route: { path } }) {
+      // Ensure the path does not have a trailing slash
+      // eslint-disable-next-line no-param-reassign
+      path = path.replace(/\/$/, '');
       // route's path is activePath on root
       if (!parentTopicReferences.length) return [path];
       let itemsToSlice = 1;

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -181,6 +181,21 @@ describe('Navigator', () => {
     ]);
   });
 
+  it('strips out trailing slashes from the last activePath item', () => {
+    const wrapper = createWrapper({
+      mocks: {
+        ...mocks,
+        $route: {
+          ...mocks.$route,
+          path: '/documentation/foo/bar/',
+        },
+      },
+    });
+    expect(wrapper.find(NavigatorCard).props('activePath')).toEqual([
+      references.first.url, references.second.url, '/documentation/foo/bar',
+    ]);
+  });
+
   it('renders the root path as activePath when there is no parentTopicIdentifiers', () => {
     const wrapper = createWrapper({
       propsData: {


### PR DESCRIPTION
- Rationale: Updates the route matching logic in the Navigator, to compensate for trailing slashes.
- Risk: Low
- Risk Detail: We are only stripping any extra slashes in the path matcher.
- Reward: High
- Reward Details: Properly highlights the current page you are on, when viewing github pages deployed app.
- Original PR: https://github.com/apple/swift-docc-render/pull/147
- Issue: rdar://91443710
- Code Reviewed By: @mportiz08 
- Testing Details: Automated Tests + Manually tested by adding trailing slashes to the URL