### PR TITLE
[5.7] Make sure we show only tags, that match the currently filtered items in navigator

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -258,11 +258,12 @@ export default {
      * Generates an array of tag labels for filtering.
      * Shows only tags, that have children matches.
      */
-    availableTags: ({ selectedTags, children }) => {
+    availableTags: ({ selectedTags, renderableChildNodesMap }) => {
       const tagLabels = selectedTags.length ? [] : Object.values(FILTER_TAGS_TO_LABELS);
       if (!tagLabels.length) return tagLabels;
       const tagLabelsSet = new Set(tagLabels);
       const availableTags = [];
+      const children = Object.values(renderableChildNodesMap);
       const len = children.length;
       let i;
       // iterate over the nodes to render

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1428,6 +1428,10 @@ describe('NavigatorCard', () => {
     const filter = wrapper.find(FilterInput);
     // assert there are no Articles for example
     expect(filter.props('tags')).toEqual(['Tutorials', 'Sample Code']);
+    // apply a filter
+    filter.vm.$emit('input', sampleCode.title);
+    await flushPromises();
+    expect(filter.props('tags')).toEqual(['Sample Code']);
   });
 
   describe('navigating', () => {


### PR DESCRIPTION
- **Rationale:** Navigator should only show tags, that can yield results.
- **Risk:** Low
- **Risk Detail:** The change only touches the navigator tag filtering logic.
- **Reward:** High
- **Reward Details:** Users will not get an empty navigator, if they select a tag in certain situations
- **Original PR:** https://github.com/apple/swift-docc-render/pull/172
- **Issue:** rdar://89482723
- **Code Reviewed By:** @mportiz08 @hqhhuang 
- **Testing Details:** Manually tested in the browser and in unit tests