### PR TITLE
[5.7] Remove extra borders from Navigator (#154)

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -190,7 +190,6 @@ export default {
 
 .navigator {
   height: 100%;
-  border-left: 1px solid var(--color-grid);
   display: flex;
   flex-flow: column;
 
@@ -200,7 +199,6 @@ export default {
 
   @include breakpoint(medium, nav) {
     position: static;
-    border-left: none;
     transition: none;
   }
 }


### PR DESCRIPTION
- Rationale: Remove an extra border from navigator, that we dont need.
- Risk: Low
- Risk Detail: Its removing a line of css, that was left out from previous refactors.
- Reward: Medium
- Reward Details: Fixes a small visual problem.
- Original PR: https://github.com/apple/swift-docc-render/pull/154
- Issue: rdar://89638066
- Code Reviewed By: @marinaaisa 
- Testing Details: Visually inspected on all supported viewports.