### PR TITLE
Sidebar AX: Focus is lost when pressing Enter on a row that has children

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -453,6 +453,8 @@ export default {
       this.debouncedFilter = value;
       // note to the component, that we want to reset the scroll
       this.resetScroll = true;
+      // reset the last focus target
+      this.lastFocusTarget = null;
     }, 500),
     /**
      * Finds which nodes need to be opened.
@@ -462,8 +464,6 @@ export default {
       [filteredChildren, activePathChildren, filter, selectedTags],
       [, activePathChildrenBefore = [], filterBefore = '', selectedTagsBefore = []] = [],
     ) {
-      // reset the last focus target
-      this.lastFocusTarget = null;
       // skip in case this is a first mount and we are syncing the `filter` and `selectedTags`.
       if (
         (filter !== filterBefore && !filterBefore && sessionStorage.get(STORAGE_KEYS.filter))

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -2024,27 +2024,5 @@ describe('NavigatorCard', () => {
       expect(wrapper.vm.lastFocusTarget).toEqual(null);
       expect(focusSpy).toHaveBeenCalledTimes(0);
     });
-
-    it('clears the focusTarget on page nav', async () => {
-      const wrapper = createWrapper();
-      await flushPromises();
-      // Set the focus item to be something outside the scroller.
-      // This might happen if it deletes an item, that was in focus
-      const button = wrapper.find(NavigatorCardItem).find('button');
-      // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
-      const focusSpy = jest.spyOn(button.element, 'focus');
-      await flushPromises();
-      // simulate a page nav
-      wrapper.setProps({
-        activePath: [root1.path],
-      });
-      await flushPromises();
-      // trigger an update
-      wrapper.find(RecycleScroller).vm.$emit('update');
-      await flushPromises();
-      expect(wrapper.vm.lastFocusTarget).toEqual(null);
-      expect(focusSpy).toHaveBeenCalledTimes(0);
-    });
   });
 });


### PR DESCRIPTION
Bug/issue #92082015, if applicable: 

## Summary

When using the sidebar with keyboard arrows, pressing Enter on an item *with children* loses focus on the sidebar item, so you can’t use arrows to navigate the sidebar anymore. This doesn’t happen when you press Enter on rows that don’t have children though.

## Dependencies

NA

## Testing

Steps:
1. Open a .doccarchive with navigation
2. Open Safari
3. Use the keyboard arrows to navigate through the items in the sidenav
4. Press enter on a item and assert that it does not loses focus
5. Assert that there are no regressions

## Checklist

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
