### PR TITLE
[5.7] Don't render default footer for IDE target

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,7 @@
     <slot :isTargetIDE="isTargetIDE">
       <router-view />
       <custom-footer v-if="hasCustomFooter" :data-color-scheme="preferredColorScheme" />
-      <Footer v-else />
+      <Footer v-else-if="!isTargetIDE" />
     </slot>
     <slot name="footer" :isTargetIDE="isTargetIDE" />
   </div>

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -21,7 +21,7 @@ html {
 
 body {
   @include font-styles(body);
-  background-color: var(--color-fill);
+  background-color: var(--color-text-background);
   color: var(--colors-text, var(--color-text));
   font-style: normal;
   word-wrap: break-word;

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -169,9 +169,12 @@ describe('App', () => {
     expect(wrapper.find(InitialLoadingPlaceholder).exists()).toBe(true);
   });
 
-  it('renders a `Footer`', () => {
+  it('renders a default `Footer` for non-IDE targets', () => {
     const wrapper = createWrapper();
     expect(wrapper.contains(Footer)).toBe(true);
+
+    wrapper.setData({ isTargetIDE: true });
+    expect(wrapper.contains(Footer)).toBe(false);
   });
 
   describe('Custom CSS Properties', () => {


### PR DESCRIPTION
- **Rationale:** Fixes issue where default footer with color scheme toggle may briefly flash on screen in IDE targets in rare scenarios where pages are being navigated very rapidly.
- **Risk:** Low
- **Risk Detail:** One JS conditional added, one color mapping changed
- **Reward:** High
- **Reward Details:** Fixes visual bug where UI that shouldn't be shown is.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/215
- **Issue:** rdar://89998805
- **Code Reviewed By:** @dobromir-hristov, @hqhhuang 
- **Testing Details:** Added unit tests, manually reproduced problematic scenario and verified that the footer/toggle no longer flashes on-screen with these changes.