### PR TITLE
Fix no space between Deprecated warning and the DocumentationHero

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -37,7 +37,7 @@
         />
       </DocumentationHero>
       <div v-if="showContainer" class="container">
-        <div class="description">
+        <div class="description" :class="{ 'after-enhanced-hero': enhanceBackground }">
           <RequirementMetadata
             v-if="isRequirement"
             :defaultImplementationsCount="defaultImplementationsCount"
@@ -384,12 +384,14 @@ export default {
 }
 
 .description {
+  margin-bottom: $contenttable-spacing-single-side;
+
   &:empty {
     display: none;
   }
 
-  &:not(:empty) {
-    margin-bottom: $contenttable-spacing-single-side;
+  &.after-enhanced-hero {
+    margin-top: $contenttable-spacing-single-side;
   }
 
   /deep/ .content + * {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -329,6 +329,16 @@ describe('DocumentationTopic', () => {
   });
 
   describe('description column', () => {
+    it('renders the description section', () => {
+      const description = wrapper.find('.description');
+      expect(description.exists()).toBe(true);
+      expect(description.classes()).toContain('after-enhanced-hero');
+      wrapper.setProps({
+        symbolKind: 'something-else',
+      });
+      expect(description.classes()).not.toContain('after-enhanced-hero');
+    });
+
     it('renders a deprecated `Aside` when deprecated', () => {
       expect(wrapper.contains(Aside)).toBe(false);
       wrapper.setProps({ deprecationSummary });


### PR DESCRIPTION
Bug/issue #, if applicable: 91008709

## Summary

Fixes the lack of space between the DocumentationHero and any deprecation warnings.

![image](https://user-images.githubusercontent.com/9863944/163993600-30010f77-8388-4dc8-a2f7-84f173c32416.png)


## Dependencies

NA

## Testing

[TinyMixedLanguageLibrary.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8512538/TinyMixedLanguageLibrary.doccarchive.zip)

Use the provided archive to test out this exact scenario, but its also a good idea to test with other archives, to make sure I did not introduce a regression.

Steps:
1. Go to http://localhost:8080/documentation/tinymixedlanguagelibrary
2. Assert there is enough space between the Hero and the deprecation notice

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
