### PR TITLE
[5.7] Update padding in S viewport

### DIFF
--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -65,6 +65,22 @@ $breakpoint-attributes: (
   @return map-keys($attributes);
 }
 
+/// Returns the width for the dynamic-sidebar-content in small viewport.
+/// This function allows overriding the small width in third party themes.
+///
+/// @param {Number} $content-width
+///   The width of the content
+///
+/// @param {Number} $min-width
+///   The min-width of the content
+///
+/// @returns {String | Number}
+///   Returns a width value
+///
+@function -calculate-small-dynamic-sidebar-content-width($content-width, $min-width) {
+  @return auto;
+}
+
 /// Injects the provided style block within a max-width media query so that the
 /// styles only apply to the given breakpoint size.
 ///
@@ -342,8 +358,11 @@ $breakpoint-attributes: (
     }
 
     @include breakpoint(small) {
-      padding-left: 20px;
-      padding-right: 20px;
+      $content-width: map-deep-get($breakpoint-attributes, (default, small, content-width));
+      $min-width: map-deep-get($breakpoint-attributes, (default, small, min-width));
+      width: -calculate-small-dynamic-sidebar-content-width($content-width, $min-width);
+      padding-left: $small-viewport-content-padding;
+      padding-right: $small-viewport-content-padding;
     }
   }
 

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -64,3 +64,6 @@ $total-columns: 12 !default;
 $card-horizontal-spacing: 10px;
 $card-horizontal-spacing-large: $card-horizontal-spacing * 2;
 $card-horizontal-spacing-small: $card-horizontal-spacing / 2;
+
+// Small vp padding and width
+$small-viewport-content-padding: 20px !default;


### PR DESCRIPTION
- **Rationale:** Update padding in S viewport to use variable.
- **Risk:** Low
- **Risk Detail:** Added a mixin to calculate width and a variable for padding of body content.
- **Reward:** High
- **Reward Details:** Allows styling override as a result of adding the mixin.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/177
- **Issue:** rdar://90844182
- **Code Reviewed By:** @dobromir-hristov
- **Testing Details:** Visually test in browser and verify that padding on either side of body content in small vp is still 20px.