### PR TITLE
[5.7] Cast to lower case the current path in the navigator, to ensure matching paths with capital cases

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -107,7 +107,7 @@ export default {
     activePath({ parentTopicReferences, $route: { path } }) {
       // Ensure the path does not have a trailing slash
       // eslint-disable-next-line no-param-reassign
-      path = path.replace(/\/$/, '');
+      path = path.replace(/\/$/, '').toLowerCase();
       // route's path is activePath on root
       if (!parentTopicReferences.length) return [path];
       let itemsToSlice = 1;

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -705,11 +705,15 @@ export default {
       }
       // make sure all nodes exist in the childrenMap
       const allNodesMatch = nodesToRender.every(uid => this.childrenMap[uid]);
+      let activeUIDMatchesCurrentPath = true;
       // check if activeUID node matches the current page path
-      const activeUIDMatchesCurrentPath = (activeUID && this.activePath.length)
-        ? (this.childrenMap[activeUID] || {}).path === last(this.activePath)
-        // if there is no activeUID this check is not relevant
-        : true;
+      if (activeUID && this.activePath.length) {
+        activeUIDMatchesCurrentPath = (this.childrenMap[activeUID] || {}).path
+          === last(this.activePath);
+        // set ot `false`, if there is no `activeUID`, but there are `activePath` items
+      } else if (!activeUID && this.activePath.length) {
+        activeUIDMatchesCurrentPath = false;
+      }
       // take a second pass at validating data
       if (
         // if the technology is different

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -181,13 +181,13 @@ describe('Navigator', () => {
     ]);
   });
 
-  it('strips out trailing slashes from the last activePath item', () => {
+  it('casts to lowercase and strips out trailing slashes from the last activePath item', () => {
     const wrapper = createWrapper({
       mocks: {
         ...mocks,
         $route: {
           ...mocks.$route,
-          path: '/documentation/foo/bar/',
+          path: '/documentation/Foo/Bar/',
         },
       },
     });

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1300,7 +1300,7 @@ describe('NavigatorCard', () => {
       if (key === STORAGE_KEYS.filter) return '';
       if (key === STORAGE_KEYS.openNodes) return [];
       if (key === STORAGE_KEYS.apiChanges) return false;
-      if (key === STORAGE_KEYS.activeUID) return null;
+      if (key === STORAGE_KEYS.activeUID) return root0Child0.uid;
       return '';
     });
     const wrapper = createWrapper();
@@ -1319,6 +1319,23 @@ describe('NavigatorCard', () => {
       if (key === STORAGE_KEYS.openNodes) return [root0.uid];
       if (key === STORAGE_KEYS.selectedTags) return [];
       if (key === STORAGE_KEYS.apiChanges) return true;
+      return '';
+    });
+    const wrapper = createWrapper();
+    await flushPromises();
+    expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(4);
+  });
+
+  it('does not restore the state, if `activeUID` is null, but there are activePath items', async () => {
+    sessionStorage.get.mockImplementation((key) => {
+      if (key === STORAGE_KEYS.filter) return '';
+      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
+      // simulate we have collapses all, but the top item
+      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid];
+      if (key === STORAGE_KEYS.openNodes) return [root0.uid];
+      if (key === STORAGE_KEYS.selectedTags) return [];
+      if (key === STORAGE_KEYS.apiChanges) return false;
+      if (key === STORAGE_KEYS.activeUID) return null;
       return '';
     });
     const wrapper = createWrapper();


### PR DESCRIPTION
- **Rationale:** Fixes a bug where urls with capital case segments cannot be matched against in the navigator
- **Risk:** Low
- **Risk Detail:** Cast the current URL to lowercase, before we do any matching.
- **Reward:** High
- **Reward Details:** Fixes issues related to mixed-case urls and Navigator finding the current page item
- **Original PR:** https://github.com/apple/swift-docc-render/pull/181
- **Issue:** rdar://91824384
- **Code Reviewed By:** @mportiz08 
- **Testing Details:** Manually tested in the browser by changing the URL to have capital case letters and with unit tests