### PR TITLE
Add possible API changes as suggested tags in the sidebar Navigator

### DIFF
--- a/src/constants/Changes.js
+++ b/src/constants/Changes.js
@@ -21,3 +21,9 @@ export const ChangeNames = {
   [ChangeTypes.added]: 'Added',
   [ChangeTypes.deprecated]: 'Deprecated',
 };
+
+export const ChangeNameToType = {
+  Modified: ChangeTypes.modified,
+  Added: ChangeTypes.added,
+  Deprecated: ChangeTypes.deprecated,
+};

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -20,6 +20,7 @@ import Reference from '@/components/ContentNode/Reference.vue';
 import FilterInput from '@/components/Filter/FilterInput.vue';
 import { BreakpointName } from '@/utils/breakpoints';
 import { waitFor } from '@/utils/loading';
+import { ChangeNames, ChangeTypes } from 'docc-render/constants/Changes';
 import { flushPromises } from '../../../../test-utils';
 
 jest.mock('docc-render/utils/debounce', () => jest.fn(fn => fn));
@@ -1068,8 +1069,8 @@ describe('NavigatorCard', () => {
 
   it('allows filtering while API changes are ON', async () => {
     const apiChanges = {
-      [root0Child0.path]: 'modified',
-      [root0Child1.path]: 'modified',
+      [root0Child0.path]: ChangeTypes.modified,
+      [root0Child1.path]: ChangeTypes.modified,
     };
     const wrapper = createWrapper({
       propsData: {
@@ -1089,6 +1090,59 @@ describe('NavigatorCard', () => {
     expect(all).toHaveLength(2);
     expect(all.at(0).props('item')).toEqual(root0);
     expect(all.at(1).props('item')).toEqual(root0Child0);
+  });
+
+  it('allows filtering by change type via tags, while API changes are ON', async () => {
+    const apiChanges = {
+      [root0Child0.path]: ChangeTypes.modified,
+      [root0Child1.path]: ChangeTypes.added,
+    };
+    const wrapper = createWrapper({
+      propsData: {
+        apiChanges,
+      },
+    });
+    await flushPromises();
+    let all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(3);
+    expect(all.at(0).props('item')).toEqual(root0);
+    expect(all.at(1).props('item')).toEqual(root0Child0);
+    expect(all.at(2).props('item')).toEqual(root0Child1);
+    // filter
+    wrapper.find(FilterInput).vm.$emit('update:selectedTags', [ChangeNames.added]);
+    await flushPromises();
+    all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(2);
+    expect(all.at(0).props('item')).toEqual(root0);
+    expect(all.at(1).props('item')).toEqual(root0Child1);
+  });
+
+  it('removes any previously selected API changes tags, if API changes goes OFF', async () => {
+    const apiChanges = {
+      [root0Child0.path]: ChangeTypes.modified,
+      [root0Child1.path]: ChangeTypes.added,
+    };
+    const wrapper = createWrapper({
+      propsData: {
+        apiChanges,
+      },
+    });
+    await flushPromises();
+    let all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(3);
+    // filter
+    const filter = wrapper.find(FilterInput);
+    filter.vm.$emit('update:selectedTags', [ChangeNames.added]);
+    await flushPromises();
+    all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(2);
+    wrapper.setProps({ apiChanges: null });
+    await flushPromises();
+
+    // assert all items are again visible
+    all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(4);
+    expect(filter.props()).toHaveProperty('selectedTags', []);
   });
 
   it('clears previously open items, when filtering and clearing the filter', async () => {
@@ -1340,8 +1394,8 @@ describe('NavigatorCard', () => {
     const wrapper = createWrapper({
       propsData: {
         apiChanges: {
-          [root0Child0.path]: 'modified',
-          [root0Child1.path]: 'modified',
+          [root0Child0.path]: ChangeTypes.modified,
+          [root0Child1.path]: ChangeTypes.modified,
         },
       },
     });
@@ -1418,6 +1472,10 @@ describe('NavigatorCard', () => {
       index: 1,
       childUIDs: [],
     };
+    const apiChanges = {
+      [sampleCode.path]: ChangeTypes.modified,
+      [root0Child0.path]: ChangeTypes.added,
+    };
     const wrapper = createWrapper({
       propsData: {
         children: [root0, root0Child0, sampleCode],
@@ -1432,6 +1490,9 @@ describe('NavigatorCard', () => {
     filter.vm.$emit('input', sampleCode.title);
     await flushPromises();
     expect(filter.props('tags')).toEqual(['Sample Code']);
+    wrapper.setProps({ apiChanges });
+    await flushPromises();
+    expect(filter.props('tags')).toEqual(['Sample Code', ChangeNames.modified]);
   });
 
   describe('navigating', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 91762298

## Summary

This PR adds available API change types as tags to the Navigator. Only types, that yield results will be available to the users to pick.

## Dependencies

NA

## Testing

Not yet testable, rely on Unit Tests

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
