### PR TITLE
[5.7] Prevent losing focus when navigating using the keyboard nav in Safari in the sidenav

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -453,6 +453,8 @@ export default {
       this.debouncedFilter = value;
       // note to the component, that we want to reset the scroll
       this.resetScroll = true;
+      // reset the last focus target
+      this.lastFocusTarget = null;
     }, 500),
     /**
      * Finds which nodes need to be opened.
@@ -462,8 +464,6 @@ export default {
       [filteredChildren, activePathChildren, filter, selectedTags],
       [, activePathChildrenBefore = [], filterBefore = '', selectedTagsBefore = []] = [],
     ) {
-      // reset the last focus target
-      this.lastFocusTarget = null;
       // skip in case this is a first mount and we are syncing the `filter` and `selectedTags`.
       if (
         (filter !== filterBefore && !filterBefore && sessionStorage.get(STORAGE_KEYS.filter))

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -2024,27 +2024,5 @@ describe('NavigatorCard', () => {
       expect(wrapper.vm.lastFocusTarget).toEqual(null);
       expect(focusSpy).toHaveBeenCalledTimes(0);
     });
-
-    it('clears the focusTarget on page nav', async () => {
-      const wrapper = createWrapper();
-      await flushPromises();
-      // Set the focus item to be something outside the scroller.
-      // This might happen if it deletes an item, that was in focus
-      const button = wrapper.find(NavigatorCardItem).find('button');
-      // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
-      const focusSpy = jest.spyOn(button.element, 'focus');
-      await flushPromises();
-      // simulate a page nav
-      wrapper.setProps({
-        activePath: [root1.path],
-      });
-      await flushPromises();
-      // trigger an update
-      wrapper.find(RecycleScroller).vm.$emit('update');
-      await flushPromises();
-      expect(wrapper.vm.lastFocusTarget).toEqual(null);
-      expect(focusSpy).toHaveBeenCalledTimes(0);
-    });
   });
 });


### PR DESCRIPTION
- Rationale: Prevent losing focus when navigating using the keyboard nav in Safari in the sidenav
- Risk: Low
- Risk Detail: it only resets the last focus target
- Reward: Medium
- Reward Details: Users won't lose focus when navigating using the keyboard nav in Safari in the sidenav
- Original PR: https://github.com/apple/swift-docc-render/pull/219/
- Issue: rdar://92082015
- Code Reviewed By: [@dobromir-hristov](https://github.com/dobromir-hristov)
- Testing Details: Assert you use the keyboard navigation in the sidenav in Safari