### PR TITLE
[5.7] Patch swift syntax language to support `distributed` keyword

### DIFF
--- a/src/utils/custom-highlight-lang/swift.js
+++ b/src/utils/custom-highlight-lang/swift.js
@@ -13,6 +13,16 @@ import swift from 'highlight.js/lib/languages/swift';
 export default function (hljs) {
   const language = swift(hljs);
 
+  // Temporarily patch the Swift language syntax to recognize `distributed` as
+  // a keyword until the next version of highlight.js (v11.6) is released, which
+  // will have built-in support for this [1]
+  //
+  // [1]: https://github.com/highlightjs/highlight.js/pull/3523
+  language.keywords.keyword = [
+    ...language.keywords.keyword,
+    'distributed',
+  ];
+
   const isClassMode = ({ beginKeywords = '' }) => beginKeywords
     .split(' ')
     .includes('class');

--- a/tests/unit/utils/custom-highlight-lang/swift.spec.js
+++ b/tests/unit/utils/custom-highlight-lang/swift.spec.js
@@ -18,6 +18,10 @@ describe('swift', () => {
     language = swift(hljs);
   });
 
+  it('recognizes the `distributed` keyword', () => {
+    expect(language.keywords.keyword.includes('distributed')).toBe(true);
+  });
+
   describe('class mode', () => {
     let mode;
 


### PR DESCRIPTION
- **Rationale:** Adds support for syntax highlighting Swift 5.7 language feature.
- **Risk:** Low
- **Risk Detail:** Very small/focused change, adding one item to an array
- **Reward:** High
- **Reward Details:** Allows `distributed` keyword to be syntax highlighted as expected in docs with Swift code.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/191
- **Issue:** rdar://89083261
- **Code Reviewed By:** @dobromir-hristov
- **Testing Details:** Visually verified example DocC pages with Swift code listings using the `distributed` keyword.