### PR TITLE
Keyboard navigation should scroll as in macOS instead of jumping back to center the view

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -49,6 +49,7 @@
             @focusin.native="handleFocusIn"
             @focusout.native="handleFocusOut"
             @update="handleScrollerUpdate"
+            @scroll.native="handleScroll"
           >
             <NavigatorCardItem
               :item="item"
@@ -812,6 +813,26 @@ export default {
       if (!this.isInsideScroller(event.relatedTarget)) {
         this.lastFocusTarget = null;
       }
+    },
+    handleScroll(event) {
+      if (!this.latestKeyboardMovement) return;
+      // prevent default scroll
+      event.preventDefault();
+      // if the lastest keyboard movement as been next
+      // scroll down the scroller
+      if (this.latestKeyboardMovement === 'next') {
+        this.$refs.scroller.$el.scrollBy({
+          top: 12,
+          left: 0,
+        });
+      }
+      // if the lastest keyboard movement as been prev
+      // scroll to current focus item
+      if (this.latestKeyboardMovement === 'prev') {
+        this.scrollToFocus();
+      }
+      // reset latest keyboard movement
+      this.latestKeyboardMovement = null;
     },
     handleScrollerUpdate: debounce(async function handleScrollerUpdate() {
       // wait is long, because the focus change is coming in very late

--- a/src/mixins/keyboardNavigation.js
+++ b/src/mixins/keyboardNavigation.js
@@ -13,6 +13,7 @@ export default {
     return {
       focusedIndex: 0,
       externalFocusChange: false,
+      latestKeyboardMovement: null,
     };
   },
   methods: {
@@ -26,6 +27,7 @@ export default {
       this.externalFocusChange = false;
       if (this.focusedIndex > 0) {
         this.focusIndex(this.focusedIndex - 1);
+        this.latestKeyboardMovement = 'prev';
       } else {
         this.startingPointHook();
       }
@@ -36,6 +38,7 @@ export default {
       this.externalFocusChange = false;
       if (this.focusedIndex < this.totalItemsToNavigate - 1) {
         this.focusIndex(this.focusedIndex + 1);
+        this.latestKeyboardMovement = 'next';
       } else {
         this.endingPointHook();
       }

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -915,6 +915,36 @@ describe('NavigatorCard', () => {
     expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledWith(0);
   });
 
+  it('scrolls down one item if the lastest keyboard movement as been `next`', async () => {
+    const wrapper = createWrapper();
+    const scrollByMock = jest.fn();
+    await flushPromises();
+    Object.defineProperty(wrapper.find({ ref: 'scroller' }).element, 'scrollBy', {
+      value: scrollByMock,
+    });
+    expect(scrollByMock).toHaveBeenCalledTimes(0);
+    expect(wrapper.vm.focusedIndex).toBe(1);
+    const items = wrapper.findAll(NavigatorCardItem);
+    expect(items.at(0).props('enableSelfFocus')).toBe(false);
+    expect(items.at(0).exists()).toBe(true);
+    items.at(0).trigger('keydown.down');
+    wrapper.find(RecycleScroller).trigger('scroll');
+    expect(scrollByMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('scrolls up one item if the lastest keyboard movement as been `prev`', async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.focusedIndex).toBe(1);
+    const items = wrapper.findAll(NavigatorCardItem);
+    expect(items.at(0).props('enableSelfFocus')).toBe(false);
+    expect(items.at(0).exists()).toBe(true);
+    items.at(0).trigger('keydown.up');
+    wrapper.find(RecycleScroller).trigger('scroll');
+    expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(2);
+  });
+
   it('filters items, keeping only direct matches, removing siblings, even if parent is a direct match', async () => {
     const root0Updated = {
       ...root0,


### PR DESCRIPTION
Bug/issue #90601877, if applicable: 

## Summary

Keyboard navigation should scroll as in macOS instead of jumping back to center the view

![demo](https://user-images.githubusercontent.com/8567677/165797267-cedde568-48dd-439c-8435-225e9df2f3ad.gif)

## Dependencies

NA

## Testing

Steps:
1. Open a .doccarchive with navigation
2. Using the keyboard navigation go to the bottom of the sidenav
3. Assert that when you reach the bottom it scrolls as in macOS instead of jumping to the center of the page
4. Assert the same for the top part

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
