### PR TITLE
Make sure spacing between elements in body content is 40px

### DIFF
--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -19,7 +19,7 @@ $tiny-border-radius: $border-radius !default;
 $big-border-radius: $border-radius !default;
 $small-border-radius: $border-radius !default;
 
-$contenttable-spacing-single-side: 2rem;
+$contenttable-spacing-single-side: 2.353rem;
 
 // Shared variables for tutorials-overview page components
 $tutorials-overview-tile-margin-single-side: 2px;


### PR DESCRIPTION
Bug/issue #, if applicable: 91070521

## Summary
Make sure the spacing between elements is 40px.
Fixes issue where when Asides are shown, the spacing is 2rem (34px).

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
