### PR TITLE
[5.7] Extra padding for pages with short hero section

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -11,7 +11,11 @@
 <template>
   <div class="doc-topic">
     <main class="main" id="main" role="main" tabindex="0">
-      <DocumentationHero :type="role" :enhanceBackground="enhanceBackground">
+      <DocumentationHero
+        :role="role"
+        :enhanceBackground="enhanceBackground"
+        :extraPadding="extraPadding"
+      >
         <template #above-content>
           <slot name="above-hero-content" />
         </template>
@@ -293,6 +297,15 @@ export default {
       objcPath && swiftPath && isTargetIDE
     ),
     enhanceBackground: ({ symbolKind }) => (symbolKind ? (symbolKind === 'module') : true),
+    extraPadding: ({
+      roleHeading,
+      abstract,
+      sampleCodeDownload,
+      hasAvailability,
+    }) => (
+      // apply extra padding when there are less than 2 items in the Hero section other than `title`
+      (!!roleHeading + !!abstract + !!sampleCodeDownload + !!hasAvailability) <= 1
+    ),
     technologies({ modules = [] }) {
       const technologyList = modules.reduce((list, module) => {
         list.push(module.name);

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -25,7 +25,10 @@
     <div class="documentation-hero__above-content">
       <slot name="above-content" />
     </div>
-    <div class="documentation-hero__content">
+    <div
+    class="documentation-hero__content"
+    :class="{ 'extra-padding': extraPadding }"
+    >
       <slot />
     </div>
   </div>
@@ -46,6 +49,10 @@ export default {
       required: true,
     },
     enhanceBackground: {
+      type: Boolean,
+      required: true,
+    },
+    extraPadding: {
       type: Boolean,
       required: true,
     },
@@ -151,6 +158,11 @@ $doc-hero-icon-dimension: 250px;
   &:after {
     content: none;
   }
+}
+
+.extra-padding {
+  padding-top: rem(60px);
+  padding-bottom: rem(60px);
 }
 
 .theme-dark /deep/ a:not(.button-cta) {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -212,12 +212,28 @@ describe('DocumentationTopic', () => {
   it('renders a `DocumentationHero`, enabled', () => {
     const hero = wrapper.find(DocumentationHero);
     expect(hero.exists()).toBe(true);
-    expect(hero.props()).toEqual({ type: propsData.role, enhanceBackground: true });
+    expect(hero.props()).toEqual({
+      role: propsData.role,
+      enhanceBackground: true,
+      extraPadding: false,
+    });
   });
 
   it('render a `DocumentationHero`, enabled, if top-level technology page', () => {
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: TopicTypes.collection, enhanceBackground: true });
+    expect(hero.props()).toEqual({
+      role: TopicTypes.collection,
+      enhanceBackground: true,
+      extraPadding: false,
+    });
+  });
+
+  it('computes `extraPadding correctly', () => {
+    const hero = wrapper.find(DocumentationHero);
+    expect(hero.props('extraPadding')).toBe(false);
+
+    wrapper.setProps({ abstract: '', roleHeading: '', sampleCodeDownload: '' });
+    expect(hero.props('extraPadding')).toBe(true);
   });
 
   it('render a `DocumentationHero`, disabled, if symbol page', () => {
@@ -234,7 +250,11 @@ describe('DocumentationTopic', () => {
       },
     });
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: 'symbol', enhanceBackground: false });
+    expect(hero.props()).toEqual({
+      role: 'symbol',
+      enhanceBackground: false,
+      extraPadding: false,
+    });
   });
 
   it('renders a `Title`', () => {

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -17,6 +17,7 @@ import { HeroColors, HeroColorsMap } from '@/constants/HeroColors';
 const defaultProps = {
   type: TopicTypes.class,
   enhanceBackground: true,
+  extraPadding: true,
 };
 
 const createWrapper = ({ propsData, ...others } = {}) => shallowMount(DocumentationHero, {
@@ -63,6 +64,16 @@ describe('DocumentationHero', () => {
     expect(wrapper.vm.styles).toEqual({
       '--accent-color': `var(--color-type-icon-${HeroColorsMap[defaultProps.type]}, var(--color-figure-gray-secondary))`,
     });
+  });
+
+  it('renders the right classes based on `extraPadding` prop', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('.extra-padding').exists()).toBe(true);
+
+    wrapper.setProps({
+      extraPadding: false,
+    });
+    expect(wrapper.find('.extra-padding').exists()).toBe(false);
   });
 
   it('finds aliases, for the color', () => {


### PR DESCRIPTION
- **Rationale:** Add extra padding for pages with short hero section (2 items or less), in order to optimize the look of hero icon.
- **Risk:** Low
- **Risk Detail:** Change only concerns the hero section.
- **Reward:** High
- **Reward Details:** Makes sure icons look good in pages with short hero section, especially API Collection pages.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/184/
- **Issue:** rdar://90792025
- **Code Reviewed By:** @dobromir-hristov
- **Testing Details:** Visually test in browser and verify that padding is 60px in the hero section for pages that have 2 items or less in that section. 