### PR TITLE
[5.7] Update Icon color for collectionGroup and sampleCode 

### DIFF
--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -34,7 +34,8 @@
 <script>
 
 import NavigatorLeafIcon from 'docc-render/components/Navigator/NavigatorLeafIcon.vue';
-import { TopicTypeColorsMap, TopicTypeAliases, TopicTypeColors } from 'docc-render/constants/TopicTypes';
+import { TopicTypeAliases } from 'docc-render/constants/TopicTypes';
+import { HeroColorsMap, HeroColors } from 'docc-render/constants/HeroColors';
 
 export default {
   name: 'DocumentationHero',
@@ -51,7 +52,7 @@ export default {
   },
   computed: {
     // get the alias, if any, and fallback to the `teal` color
-    color: ({ type }) => TopicTypeColorsMap[TopicTypeAliases[type] || type] || TopicTypeColors.teal,
+    color: ({ type }) => HeroColorsMap[TopicTypeAliases[type] || type] || HeroColors.teal,
     styles: ({ color }) => ({
       // use the color or fallback to the gray secondary, if not defined.
       '--accent-color': `var(--color-type-icon-${color}, var(--color-figure-gray-secondary))`,

--- a/src/components/Navigator/NavigatorLeafIcon.vue
+++ b/src/components/Navigator/NavigatorLeafIcon.vue
@@ -26,7 +26,8 @@ import CurlyBracketsIcon from 'theme/components/Icons/CurlyBracketsIcon.vue';
 import TopicSubscriptIcon from 'theme/components/Icons/TopicSubscriptIcon.vue';
 import TwoLetterSymbolIcon from 'theme/components/Icons/TwoLetterSymbolIcon.vue';
 import SingleLetterSymbolIcon from 'theme/components/Icons/SingleLetterSymbolIcon.vue';
-import { TopicTypes, TopicTypeAliases, TopicTypeColorsMap } from 'docc-render/constants/TopicTypes';
+import { TopicTypes, TopicTypeAliases } from 'docc-render/constants/TopicTypes';
+import { HeroColorsMap } from 'docc-render/constants/HeroColors';
 
 const TopicTypeIcons = {
   [TopicTypes.article]: ArticleIcon,
@@ -96,7 +97,7 @@ export default {
     normalisedType: ({ type }) => TopicTypeAliases[type] || type,
     icon: ({ normalisedType }) => TopicTypeIcons[normalisedType] || CollectionIcon,
     iconProps: ({ normalisedType }) => TopicTypeProps[normalisedType] || {},
-    color: ({ normalisedType }) => TopicTypeColorsMap[normalisedType],
+    color: ({ normalisedType }) => HeroColorsMap[normalisedType],
     styles: ({ color, withColors }) => (withColors && color ? { color: `var(--color-type-icon-${color})` } : {}),
   },
 };

--- a/src/constants/HeroColors.js
+++ b/src/constants/HeroColors.js
@@ -1,0 +1,49 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+import { TopicTypes } from 'docc-render/constants/TopicTypes';
+import { TopicRole } from 'docc-render/constants/roles';
+
+export const HeroColors = {
+  blue: 'blue',
+  teal: 'teal',
+  orange: 'orange',
+  purple: 'purple',
+  green: 'green',
+  sky: 'sky',
+  pink: 'pink',
+};
+
+export const HeroColorsMap = {
+  [TopicTypes.article]: HeroColors.teal,
+  [TopicTypes.init]: HeroColors.blue,
+  [TopicTypes.case]: HeroColors.orange,
+  [TopicTypes.class]: HeroColors.purple,
+  [TopicTypes.collection]: HeroColors.sky,
+  [TopicRole.collectionGroup]: HeroColors.teal,
+  [TopicTypes.dictionarySymbol]: HeroColors.purple,
+  [TopicTypes.enum]: HeroColors.orange,
+  [TopicTypes.extension]: HeroColors.orange,
+  [TopicTypes.func]: HeroColors.green,
+  [TopicTypes.op]: HeroColors.green,
+  [TopicTypes.httpRequest]: HeroColors.green,
+  [TopicTypes.module]: HeroColors.sky,
+  [TopicTypes.method]: HeroColors.blue,
+  [TopicTypes.macro]: HeroColors.pink,
+  [TopicTypes.protocol]: HeroColors.purple,
+  [TopicTypes.property]: HeroColors.teal,
+  [TopicTypes.propertyListKey]: HeroColors.green,
+  [TopicTypes.propertyListKeyReference]: HeroColors.green,
+  [TopicTypes.sampleCode]: HeroColors.teal,
+  [TopicTypes.struct]: HeroColors.purple,
+  [TopicTypes.subscript]: HeroColors.blue,
+  [TopicTypes.typealias]: HeroColors.orange,
+  [TopicTypes.union]: HeroColors.purple,
+  [TopicTypes.var]: HeroColors.purple,
+};

--- a/src/constants/TopicTypes.js
+++ b/src/constants/TopicTypes.js
@@ -54,39 +54,3 @@ export const TopicTypeAliases = {
   [TopicTypes.propertyListKeyReference]: TopicTypes.propertyListKey,
   [TopicTypes.project]: TopicTypes.tutorial,
 };
-
-export const TopicTypeColors = {
-  blue: 'blue',
-  teal: 'teal',
-  orange: 'orange',
-  purple: 'purple',
-  green: 'green',
-  sky: 'sky',
-  pink: 'pink',
-};
-
-export const TopicTypeColorsMap = {
-  [TopicTypes.article]: TopicTypeColors.teal,
-  [TopicTypes.init]: TopicTypeColors.blue,
-  [TopicTypes.case]: TopicTypeColors.orange,
-  [TopicTypes.class]: TopicTypeColors.purple,
-  [TopicTypes.collection]: TopicTypeColors.sky,
-  [TopicTypes.dictionarySymbol]: TopicTypeColors.purple,
-  [TopicTypes.enum]: TopicTypeColors.orange,
-  [TopicTypes.extension]: TopicTypeColors.orange,
-  [TopicTypes.func]: TopicTypeColors.green,
-  [TopicTypes.op]: TopicTypeColors.green,
-  [TopicTypes.httpRequest]: TopicTypeColors.green,
-  [TopicTypes.module]: TopicTypeColors.sky,
-  [TopicTypes.method]: TopicTypeColors.blue,
-  [TopicTypes.macro]: TopicTypeColors.pink,
-  [TopicTypes.protocol]: TopicTypeColors.purple,
-  [TopicTypes.property]: TopicTypeColors.teal,
-  [TopicTypes.propertyListKey]: TopicTypeColors.green,
-  [TopicTypes.propertyListKeyReference]: TopicTypeColors.green,
-  [TopicTypes.struct]: TopicTypeColors.purple,
-  [TopicTypes.subscript]: TopicTypeColors.blue,
-  [TopicTypes.typealias]: TopicTypeColors.orange,
-  [TopicTypes.union]: TopicTypeColors.purple,
-  [TopicTypes.var]: TopicTypeColors.purple,
-};

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -10,13 +10,9 @@
 
 import DocumentationHero from '@/components/DocumentationTopic/DocumentationHero.vue';
 import { shallowMount } from '@vue/test-utils';
-import {
-  TopicTypes,
-  TopicTypeAliases,
-  TopicTypeColors,
-  TopicTypeColorsMap,
-} from '@/constants/TopicTypes';
+import { TopicTypes, TopicTypeAliases } from '@/constants/TopicTypes';
 import NavigatorLeafIcon from '@/components/Navigator/NavigatorLeafIcon.vue';
+import { HeroColors, HeroColorsMap } from '@/constants/HeroColors';
 
 const defaultProps = {
   type: TopicTypes.class,
@@ -65,7 +61,7 @@ describe('DocumentationHero', () => {
     expect(wrapper.find('.default-slot').text()).toBe('Default Slot');
     expect(wrapper.find('.above-content-slot').text()).toBe('Above Content Slot');
     expect(wrapper.vm.styles).toEqual({
-      '--accent-color': `var(--color-type-icon-${TopicTypeColorsMap[defaultProps.type]}, var(--color-figure-gray-secondary))`,
+      '--accent-color': `var(--color-type-icon-${HeroColorsMap[defaultProps.type]}, var(--color-figure-gray-secondary))`,
     });
   });
 
@@ -75,7 +71,7 @@ describe('DocumentationHero', () => {
         type: TopicTypes.init,
       },
     });
-    const color = TopicTypeColorsMap[TopicTypeAliases[TopicTypes.init]];
+    const color = HeroColorsMap[TopicTypeAliases[TopicTypes.init]];
     expect(wrapper.vm.styles).toEqual({
       '--accent-color': `var(--color-type-icon-${color}, var(--color-figure-gray-secondary))`,
     });
@@ -88,7 +84,7 @@ describe('DocumentationHero', () => {
       },
     });
     expect(wrapper.vm.styles).toEqual({
-      '--accent-color': `var(--color-type-icon-${TopicTypeColors.teal}, var(--color-figure-gray-secondary))`,
+      '--accent-color': `var(--color-type-icon-${HeroColors.teal}, var(--color-figure-gray-secondary))`,
     });
   });
 
@@ -111,7 +107,7 @@ describe('DocumentationHero', () => {
     // assert slot
     expect(wrapper.find('.default-slot').text()).toBe('Default Slot');
     expect(wrapper.vm.styles).toEqual({
-      '--accent-color': `var(--color-type-icon-${TopicTypeColorsMap[defaultProps.type]}, var(--color-figure-gray-secondary))`,
+      '--accent-color': `var(--color-type-icon-${HeroColorsMap[defaultProps.type]}, var(--color-figure-gray-secondary))`,
     });
   });
 });

--- a/tests/unit/components/Navigator/NavigatorLeafIcon.spec.js
+++ b/tests/unit/components/Navigator/NavigatorLeafIcon.spec.js
@@ -10,7 +10,8 @@
 
 import NavigatorLeafIcon from '@/components/Navigator/NavigatorLeafIcon.vue';
 import { shallowMount } from '@vue/test-utils';
-import { TopicTypes, TopicTypeAliases, TopicTypeColorsMap } from '@/constants/TopicTypes';
+import { TopicTypes, TopicTypeAliases } from '@/constants/TopicTypes';
+import { HeroColorsMap } from 'docc-render/constants/HeroColors';
 import CollectionIcon from '@/components/Icons/CollectionIcon.vue';
 
 const createWrapper = opts => shallowMount(NavigatorLeafIcon, opts);
@@ -22,7 +23,7 @@ const {
 const cases = Object.keys(TopicTypes).map((type) => {
   const k = TopicTypeAliases[type] || type;
   const icon = TopicTypeIcons[k] || CollectionIcon;
-  const color = TopicTypeColorsMap[k];
+  const color = HeroColorsMap[k];
   return [type, icon.name, TopicTypeProps[type] || {}, color, icon];
 });
 


### PR DESCRIPTION
- **Rationale:** Icon color was not applying for collectionGroup and sampleCode pages
- **Risk:** Low
- **Risk Detail:** The change moved the color mapping logic to a different file, but is only changes affecting color and there's no change in the logic itself.
- **Reward:** High
- **Reward Details:** Fixes the issue where the icons on those pages are not visible at all.  
- **Original PR:** https://github.com/apple/swift-docc-render/pull/158
- **Issue:** rdar://91450969
- **Code Reviewed By:** @dobromir-hristov
- **Testing Details:** Manually tested in the browser 