### PR TITLE
[5.7] Fix bug in Safari, where the navigator cannot be scrolled by dragging scrollbar

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1121,6 +1121,13 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
   @include breakpoint(medium, nav) {
     padding-bottom: $nav-menu-items-ios-bottom-spacing;
   }
+
+  // The VueVirtualScroller scrollbar is not selectable and draggable in Safari,
+  // which is most probably caused by the complicated styling of the component.
+  // Adding translate3D causes the browser to use hardware acceleration and fixes the issue.
+  /deep/ .vue-recycle-scroller__item-wrapper {
+    transform: translate3d(0, 0, 0);
+  }
 }
 
 .filter-wrapper {


### PR DESCRIPTION
- **Rationale:** Navigator scrollbar in Safari cannot be dragged with mouse
- **Risk:** Low
- **Risk Detail:** single css line added to a very isolated place
- **Reward:** Medium
- **Reward Details:** Users can now click and drag the navigator scrollbar
- **Original PR:** https://github.com/apple/swift-docc-render/pull/221
- **Issue:** rdar://92337769
- **Code Reviewed By:** @marinaaisa @mportiz08 
- **Testing Details:** Assert you can drag the navigator scrollbar in Safari