### PR TITLE
Patch swift syntax language to support `distributed` keyword

### DIFF
--- a/src/utils/custom-highlight-lang/swift.js
+++ b/src/utils/custom-highlight-lang/swift.js
@@ -13,6 +13,16 @@ import swift from 'highlight.js/lib/languages/swift';
 export default function (hljs) {
   const language = swift(hljs);
 
+  // Temporarily patch the Swift language syntax to recognize `distributed` as
+  // a keyword until the next version of highlight.js (v11.6) is released, which
+  // will have built-in support for this [1]
+  //
+  // [1]: https://github.com/highlightjs/highlight.js/pull/3523
+  language.keywords.keyword = [
+    ...language.keywords.keyword,
+    'distributed',
+  ];
+
   const isClassMode = ({ beginKeywords = '' }) => beginKeywords
     .split(' ')
     .includes('class');

--- a/tests/unit/utils/custom-highlight-lang/swift.spec.js
+++ b/tests/unit/utils/custom-highlight-lang/swift.spec.js
@@ -18,6 +18,10 @@ describe('swift', () => {
     language = swift(hljs);
   });
 
+  it('recognizes the `distributed` keyword', () => {
+    expect(language.keywords.keyword.includes('distributed')).toBe(true);
+  });
+
   describe('class mode', () => {
     let mode;
 


### PR DESCRIPTION
Bug/issue #, if applicable: 89083261

## Summary

This temporarily adds support for highlighting the `distributed` keyword for Swift code listings until highlight.js officially supports that itself with the next release.

A PR has already been [merged](https://github.com/highlightjs/highlight.js/pull/3523) in highlight.js for this, but this next v11.6 release may not be included as part of an official release for some time, so this is a workaround until then.

## Testing

Add the following example Swift code listing to `SwiftDocCRender.docc/SwiftDocCRender.md`:

```swift
distributed actor Foobar {
  distributed func baz() {
  }

  func qux() {
  }
}
```

Steps:
1. Run `npm run build`. 
2. Run `DOCC_HTML_DIR=/path/to/swift-docc-render/dist npm run docs:preview` 
3. Open http://localhost:8000/documentation/swiftdoccrender and verify that the `distributed` keyword is highlighted in the code listing

# Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary