### PR TITLE
[5.7] Sidenav toggle button should have aria-label description

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -21,7 +21,11 @@
     aria-label="API Reference"
   >
     <template #pre-title="{ closeNav }" v-if="isWideFormat">
-      <button class="sidenav-toggle" @click.prevent="handleSidenavToggle(closeNav)">
+      <button
+        aria-label="Open documentation navigator"
+        class="sidenav-toggle"
+        @click.prevent="handleSidenavToggle(closeNav)"
+      >
         <SidenavIcon class="icon-inline sidenav-icon" />
       </button>
     </template>

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -13,7 +13,11 @@
     <div class="navigator-card-full-height">
       <div class="navigator-card-inner">
         <div class="head-wrapper">
-          <button class="close-card-mobile" @click="$emit('close')">
+          <button
+            aria-label="Close documentation navigator"
+            class="close-card-mobile"
+            @click="$emit('close')"
+          >
             <SidenavIcon class="icon-inline close-icon" />
           </button>
           <Reference :url="technologyPath" class="navigator-head" :id="INDEX_ROOT_KEY">
@@ -35,7 +39,7 @@
             :id="scrollLockID"
             ref="scroller"
             class="scroller"
-            aria-label="Sidebar Tree Navigator"
+            aria-label="Documentation Navigator"
             :items="nodesToRender"
             :item-size="itemSize"
             :buffer="1000"

--- a/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
@@ -266,8 +266,10 @@ describe('DocumentationNav', () => {
   });
 
   it('renders a sidenav toggle', async () => {
-    wrapper.find('.sidenav-toggle').trigger('click');
+    const button = wrapper.find('.sidenav-toggle');
+    button.trigger('click');
     await flushPromises();
+    expect(button.attributes('aria-label')).toBe('Open documentation navigator');
     expect(wrapper.emitted('toggle-sidenav')).toBeTruthy();
   });
 

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -169,7 +169,7 @@ describe('NavigatorCard', () => {
       keyField: 'uid',
       buffer: 1000,
     });
-    expect(wrapper.find(RecycleScroller).attributes('aria-label')).toBe('Sidebar Tree Navigator');
+    expect(wrapper.find(RecycleScroller).attributes('aria-label')).toBe('Documentation Navigator');
     expect(scroller.attributes('id')).toEqual(defaultProps.scrollLockID);
     // assert CardItem
     const items = wrapper.findAll(NavigatorCardItem);
@@ -1110,8 +1110,10 @@ describe('NavigatorCard', () => {
 
   it('emits a `close` event', async () => {
     const wrapper = createWrapper();
-    wrapper.find('.close-card-mobile').trigger('click');
+    const button = wrapper.find('.close-card-mobile');
+    button.trigger('click');
     await flushPromises();
+    expect(button.attributes('aria-label')).toBe('Close documentation navigator');
     expect(wrapper.emitted('close')).toHaveLength(1);
   });
 


### PR DESCRIPTION
Rationale: Update aria-labels for documentation navigator
Risk: Low
Risk Detail: Only aria-labels changes.
Reward: High for VoiceOver users
Reward Details: Better VoiceOver descriptions
Original PR: https://github.com/apple/swift-docc-render/pull/161
Issue: rdar://91493171
Code Reviewed By: @dobromir-hristov @[hqhhuang](https://github.com/hqhhuang)
Testing Details: Using VoiceOver