### PR TITLE
[regression] Fix bug where long titles are now broken at arbitrary characters

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -27,7 +27,8 @@
           :swiftPath="swiftPath"
         />
         <Title :eyebrow="roleHeading">
-          {{ title }}
+          <WordBreak>{{ title }}</WordBreak>
+          <template v-if="isSymbolBeta || isSymbolDeprecated">&nbsp;</template>
           <small v-if="isSymbolDeprecated" slot="after" class="deprecated">Deprecated</small>
           <small v-else-if="isSymbolBeta" slot="after" class="beta">Beta</small>
         </Title>
@@ -95,6 +96,7 @@ import Aside from 'docc-render/components/ContentNode/Aside.vue';
 import BetaLegalText from 'theme/components/DocumentationTopic/BetaLegalText.vue';
 import LanguageSwitcher from 'theme/components/DocumentationTopic/Summary/LanguageSwitcher.vue';
 import DocumentationHero from 'docc-render/components/DocumentationTopic/DocumentationHero.vue';
+import WordBreak from 'docc-render/components/WordBreak.vue';
 import Abstract from './DocumentationTopic/Description/Abstract.vue';
 import ContentNode from './DocumentationTopic/ContentNode.vue';
 import CallToActionButton from './CallToActionButton.vue';
@@ -141,6 +143,7 @@ export default {
     SeeAlso,
     Title,
     Topics,
+    WordBreak,
   },
   props: {
     abstract: {

--- a/src/components/DocumentationTopic/Title.vue
+++ b/src/components/DocumentationTopic/Title.vue
@@ -11,19 +11,16 @@
 <template>
   <div class="topictitle">
     <span v-if="eyebrow" class="eyebrow">{{eyebrow}}</span>
-    <WordBreak class="title" tag="h1">
+    <h1 class="title">
       <slot />
       <slot name="after" />
-    </WordBreak>
+    </h1>
   </div>
 </template>
 
 <script>
-import WordBreak from 'docc-render/components/WordBreak.vue';
-
 export default {
   name: 'Title',
-  components: { WordBreak },
   props: {
     eyebrow: {
       type: String,

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -29,6 +29,7 @@ const {
   Topics,
   Title,
   BetaLegalText,
+  WordBreak,
 } = DocumentationTopic.components;
 
 const foo = {
@@ -259,10 +260,14 @@ describe('DocumentationTopic', () => {
 
   it('renders a `Title`', () => {
     const hero = wrapper.find(DocumentationHero);
+
     const title = hero.find(Title);
     expect(title.exists()).toBe(true);
     expect(title.props('eyebrow')).toBe(propsData.roleHeading);
-    expect(title.text()).toBe(propsData.title);
+
+    const wb = title.find(WordBreak);
+    expect(wb.exists()).toBe(true);
+    expect(wb.text()).toBe(propsData.title);
   });
 
   it('renders smaller "Beta" and "Deprecated" text in title when relevant', () => {
@@ -276,6 +281,7 @@ describe('DocumentationTopic', () => {
       isSymbolDeprecated: true,
       isSymbolBeta: true,
     });
+    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Deprecated/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).is('.beta')).toBe(false);
@@ -287,6 +293,7 @@ describe('DocumentationTopic', () => {
       isSymbolDeprecated: false,
       isSymbolBeta: true,
     });
+    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Beta/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).is('.beta')).toBe(true);
@@ -298,6 +305,7 @@ describe('DocumentationTopic', () => {
       isSymbolDeprecated: true,
       isSymbolBeta: false,
     });
+    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Deprecated/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).is('.beta')).toBe(false);

--- a/tests/unit/components/DocumentationTopic/Title.spec.js
+++ b/tests/unit/components/DocumentationTopic/Title.spec.js
@@ -36,11 +36,9 @@ describe('Title', () => {
     expect(eyebrow.text()).toBe('Thing');
   });
 
-  it('renders a `WordBreak` with an <h1> tag for the default slot', () => {
-    const { WordBreak } = Title.components;
-    const wb = wrapper.find(WordBreak);
-    expect(wb.classes('title')).toBe(true);
-    expect(wb.attributes('tag')).toBe('h1');
-    expect(wb.text()).toBe('FooKit');
+  it('renders <h1> tag for the default slot', () => {
+    const h1 = wrapper.find('h1');
+    expect(h1.classes('title')).toBe(true);
+    expect(h1.text()).toBe('FooKit');
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 92081750

## Summary

This fixes a regression introduced on main with f12b885045341728ebf94329f0581747a933753e as part of the updated layout changes in support of the new navigator UX.

This happened because the `WordBreak` component only works with string slot content, and there was some shuffling of slots in the title component to add beta/deprecated text that caused it to stop working as expected.

main:
![Screen Shot 2022-04-26 at 14 50 31](https://user-images.githubusercontent.com/212918/165399401-1c4b210c-bfc3-428d-b1fe-8d1bb0f4db04.png)

this branch:
![Screen Shot 2022-04-26 at 14 51 07](https://user-images.githubusercontent.com/212918/165399423-3b221fbf-3e9c-4380-b023-58ddbe8ed9c7.png)

## Testing

Steps:
1. Run `env VUE_APP_DEV_SERVER_PROXY=https://ethan-kusters.github.io/swift-argument-parser npm run serve`
2. Open http://localhost:8080/documentation/argumentparser/parsablecommand/helpmessage(for:includehidden:columns:) (or any other long symbol whose title wraps to the next line)
3. Verify that the string is broken at the start of individual parameter names instead of arbitrary characters

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
