### PR TITLE
[5.7] Render beta badge in navigator when applicable

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -83,6 +83,7 @@
           />
         </Reference>
         <Badge v-if="isDeprecated" variant="deprecated" />
+        <Badge v-else-if="isBeta" variant="beta" />
       </div>
     </div>
   </div>
@@ -171,6 +172,7 @@ export default {
       if (!isParent) return `${baseLabel} ${usageLabel}`;
       return `${baseLabel} ${parentLabel} ${usageLabel}`;
     },
+    isBeta: ({ item: { beta } }) => !!beta,
     isDeprecated: ({ item: { deprecated } }) => !!deprecated,
   },
   methods: {

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -90,6 +90,38 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.find(Badge).attributes('variant')).toBe('deprecated');
   });
 
+  it('renders a beta badge when item is beta', () => {
+    let wrapper;
+    wrapper = createWrapper();
+    expect(wrapper.contains(Badge)).toBe(false);
+    wrapper = createWrapper({
+      propsData: {
+        item: {
+          ...defaultProps.item,
+          beta: true,
+        },
+      },
+    });
+    expect(wrapper.find(Badge).attributes('variant')).toBe('beta');
+  });
+
+  it('only renders a deprecated badge when item is both deprecated and beta', () => {
+    let wrapper;
+    wrapper = createWrapper();
+    expect(wrapper.contains(Badge)).toBe(false);
+    wrapper = createWrapper({
+      propsData: {
+        item: {
+          ...defaultProps.item,
+          beta: true,
+          deprecated: true,
+        },
+      },
+    });
+    expect(wrapper.find(Badge).attributes('variant')).toBe('deprecated');
+    expect(wrapper.findAll(Badge).length).toBe(1);
+  });
+
   it('does not render the expand button, if has no children', () => {
     const wrapper = createWrapper({
       propsData: {


### PR DESCRIPTION
- **Rationale:** Adds support for rendering beta badge for items in navigator.
- **Risk:** Low
- **Risk Detail:** Very small, focused JS additions.
- **Reward:** High
- **Reward Details:** Allows navigator to indicate which items are currently in beta.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/204
- **Issue:** rdar://92119086
- **Code Reviewed By:** @dobromir-hristov, @hqhhuang 
- **Testing Details:** Added unit tests, visually inspected example documentation with beta items.