### PR TITLE
[5.7] Simplify the matching pattern in the Navigator filter

### DIFF
--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -186,11 +186,14 @@ export function whiteSpaceIgnorantRegex(stringToSanitize) {
     char = trimmedString[i];
     // if the character is an escape char, pass it and the next character
     if (char === '\\') {
+      // pass both escape char and char, with an empty space match before, only if not first char
+      collector.push(`${i === 0 ? '' : spaceMatch}${char}`);
+      collector.push(trimmedString[i + 1]);
       // skip one character in next iteration
       i += 1;
-      // pass both escape char and char, with an empty space match before
-      collector.push(`${spaceMatch}${char}`);
-      collector.push(trimmedString[i]);
+    } else if (i === 0) {
+      // skip the first character, if its not a `\`
+      collector.push(char);
       // add anything else, but empty spaces
     } else if (char !== singleSpace) {
       collector.push(`${spaceMatch}${char}`);

--- a/tests/unit/utils/search-utils.spec.js
+++ b/tests/unit/utils/search-utils.spec.js
@@ -13,6 +13,6 @@ import { safeHighlightPattern } from '@/utils/search-utils';
 describe('search-utils', () => {
   it('returns a safe pattern for highlighting', () => {
     expect(safeHighlightPattern('text $ % ( * .'))
-      .toEqual(/\s*t\s*e\s*x\s*t\s*\$\s*%\s*\(\s*\*\s*\./gi);
+      .toEqual(/t\s*e\s*x\s*t\s*\$\s*%\s*\(\s*\*\s*\./gi);
   });
 });

--- a/tests/unit/utils/strings.spec.js
+++ b/tests/unit/utils/strings.spec.js
@@ -181,13 +181,13 @@ describe('escapeRegExp', () => {
 
 describe('whiteSpaceIgnorantRegex', () => {
   it('adds white space matches before each character', () => {
-    expect(whiteSpaceIgnorantRegex('abc')).toBe('\\s*a\\s*b\\s*c');
+    expect(whiteSpaceIgnorantRegex('abc')).toBe('a\\s*b\\s*c');
   });
 
   it('takes into consideration escaped characters', () => {
     expect(whiteSpaceIgnorantRegex('a\\[\\.\\')).toBe(
       /* eslint-disable no-useless-concat */
-      '\\s*' + 'a'
+      'a'
       + '\\s*' + '\\['
       + '\\s*' + '\\.'
       + '\\s*' + '\\',
@@ -196,13 +196,22 @@ describe('whiteSpaceIgnorantRegex', () => {
 
   it('skips white spaces between characters', () => {
     expect(whiteSpaceIgnorantRegex('  a     b   ')).toBe(
-      '\\s*' + 'a'
+      'a'
       + '\\s*' + 'b',
     );
   });
 
   it('reduces multiple empty spaces to a single one, so no infinite matchers are returned', () => {
     expect(whiteSpaceIgnorantRegex('  ')).toBe(' ');
+  });
+
+  it('skips the first char, even if its an escape character', () => {
+    expect(whiteSpaceIgnorantRegex('\\[\\.\\')).toBe(
+      /* eslint-disable no-useless-concat */
+      '\\['
+      + '\\s*' + '\\.'
+      + '\\s*' + '\\',
+    );
   });
 });
 


### PR DESCRIPTION
- **Rationale:** Simplifies the filter matching pattern on the Navigator. Now it wont highlight leading/trailing spaces on potential matches.
- **Risk:** Low
- **Risk Detail:** Small change to the text matching pattern, that is used in the Navigator.
- **Reward:** High
- **Reward Details:** Users get an improved text matching highlight.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/148
- **Issue:** rdar://91443929
- **Code Reviewed By:** @hqhhuang @SamLanier 
- **Testing Details:** Updated unit tests and manually tested in the browser.