### PR TITLE
Render beta badge in navigator when applicable

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -83,6 +83,7 @@
           />
         </Reference>
         <Badge v-if="isDeprecated" variant="deprecated" />
+        <Badge v-else-if="isBeta" variant="beta" />
       </div>
     </div>
   </div>
@@ -171,6 +172,7 @@ export default {
       if (!isParent) return `${baseLabel} ${usageLabel}`;
       return `${baseLabel} ${parentLabel} ${usageLabel}`;
     },
+    isBeta: ({ item: { beta } }) => !!beta,
     isDeprecated: ({ item: { deprecated } }) => !!deprecated,
   },
   methods: {

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -90,6 +90,38 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.find(Badge).attributes('variant')).toBe('deprecated');
   });
 
+  it('renders a beta badge when item is beta', () => {
+    let wrapper;
+    wrapper = createWrapper();
+    expect(wrapper.contains(Badge)).toBe(false);
+    wrapper = createWrapper({
+      propsData: {
+        item: {
+          ...defaultProps.item,
+          beta: true,
+        },
+      },
+    });
+    expect(wrapper.find(Badge).attributes('variant')).toBe('beta');
+  });
+
+  it('only renders a deprecated badge when item is both deprecated and beta', () => {
+    let wrapper;
+    wrapper = createWrapper();
+    expect(wrapper.contains(Badge)).toBe(false);
+    wrapper = createWrapper({
+      propsData: {
+        item: {
+          ...defaultProps.item,
+          beta: true,
+          deprecated: true,
+        },
+      },
+    });
+    expect(wrapper.find(Badge).attributes('variant')).toBe('deprecated');
+    expect(wrapper.findAll(Badge).length).toBe(1);
+  });
+
   it('does not render the expand button, if has no children', () => {
     const wrapper = createWrapper({
       propsData: {


### PR DESCRIPTION
Bug/issue #, if applicable: 92119086

## Summary

Adds support for rendering a "Beta" badge in the navigator alongside an item name when the relevant topic has been indicated as being so.

Example:
<img width="465" alt="Screen Shot 2022-04-21 at 3 12 17 PM" src="https://user-images.githubusercontent.com/212918/164560416-d4572174-a42b-4062-b780-07385d410f62.png">

The behavior should be consistent with the deprecated badge, and the deprecated badge will take precedence over the beta badge in the rare scenario where an item happens to be both beta and deprecated, matching existing behavior for these badges at the top level of a page.

## Testing

Steps:
1. Download/unzip [ExamplePackage.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8535415/ExamplePackage.doccarchive.zip)
2. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/Example.doccarchive npm run serve`
3. Open http://localhost:8080/documentation/examplepackage and verify that a beta badge is rendered in the navigator for one of the topics

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
