### PR TITLE
[5.7] Fix uneven divider in nav bar for small viewport

### DIFF
--- a/src/components/NavMenuLink.vue
+++ b/src/components/NavMenuLink.vue
@@ -60,6 +60,7 @@ export default {
   white-space: nowrap;
 
   @include nav-in-breakpoint {
+    line-height: 42px;
     border-top: 1px solid;
     border-color: var(--color-nav-rule);
     display: flex;


### PR DESCRIPTION
- **Rationale:** Spacing was Nav bar is broken in small viewport. This is a fix for a regression
- **Risk:** Low
- **Risk Detail:** The change is only a 1 line CSS change.
- **Reward:** High
- **Reward Details:** Fixes regression in Nav bar spacing in small viewport. 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/162
- **Issue:** rdar://91372980
- **Code Reviewed By:** @dobromir-hristov
- **Testing Details:** Manually tested in the browser 