### PR TITLE
[5.7] Fix chevron icon in collapsed top nav bar is not visible 

### DIFF
--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -613,7 +613,6 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
 .nav-actions {
   display: flex;
   align-items: center;
-  max-height: $nav-height-small;
 
   @include nav-in-breakpoint {
     grid-area: actions;
@@ -731,7 +730,6 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
     width: 100%;
     height: rem(12px);
     transition: $nav-chevron-transition;
-    margin-top: 2px;
 
     &::before,
     &::after {


### PR DESCRIPTION
- **Rationale:** Fixes a bug where the chevron icon in the nav bar disappears at a certain zoom level
- **Risk:** Low
- **Risk Detail:** Isolated CSS changes in the nav bar.
- **Reward:** High
- **Reward Details:** UI is now consistent when users zoom in/out
- **Original PR:** https://github.com/apple/swift-docc-render/pull/179
- **Issue:** : SR-16120
- **Code Reviewed By:** @hqhhuang @dobromir-hristov 
- **Testing Details:** In safari, enter simulator, set browser window to 800 x 700 VP, 1x res, Safari 15.3 - macOS - Mac; Zoom out to around 85%, verify that the chevron icon in nav bar appears consistently when zooming in/out