### PR TITLE
Fix issue where inconsistent icons are used between the sidebar and intro

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -11,7 +11,7 @@
 <template>
   <div class="doc-topic">
     <main class="main" id="main" role="main" tabindex="0">
-      <DocumentationHero :type="role" :enhanceBackground="enhanceBackground">
+      <DocumentationHero :role="role" :enhanceBackground="enhanceBackground">
         <template #above-content>
           <slot name="above-hero-content" />
         </template>

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -34,14 +34,15 @@
 <script>
 
 import NavigatorLeafIcon from 'docc-render/components/Navigator/NavigatorLeafIcon.vue';
-import { TopicTypeAliases } from 'docc-render/constants/TopicTypes';
+import { TopicTypes, TopicTypeAliases } from 'docc-render/constants/TopicTypes';
 import { HeroColorsMap, HeroColors } from 'docc-render/constants/HeroColors';
+import { TopicRole } from 'docc-render/constants/roles';
 
 export default {
   name: 'DocumentationHero',
   components: { NavigatorLeafIcon },
   props: {
-    type: {
+    role: {
       type: String,
       required: true,
     },
@@ -57,6 +58,22 @@ export default {
       // use the color or fallback to the gray secondary, if not defined.
       '--accent-color': `var(--color-type-icon-${color}, var(--color-figure-gray-secondary))`,
     }),
+    // This mapping is necessary to help create a consistent mapping for the
+    // following kinds of things, which are represented as different strings
+    // depending on if the data comes from RenderJSON for a page or the
+    // navigator.
+    type: ({ role }) => {
+      switch (role) {
+      case TopicRole.collection:
+        // map role: "collection" to type: "module"
+        return TopicTypes.module;
+      case TopicRole.collectionGroup:
+        // map role: "collectionGroup" to type: "collection"
+        return TopicTypes.collection;
+      default:
+        return role;
+      }
+    },
   },
 };
 </script>

--- a/src/components/Navigator/NavigatorLeafIcon.vue
+++ b/src/components/Navigator/NavigatorLeafIcon.vue
@@ -34,7 +34,7 @@ const TopicTypeIcons = {
   [TopicTypes.associatedtype]: CollectionIcon,
   [TopicTypes.buildSetting]: CollectionIcon,
   [TopicTypes.class]: SingleLetterSymbolIcon,
-  [TopicTypes.collection]: TechnologyIcon,
+  [TopicTypes.collection]: CollectionIcon,
   [TopicTypes.dictionarySymbol]: SingleLetterSymbolIcon,
   [TopicTypes.container]: CollectionIcon,
   [TopicTypes.enum]: SingleLetterSymbolIcon,

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -212,12 +212,12 @@ describe('DocumentationTopic', () => {
   it('renders a `DocumentationHero`, enabled', () => {
     const hero = wrapper.find(DocumentationHero);
     expect(hero.exists()).toBe(true);
-    expect(hero.props()).toEqual({ type: propsData.role, enhanceBackground: true });
+    expect(hero.props()).toEqual({ role: propsData.role, enhanceBackground: true });
   });
 
   it('render a `DocumentationHero`, enabled, if top-level technology page', () => {
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: TopicTypes.collection, enhanceBackground: true });
+    expect(hero.props()).toEqual({ role: TopicTypes.collection, enhanceBackground: true });
   });
 
   it('render a `DocumentationHero`, disabled, if symbol page', () => {
@@ -234,7 +234,7 @@ describe('DocumentationTopic', () => {
       },
     });
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: 'symbol', enhanceBackground: false });
+    expect(hero.props()).toEqual({ role: 'symbol', enhanceBackground: false });
   });
 
   it('renders a `Title`', () => {

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -13,9 +13,10 @@ import { shallowMount } from '@vue/test-utils';
 import { TopicTypes, TopicTypeAliases } from '@/constants/TopicTypes';
 import NavigatorLeafIcon from '@/components/Navigator/NavigatorLeafIcon.vue';
 import { HeroColors, HeroColorsMap } from '@/constants/HeroColors';
+import { TopicRole } from '@/constants/roles';
 
 const defaultProps = {
-  type: TopicTypes.class,
+  role: TopicTypes.class,
   enhanceBackground: true,
 };
 
@@ -54,21 +55,21 @@ describe('DocumentationHero', () => {
     expect(allIcons).toHaveLength(1);
     expect(allIcons.at(0).props()).toEqual({
       withColors: true,
-      type: defaultProps.type,
+      type: defaultProps.role,
     });
     expect(allIcons.at(0).classes()).toEqual(['background-icon', 'first-icon']);
     // assert slot
     expect(wrapper.find('.default-slot').text()).toBe('Default Slot');
     expect(wrapper.find('.above-content-slot').text()).toBe('Above Content Slot');
     expect(wrapper.vm.styles).toEqual({
-      '--accent-color': `var(--color-type-icon-${HeroColorsMap[defaultProps.type]}, var(--color-figure-gray-secondary))`,
+      '--accent-color': `var(--color-type-icon-${HeroColorsMap[defaultProps.role]}, var(--color-figure-gray-secondary))`,
     });
   });
 
   it('finds aliases, for the color', () => {
     const wrapper = createWrapper({
       propsData: {
-        type: TopicTypes.init,
+        role: TopicTypes.init,
       },
     });
     const color = HeroColorsMap[TopicTypeAliases[TopicTypes.init]];
@@ -80,7 +81,7 @@ describe('DocumentationHero', () => {
   it('falls back to the teal color for types without a color', () => {
     const wrapper = createWrapper({
       propsData: {
-        type: TopicTypes.section,
+        role: TopicTypes.section,
       },
     });
     expect(wrapper.vm.styles).toEqual({
@@ -90,7 +91,7 @@ describe('DocumentationHero', () => {
 
   it('utilizes the "sky" color for top level collection pages', () => {
     const wrapper = createWrapper({
-      propsData: { type: TopicTypes.collection },
+      propsData: { role: TopicTypes.collection },
     });
     expect(wrapper.vm.styles['--accent-color'])
       .toBe('var(--color-type-icon-sky, var(--color-figure-gray-secondary))');
@@ -107,7 +108,27 @@ describe('DocumentationHero', () => {
     // assert slot
     expect(wrapper.find('.default-slot').text()).toBe('Default Slot');
     expect(wrapper.vm.styles).toEqual({
-      '--accent-color': `var(--color-type-icon-${HeroColorsMap[defaultProps.type]}, var(--color-figure-gray-secondary))`,
+      '--accent-color': `var(--color-type-icon-${HeroColorsMap[defaultProps.role]}, var(--color-figure-gray-secondary))`,
     });
+  });
+
+  it('maps the "collection" role to the "module" type', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        enhanceBackground: true,
+        role: TopicRole.collection,
+      },
+    });
+    expect(wrapper.find(NavigatorLeafIcon).props('type')).toBe(TopicTypes.module);
+  });
+
+  it('maps the "collectionGroup" role to the "collection" type', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        enhanceBackground: true,
+        role: TopicRole.collectionGroup,
+      },
+    });
+    expect(wrapper.find(NavigatorLeafIcon).props('type')).toBe(TopicTypes.collection);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 91810837

## Summary

This fixes the icon mapping so that technologies, API collections, articles, and sample code all have the right icons in both the sidebar and the documentation intro element.

In addition to changing the icon used for collections, the following mappings were needed to make things consistent in both places:

* `role` `"collection"` => `type` `"module"`
* `role` `"collectionGroup"` => `type` `"collection"`

## Testing

Steps:
1. Verify that the right icon is used for the top level **technology** page in _both_ places
2. Verify that the right icon is used for the **API collections** in _both_ places
3. Verify that the right icon is used for **articles** in _both_ places
4. Verify that the right icon is used for **sample code** pages in _both_ places. 
5. Verify that the icon is unchanged for **symbols** and there is _no intro icon_ for these pages

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
