### PR TITLE
Extra padding for pages with short hero section 

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -11,7 +11,11 @@
 <template>
   <div class="doc-topic">
     <main class="main" id="main" role="main" tabindex="0">
-      <DocumentationHero :type="role" :enhanceBackground="enhanceBackground">
+      <DocumentationHero
+        :type="role"
+        :enhanceBackground="enhanceBackground"
+        :extraPadding="extraPadding"
+      >
         <template #above-content>
           <slot name="above-hero-content" />
         </template>
@@ -293,6 +297,14 @@ export default {
       objcPath && swiftPath && isTargetIDE
     ),
     enhanceBackground: ({ symbolKind }) => (symbolKind ? (symbolKind === 'module') : true),
+    extraPadding: ({
+      roleHeading,
+      abstract,
+      sampleCodeDownload,
+      hasAvailability,
+    }) => (
+      (!!roleHeading + !!abstract + !!sampleCodeDownload + !!hasAvailability) <= 1
+    ),
     technologies({ modules = [] }) {
       const technologyList = modules.reduce((list, module) => {
         list.push(module.name);

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -303,6 +303,7 @@ export default {
       sampleCodeDownload,
       hasAvailability,
     }) => (
+      // apply extra padding when there are less than 2 items in the Hero section other than `title`
       (!!roleHeading + !!abstract + !!sampleCodeDownload + !!hasAvailability) <= 1
     ),
     technologies({ modules = [] }) {

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -12,7 +12,7 @@
   <div class="doc-topic">
     <main class="main" id="main" role="main" tabindex="0">
       <DocumentationHero
-        :type="role"
+        :role="role"
         :enhanceBackground="enhanceBackground"
         :extraPadding="extraPadding"
       >

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -26,9 +26,8 @@
       <slot name="above-content" />
     </div>
     <div
-    :class="['documentation-hero__content', {
-      'extra-padding': extraPadding,
-    }]"
+    class="documentation-hero__content"
+    :class = "{ 'extra-padding': extraPadding }"
     >
       <slot />
     </div>
@@ -163,7 +162,7 @@ $doc-hero-icon-dimension: 250px;
 
 .extra-padding {
   padding-top: rem(60px);
-  padding-bottom: 60px;
+  padding-bottom: rem(60px);
 }
 
 .theme-dark /deep/ a:not(.button-cta) {

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -27,7 +27,7 @@
     </div>
     <div
     class="documentation-hero__content"
-    :class = "{ 'extra-padding': extraPadding }"
+    :class="{ 'extra-padding': extraPadding }"
     >
       <slot />
     </div>

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -25,7 +25,11 @@
     <div class="documentation-hero__above-content">
       <slot name="above-content" />
     </div>
-    <div class="documentation-hero__content">
+    <div
+    :class="['documentation-hero__content', {
+      'extra-padding': extraPadding,
+    }]"
+    >
       <slot />
     </div>
   </div>
@@ -46,6 +50,10 @@ export default {
       required: true,
     },
     enhanceBackground: {
+      type: Boolean,
+      required: true,
+    },
+    extraPadding: {
       type: Boolean,
       required: true,
     },
@@ -151,6 +159,11 @@ $doc-hero-icon-dimension: 250px;
   &:after {
     content: none;
   }
+}
+
+.extra-padding {
+  padding-top: rem(60px);
+  padding-bottom: 60px;
 }
 
 .theme-dark /deep/ a:not(.button-cta) {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -228,6 +228,14 @@ describe('DocumentationTopic', () => {
     });
   });
 
+  it('computes `extraPadding correctly', () => {
+    const hero = wrapper.find(DocumentationHero);
+    expect(hero.props('extraPadding')).toBe(false);
+
+    wrapper.setProps({ abstract: '', roleHeading: '', sampleCodeDownload: '' });
+    expect(hero.props('extraPadding')).toBe(true);
+  });
+
   it('render a `DocumentationHero`, disabled, if symbol page', () => {
     /* wrapper.setProps({
       symbolKind: 'protocol',

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -212,12 +212,20 @@ describe('DocumentationTopic', () => {
   it('renders a `DocumentationHero`, enabled', () => {
     const hero = wrapper.find(DocumentationHero);
     expect(hero.exists()).toBe(true);
-    expect(hero.props()).toEqual({ type: propsData.role, enhanceBackground: true });
+    expect(hero.props()).toEqual({
+      type: propsData.role,
+      enhanceBackground: true,
+      extraPadding: false,
+    });
   });
 
   it('render a `DocumentationHero`, enabled, if top-level technology page', () => {
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: TopicTypes.collection, enhanceBackground: true });
+    expect(hero.props()).toEqual({
+      type: TopicTypes.collection,
+      enhanceBackground: true,
+      extraPadding: false,
+    });
   });
 
   it('render a `DocumentationHero`, disabled, if symbol page', () => {
@@ -234,7 +242,11 @@ describe('DocumentationTopic', () => {
       },
     });
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: 'symbol', enhanceBackground: false });
+    expect(hero.props()).toEqual({
+      type: 'symbol',
+      enhanceBackground: false,
+      extraPadding: false,
+    });
   });
 
   it('renders a `Title`', () => {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -213,7 +213,7 @@ describe('DocumentationTopic', () => {
     const hero = wrapper.find(DocumentationHero);
     expect(hero.exists()).toBe(true);
     expect(hero.props()).toEqual({
-      type: propsData.role,
+      role: propsData.role,
       enhanceBackground: true,
       extraPadding: false,
     });
@@ -222,7 +222,7 @@ describe('DocumentationTopic', () => {
   it('render a `DocumentationHero`, enabled, if top-level technology page', () => {
     const hero = wrapper.find(DocumentationHero);
     expect(hero.props()).toEqual({
-      type: TopicTypes.collection,
+      role: TopicTypes.collection,
       enhanceBackground: true,
       extraPadding: false,
     });
@@ -251,7 +251,7 @@ describe('DocumentationTopic', () => {
     });
     const hero = wrapper.find(DocumentationHero);
     expect(hero.props()).toEqual({
-      type: 'symbol',
+      role: 'symbol',
       enhanceBackground: false,
       extraPadding: false,
     });

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -65,6 +65,20 @@ describe('DocumentationHero', () => {
     });
   });
 
+  it('renders the right classes based on `extraPadding` prop', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        extraPadding: true,
+      },
+    });
+    expect(wrapper.find('.extra-padding').exists()).toBe(true);
+
+    wrapper.setProps({
+      extraPadding: false,
+    });
+    expect(wrapper.find('.extra-padding').exists()).toBe(false);
+  });
+
   it('finds aliases, for the color', () => {
     const wrapper = createWrapper({
       propsData: {

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -17,6 +17,7 @@ import { HeroColors, HeroColorsMap } from '@/constants/HeroColors';
 const defaultProps = {
   type: TopicTypes.class,
   enhanceBackground: true,
+  extraPadding: true,
 };
 
 const createWrapper = ({ propsData, ...others } = {}) => shallowMount(DocumentationHero, {
@@ -66,11 +67,7 @@ describe('DocumentationHero', () => {
   });
 
   it('renders the right classes based on `extraPadding` prop', () => {
-    const wrapper = createWrapper({
-      propsData: {
-        extraPadding: true,
-      },
-    });
+    const wrapper = createWrapper();
     expect(wrapper.find('.extra-padding').exists()).toBe(true);
 
     wrapper.setProps({


### PR DESCRIPTION
Bug/issue #, if applicable: 90792025

## Summary
In order to optimize how icons look in the hero section, we want to add extra padding for short hero sections.
Note: anything that has less than 3 items, should be considered a short hero.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
