### PR TITLE
Allow "objective-c" to be alias for syntax highlighting

### DIFF
--- a/src/utils/syntax-highlight.js
+++ b/src/utils/syntax-highlight.js
@@ -10,6 +10,11 @@
 
 import hljs from 'highlight.js/lib/core';
 
+/** A map of custom aliases for supported languages (additions to default hljs aliases) */
+const CustomLanguageAliases = {
+  objectivec: ['objective-c'],
+};
+
 /** A map of supported languages and their aliases */
 const Languages = {
   bash: ['sh', 'zsh'],
@@ -23,7 +28,7 @@ const Languages = {
   json: [],
   llvm: [],
   markdown: ['md', 'mkdown', 'mkd'],
-  objectivec: ['mm', 'objc', 'obj-c'],
+  objectivec: ['mm', 'objc', 'obj-c'].concat(CustomLanguageAliases.objectivec),
   perl: ['pl', 'pm'],
   php: [],
   python: ['py', 'gyp', 'ipython'],
@@ -223,11 +228,14 @@ export function sanitizeMultilineNodes(element) {
  * @returns {string}
  */
 export function highlight(code, language) {
-  if (!hljs.getLanguage(language)) {
+  // normalize the language name in case it is a custom alias that highlight.js
+  // doesn't know about
+  const normalizedLang = getLanguageByAlias(language);
+  if (!hljs.getLanguage(normalizedLang)) {
     throw new Error(`Unsupported language for syntax highlighting: ${language}`);
   }
 
-  return hljs.highlight(code, { language, ignoreIllegals: true }).value;
+  return hljs.highlight(code, { language: normalizedLang, ignoreIllegals: true }).value;
 }
 
 /**

--- a/tests/unit/utils/syntax-highlight.spec.js
+++ b/tests/unit/utils/syntax-highlight.spec.js
@@ -279,6 +279,14 @@ describe("syntax-highlight", () => {
     }
   );
 
+  describe('custom aliases', () => {
+    it('does not throw an error when the language is "objective-c"', async () => {
+      const language = 'objective-c';
+      await registerHighlightLanguage(language);
+      expect(tryHighlight("foo", language)).not.toThrow();
+    });
+  });
+
   it("throws an error for unsupported languages", () => {
     expect(tryHighlight("foo", "bash")).toThrowError(
       /Unsupported language for syntax highlighting: bash/


### PR DESCRIPTION
Bug/issue #, if applicable: 92454948

## Summary

Right now, DocC users can use `"objectivec"` or `"objc"` to specify that a fenced code block should be syntax highlighted as Objective-C code, but they can't use `"objective-c"` (note the hyphen). This change fixes that.

## Testing

You can update `SwiftDocCRender.docc` with an example code listing by copying the following path and running `pbpaste | git apply`:
```diff
diff --git a/SwiftDocCRender.docc/SwiftDocCRender.md b/SwiftDocCRender.docc/SwiftDocCRender.md
index a2b9a6a..f759451 100644
--- a/SwiftDocCRender.docc/SwiftDocCRender.md
+++ b/SwiftDocCRender.docc/SwiftDocCRender.md
@@ -10,6 +10,10 @@ A web renderer for DocC Archives produced by DocC.
 
 DocC-Render displays documentation produced by [DocC](https://www.swift.org/documentation/docc) on the web and is included in DocC Archives.
 
+```objective-c
+[[NSFoo alloc] initWithBar: @"Baz"];
+```
+
 ### How It Works
 
 DocC-Render is a Single Page Application (SPA for short), powered by [Vue.js](https://vuejs.org). SPAs are web apps that are rendered entirely in the browser using JavaScript. Pages and content are generated dynamically at runtime, based on DocC generated Render JSON data.

```

Steps:
1. Run `npm run docs:build` to build `SwiftDocCRender.docc` with the example code listing
2. Run `env VUE_APP_DEV_SERVER_PROXY=/path/to/swift-docc-render/SwiftDocCRender.docc/.docc-build npm run serve`
3. Open http://localhost:8080/documentation/swiftdoccrender and verify that the example code listing is syntax highlighted

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
