### PR TITLE
[5.7] Improve the children flattening performance in the Navigator

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -147,9 +147,12 @@ export default {
      * @return {NavigatorFlatItem[]}
      */
     flattenNestedData(childrenNodes, parent = null, depth = 0) {
-      return childrenNodes.reduce((items, item, index) => {
+      let items = [];
+      const len = childrenNodes.length;
+      let index;
+      for (index = 0; index < len; index += 1) {
         // get the children
-        const { children, ...node } = item;
+        const { children, ...node } = childrenNodes[index];
         // generate the extra properties
         const { uid: parentUID = INDEX_ROOT_KEY } = parent || {};
         // generate a uid to track by
@@ -159,7 +162,7 @@ export default {
         // store which item it is
         node.index = index;
         // store how many siblings it has
-        node.siblingsCount = childrenNodes.length;
+        node.siblingsCount = len;
         // store the depth
         node.depth = depth;
         // store child UIDs
@@ -169,17 +172,13 @@ export default {
           // push child to parent
           parent.childUIDs.push(node.uid);
         }
+        items.push(node);
         if (children) {
-          // recursively walk the children
-          const iteratedChildren = this.flattenNestedData(children, node, depth + 1);
-          // push the node to the items stack
-          items.push(node);
           // return the children to the parent
-          return items.concat(iteratedChildren);
+          items = items.concat(this.flattenNestedData(children, node, depth + 1));
         }
-        // return the node
-        return items.concat(node);
-      }, []);
+      }
+      return items;
     },
   },
 };

--- a/src/components/Navigator/NavigatorDataProvider.vue
+++ b/src/components/Navigator/NavigatorDataProvider.vue
@@ -74,7 +74,7 @@ export default {
       try {
         this.isFetching = true;
         const { interfaceLanguages } = await fetchIndexPathsData();
-        this.navigationIndex = interfaceLanguages;
+        this.navigationIndex = Object.freeze(interfaceLanguages);
       } catch (e) {
         this.errorFetching = true;
       } finally {


### PR DESCRIPTION
- **Rationale:** Improves the Navigator rendering performance
- **Risk:** Low
- **Risk Detail:** The change only implements more performant loops and removes reactivity where not needed.
- **Reward:** High
- **Reward Details:** Users should see a much improved loading speed on large indexes. 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/157
- **Issue:** rdar://91610791
- **Code Reviewed By:** @mportiz08 
- **Testing Details:** Manually tested in the browser using performance profiling 