### PR TITLE
Convert `left` rule to `padding` rule to fix inset issue

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -998,7 +998,7 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
     padding-left: $nav-padding;
     padding-right: $nav-padding;
 
-    @include safe-area-left-set(left, 0px);
+    @include safe-area-left-set(padding-left, $nav-padding);
   }
 
   @include breakpoint(small, nav) {


### PR DESCRIPTION
Bug/issue #, if applicable: 89775264

## Summary

For some reason, there is a CSS `left` property assignment that is inconsistently being evaluated as expected on devices with left inset values.

I've simply updated this to be a `padding` rule, which seems to resolve this issue and the spacing works consistently now.

## Testing

Steps:
1. Open a page with the sidebar on a device that has a left inset when in landscape orientation (like the iPhone 13 Pro as an example).
2. Open the mobile sidebar and verify that the close icon is not obscured by the device.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~~
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
