### PR TITLE
[5.7]  Fix safari calling out label as clickable

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <div class="navigator">
+  <nav class="navigator">
     <NavigatorCard
       v-if="!isFetching"
       :technology="technology.title"
@@ -26,7 +26,7 @@
     <div v-else class="loading-placeholder">
       Fetching...
     </div>
-  </div>
+  </nav>
 </template>
 
 <script>

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -21,9 +21,9 @@
             <SidenavIcon class="icon-inline close-icon" />
           </button>
           <Reference :url="technologyPath" class="navigator-head" :id="INDEX_ROOT_KEY">
-            <div class="card-link">
+            <h2 class="card-link">
               {{ technology }}
-            </div>
+            </h2>
           </Reference>
         </div>
         <slot name="post-head" />

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -67,11 +67,11 @@
         >
           {{ item.index + 1 }} of {{ item.siblingsCount }} symbols inside
         </span>
-        <Reference
+        <component
+          :is="refComponent"
           :id="item.uid"
-          :url="item.path || ''"
-          :isActive="!isGroupMarker"
           :class="{ bolded: isBold }"
+          :url="isGroupMarker ? null : (item.path || '')"
           class="leaf-link"
           tabindex="-1"
           ref="reference"
@@ -81,7 +81,7 @@
             :text="item.title"
             :matcher="filterPattern"
           />
-        </Reference>
+        </component>
         <Badge v-if="isDeprecated" variant="deprecated" />
         <Badge v-else-if="isBeta" variant="beta" />
       </div>
@@ -174,6 +174,7 @@ export default {
     },
     isBeta: ({ item: { beta } }) => !!beta,
     isDeprecated: ({ item: { deprecated } }) => !!deprecated,
+    refComponent: ({ isGroupMarker }) => (isGroupMarker ? 'h3' : Reference),
   },
   methods: {
     toggleTree() {

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -112,8 +112,11 @@ describe('Navigator', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   it('renders the Navigator', () => {
     const wrapper = createWrapper();
+    // assert navigator is a `nav`
+    expect(wrapper.find('.navigator').is('nav')).toBe(true);
     // assert Navigator card is rendered
     expect(wrapper.find(NavigatorCard).props()).toEqual({
       activePath: [references.first.url, references.second.url, mocks.$route.path],

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -156,6 +156,7 @@ describe('NavigatorCard', () => {
     // assert link
     expect(wrapper.find(Reference).props('url')).toEqual(defaultProps.technologyPath);
     expect(wrapper.find('.card-link').text()).toBe(defaultProps.technology);
+    expect(wrapper.find('.card-link').is('h2')).toBe(true);
     // assert scroller
     const scroller = wrapper.find(RecycleScroller);
     expect(wrapper.vm.activePathChildren).toHaveLength(2);

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -356,6 +356,18 @@ describe('NavigatorCardItem', () => {
       expect(wrapper.emitted('navigate')).toBeFalsy();
     });
 
+    it('renders a h3 if it is a groupMaker', () => {
+      const wrapper = createWrapper({
+        propsData: {
+          item: {
+            ...defaultProps.item,
+            type: TopicTypes.groupMarker,
+          },
+        },
+      });
+      expect(wrapper.find('.leaf-link').is('h3')).toBe(true);
+    });
+
     it('does not apply aria-hidden to NavigatorCardItem if isRendered is true', () => {
       const wrapper = createWrapper();
       expect(wrapper.find('.navigator-card-item').attributes('aria-hidden')).toBeFalsy();


### PR DESCRIPTION
- **Rationale:** VoiceOver should read group labels in the Navigator as text, not clickable elements
- **Risk:** Low
- **Risk Detail:** only affects AX
- **Reward:** Medium for AX users
- **Reward Details:** Improves VoiceOver navigation experience
- **Original PR:** https://github.com/apple/swift-docc-render/pull/187
- **Issue:** rdar://90633560
- **Code Reviewed By:** @marinaaisa 
- **Testing Details:** Check that VO navigation does not read group labels as `clickable`