### PR TITLE
[5.7] Fix width of highlight in S viewport

### DIFF
--- a/src/components/DocumentationTopic/TopicsLinkBlock.vue
+++ b/src/components/DocumentationTopic/TopicsLinkBlock.vue
@@ -227,6 +227,7 @@ export default {
   &.changed {
     @include change-highlight-target();
     @include change-highlight-horizontal-text-alignment();
+    box-sizing: border-box;
   }
 }
 


### PR DESCRIPTION
- **Rationale:** Fixes a bug where api diff highlight box gets cut off in small viewport.
- **Risk:** Low
- **Risk Detail:** Just 1-liner CSS change
- **Reward:** High
- **Reward Details:** Fixes regression so the visual looks as intended.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/178
- **Issue:** rdar://89800555
- **Code Reviewed By:** @dobromir-hristov 
- **Testing Details:** Manually tested in the browser.