### PR TITLE
Update padding to be consistent with Tutorial in S viewport

### DIFF
--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -342,8 +342,9 @@ $breakpoint-attributes: (
     }
 
     @include breakpoint(small) {
-      padding-left: 20px;
-      padding-right: 20px;
+      width: 87.5%;
+      padding-left: unset;
+      padding-right: unset;
     }
   }
 


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://90844182

## Summary
The padding for documentation pages in S viewport is too small.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
