### PR TITLE
[5.7] Stop resetting the selectedAPIChangesVersion, on each page navigation

### DIFF
--- a/src/stores/ApiChangesStoreBase.js
+++ b/src/stores/ApiChangesStoreBase.js
@@ -34,10 +34,11 @@ export default {
   setSelectedAPIChangesVersion(value) {
     this.state.selectedAPIChangesVersion = value;
   },
+  // Reset the API changes data, except for the `selectedAPIChangesVersion`.
+  // This method is called primarily on page navigation, to clear old changes data.
   resetApiChanges() {
     this.state.apiChanges = null;
     this.state.apiChangesCounts = apiChangesCountsFactory();
-    this.state.selectedAPIChangesVersion = null;
   },
   async updateApiChangesCounts() {
     await Vue.nextTick();

--- a/tests/unit/stores/ApiChangesStoreBase.spec.js
+++ b/tests/unit/stores/ApiChangesStoreBase.spec.js
@@ -50,7 +50,8 @@ describe('ApiChangesStoreBase', () => {
     expect(ApiChangesStoreBase.state.apiChangesCounts).toHaveProperty('modified', 5);
     ApiChangesStoreBase.resetApiChanges();
     expect(ApiChangesStoreBase.state.apiChangesCounts).toEqual(defaultCounts);
-    expect(ApiChangesStoreBase.state.selectedAPIChangesVersion).toEqual(null);
+    // assert `selectedAPIChangesVersion` not changed
+    expect(ApiChangesStoreBase.state.selectedAPIChangesVersion).toEqual('latest_major');
     expect(ApiChangesStoreBase.state.apiChanges).toEqual(null);
   });
 });


### PR DESCRIPTION
- **Rationale:** the `selectedAPIChangesVersion` should only be changed from a toggle
- **Risk:** Low
- **Risk Detail:** The change is only scoped to a store, that is not yet utilised in docc-render.
- **Reward:** High
- **Reward Details:** Users will not get `selectedAPIChangesVersion` reset via page navigation.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/166
- **Issue:** rdar://91334846
- **Code Reviewed By:** @mportiz08 
- **Testing Details:** Added Unit Tests