### PR TITLE
[5.7] Fix no space between description and the DocumentationHero

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -37,7 +37,7 @@
         />
       </DocumentationHero>
       <div v-if="showContainer" class="container">
-        <div class="description">
+        <div class="description" :class="{ 'after-enhanced-hero': enhanceBackground }">
           <RequirementMetadata
             v-if="isRequirement"
             :defaultImplementationsCount="defaultImplementationsCount"
@@ -384,12 +384,14 @@ export default {
 }
 
 .description {
+  margin-bottom: $contenttable-spacing-single-side;
+
   &:empty {
     display: none;
   }
 
-  &:not(:empty) {
-    margin-bottom: $contenttable-spacing-single-side;
+  &.after-enhanced-hero {
+    margin-top: $contenttable-spacing-single-side;
   }
 
   /deep/ .content + * {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -329,6 +329,16 @@ describe('DocumentationTopic', () => {
   });
 
   describe('description column', () => {
+    it('renders the description section', () => {
+      const description = wrapper.find('.description');
+      expect(description.exists()).toBe(true);
+      expect(description.classes()).toContain('after-enhanced-hero');
+      wrapper.setProps({
+        symbolKind: 'something-else',
+      });
+      expect(description.classes()).not.toContain('after-enhanced-hero');
+    });
+
     it('renders a deprecated `Aside` when deprecated', () => {
       expect(wrapper.contains(Aside)).toBe(false);
       wrapper.setProps({ deprecationSummary });


### PR DESCRIPTION
- **Rationale:** Fixes a bug where there is no space between deprecated aside and the DocumentationHero
- **Risk:** Low
- **Risk Detail:** It conditionally adds an extra space to the description section and the DocumentationHero.
- **Reward:** High
- **Reward Details:** Fixes a visual regression, where it has no space between items
- **Original PR:** https://github.com/apple/swift-docc-render/pull/188
- **Issue:** rdar://91008709
- **Code Reviewed By:** @hqhhuang 
- **Testing Details:** Manually tested in the browser and added Unit tests