### PR TITLE
[5.7] Improve the left/right arrow navigation inside the Navigator

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -64,6 +64,7 @@
               @toggle-full="toggleFullTree"
               @toggle-siblings="toggleSiblings"
               @navigate="setActiveUID"
+              @focus-parent="focusNodeParent"
             />
           </RecycleScroller>
           <div aria-live="polite" class="visuallyhidden">
@@ -896,6 +897,18 @@ export default {
         all[current.uid] = current;
         return all;
       }, {});
+    },
+    /**
+     * Focuses the parent of a child node.
+     * @param {NavigatorFlatItem} item
+     */
+    focusNodeParent(item) {
+      const parent = this.childrenMap[item.parent];
+      if (!parent) return;
+      const parentIndex = this.nodesToRender.findIndex(c => c.uid === parent.uid);
+      if (parentIndex === -1) return;
+      // we perform an intentional focus change, so no need to set `externalFocusChange` to `true`
+      this.focusIndex(parentIndex);
     },
   },
 };

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -19,8 +19,8 @@
     :aria-expanded="expanded ? 'true': 'false'"
     :aria-describedby="ariaDescribedBy"
     :id="`container-${item.uid}`"
-    @keydown.left.prevent="toggleTree"
-    @keydown.right.prevent="toggleTree"
+    @keydown.left.prevent="handleLeftKeydown"
+    @keydown.right.prevent="handleRightKeydown"
     @keydown.enter.prevent="clickReference"
   >
     <div class="head-wrapper" :class="{ active: isActive, 'is-group': isGroupMarker }">
@@ -185,6 +185,21 @@ export default {
     toggleSiblings() {
       this.idState.isOpening = true;
       this.$emit('toggle-siblings', this.item);
+    },
+    handleLeftKeydown() {
+      // if not expanded, go to the nearest parent
+      if (!this.expanded) {
+        this.$emit('focus-parent', this.item);
+        return;
+      }
+      // close the tree otherwise
+      this.toggleTree();
+    },
+    handleRightKeydown() {
+      // if we are already expanded, dont do anything
+      if (this.expanded || !this.isParent) return;
+      // otherwise expand
+      this.toggleTree();
     },
     clickReference() {
       this.$refs.reference.$el.click();

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -781,6 +781,34 @@ describe('NavigatorCard', () => {
     });
   });
 
+  describe('on @focus-parent', () => {
+    it('focuses parent', async () => {
+      const wrapper = createWrapper();
+      await flushPromises();
+      const items = wrapper.findAll(NavigatorCardItem);
+      expect(items.at(0).props('isFocused')).toBe(false);
+      expect(items.at(1).props('isFocused')).toBe(true);
+      items.at(1).vm.$emit('focus-parent', root0Child0);
+      await flushPromises();
+      expect(items.at(0).props('isFocused')).toBe(true);
+      expect(items.at(1).props('isFocused')).toBe(false);
+    });
+
+    it('does nothing, if parent is root', async () => {
+      const wrapper = createWrapper({
+        propsData: {
+          activePath: [root1.path],
+        },
+      });
+      await flushPromises();
+      const items = wrapper.findAll(NavigatorCardItem);
+      expect(items.at(1).props('isFocused')).toBe(true);
+      items.at(1).vm.$emit('focus-parent', root1);
+      await flushPromises();
+      expect(items.at(1).props('isFocused')).toBe(true);
+    });
+  });
+
   it('highlights the current page, and expands all of its parents', async () => {
     const wrapper = createWrapper();
     await flushPromises();

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -229,6 +229,61 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.emitted('navigate')).toEqual([[defaultProps.item.uid]]);
   });
 
+  describe('keyboard navigation', () => {
+    it('clicks the reference link on `@keydown.enter`', () => {
+      const wrapper = createWrapper();
+      const spy = jest.spyOn(wrapper.find(Reference).vm.$el, 'click');
+      wrapper.trigger('keydown.enter');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens children on `@keydown.right`', () => {
+      const wrapper = createWrapper();
+      wrapper.trigger('keydown.right');
+      expect(wrapper.emitted('toggle')).toEqual([[defaultProps.item]]);
+    });
+
+    it('does nothing if already open on `@keydown.right`', () => {
+      const wrapper = createWrapper({
+        propsData: {
+          expanded: true,
+        },
+      });
+      wrapper.trigger('keydown.right');
+      expect(wrapper.emitted('toggle')).toBeFalsy();
+    });
+
+    it('does nothing if has no children, on `@keydown.right`', () => {
+      const wrapper = createWrapper({
+        propsData: {
+          item: {
+            ...defaultProps.item,
+            childUIDs: [],
+          },
+        },
+      });
+      wrapper.trigger('keydown.right');
+      expect(wrapper.emitted('toggle')).toBeFalsy();
+    });
+
+    it('closes, on `@keydown.left`, if open', () => {
+      const wrapper = createWrapper({
+        propsData: {
+          expanded: true,
+        },
+      });
+      wrapper.trigger('keydown.left');
+      expect(wrapper.emitted('toggle')).toEqual([[defaultProps.item]]);
+    });
+
+    it('focuses its parent, on `@keydown.left` if not open', () => {
+      const wrapper = createWrapper();
+      wrapper.trigger('keydown.left');
+      expect(wrapper.emitted('toggle')).toBeFalsy();
+      expect(wrapper.emitted('focus-parent')).toEqual([[defaultProps.item]]);
+    });
+  });
+
   describe('AX', () => {
     it('applies aria-hidden to NavigatorCardItem if isRendered is false', () => {
       const wrapper = createWrapper({


### PR DESCRIPTION
- **Rationale:** Allows users to user the keyboard left/right arrows to expand/contract the navigator items.
- **Risk:** Low
- **Risk Detail:** A focused change for parent items in the navigator
- **Reward:** High
- **Reward Details:** Users would be able to use the keyboard to navigate more efficiently
- **Original PR:** https://github.com/apple/swift-docc-render/pull/169
- **Issue:** rdar://90865355
- **Code Reviewed By:** @hqhhuang 
- **Testing Details:** Manually tested in the browser and with Unit tests