### PR TITLE
[5.7] Make sure spacing between elements in body content is 40px 

### DIFF
--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -19,7 +19,7 @@ $tiny-border-radius: $border-radius !default;
 $big-border-radius: $border-radius !default;
 $small-border-radius: $border-radius !default;
 
-$contenttable-spacing-single-side: 2rem;
+$contenttable-spacing-single-side: 2.353rem;
 
 // Shared variables for tutorials-overview page components
 $tutorials-overview-tile-margin-single-side: 2px;


### PR DESCRIPTION
- **Rationale:** Change value for padding in body content to be 40px.
- **Risk:** Low
- **Risk Detail:** Only 1 variable change.
- **Reward:** High
- **Reward Details:** Makes sure all the spacing on the page is 40px, removes inconsistency.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/193
- **Issue:** rdar://91070521
- **Code Reviewed By:** @dobromir-hristov
- **Testing Details:** Visually test in browser and verify that spacing between sections in the body content is 40px.