### PR TITLE
[5.7] Convert `left` rule to `padding` to fix inset issue

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -998,7 +998,7 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
     padding-left: $nav-padding;
     padding-right: $nav-padding;
 
-    @include safe-area-left-set(left, 0px);
+    @include safe-area-left-set(padding-left, $nav-padding);
   }
 
   @include breakpoint(small, nav) {


### PR DESCRIPTION
- **Rationale:** Fixes a bug where device insets can potentially obscure mobile sidebar close button.
- **Risk:** Low
- **Risk Detail:** Very minor/focused CSS-only change.
- **Reward:** High
- **Reward Details:** Fixes an issue that can impact usability of sidebar on certain mobile devices.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/176
- **Issue:** rdar://89775264
- **Code Reviewed By:** @dobromir-hristov
- **Testing Details:** Visually tested problematic UI on real device to ensure that the button does not get obscured anymore.