### PR TITLE
Fix width of highlight in S viewport

### DIFF
--- a/src/components/DocumentationTopic/TopicsLinkBlock.vue
+++ b/src/components/DocumentationTopic/TopicsLinkBlock.vue
@@ -227,6 +227,7 @@ export default {
   &.changed {
     @include change-highlight-target();
     @include change-highlight-horizontal-text-alignment();
+    box-sizing: border-box;
   }
 }
 

--- a/src/styles/core/_changes.scss
+++ b/src/styles/core/_changes.scss
@@ -78,7 +78,7 @@ $deprecated-dark-rounded-svg: $deprecated-svg !default;
 }
 
 @mixin change-highlight-end-spacing() {
-  padding-right: $change-icon-width + $change-highlight-horizontal-space-rem;
+  padding-right: $change-highlight-horizontal-space;
 }
 
 @mixin change-highlight-horizontal-spacing() {
@@ -130,7 +130,7 @@ $deprecated-dark-rounded-svg: $deprecated-svg !default;
 
     &.changed {
       margin-left: rem(-$change-highlight-horizontal-space);
-      width: calc(100% + #{$change-highlight-horizontal-space * 2});
+      width: 100%;
     }
   }
 }

--- a/src/styles/core/_changes.scss
+++ b/src/styles/core/_changes.scss
@@ -78,7 +78,7 @@ $deprecated-dark-rounded-svg: $deprecated-svg !default;
 }
 
 @mixin change-highlight-end-spacing() {
-  padding-right: $change-highlight-horizontal-space;
+  padding-right: $change-icon-width + $change-highlight-horizontal-space-rem;
 }
 
 @mixin change-highlight-horizontal-spacing() {
@@ -130,7 +130,7 @@ $deprecated-dark-rounded-svg: $deprecated-svg !default;
 
     &.changed {
       margin-left: rem(-$change-highlight-horizontal-space);
-      width: 100%;
+      width: calc(100% + #{$change-highlight-horizontal-space * 2});
     }
   }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 89800555

## Summary
Fix width of highlight in S viewport to avoid it being cut off.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
