### PR TITLE
[5.7] Allow "objective-c" to be alias for syntax highlighting

### DIFF
--- a/src/utils/syntax-highlight.js
+++ b/src/utils/syntax-highlight.js
@@ -10,6 +10,11 @@
 
 import hljs from 'highlight.js/lib/core';
 
+/** A map of custom aliases for supported languages (additions to default hljs aliases) */
+const CustomLanguageAliases = {
+  objectivec: ['objective-c'],
+};
+
 /** A map of supported languages and their aliases */
 const Languages = {
   bash: ['sh', 'zsh'],
@@ -23,7 +28,7 @@ const Languages = {
   json: [],
   llvm: [],
   markdown: ['md', 'mkdown', 'mkd'],
-  objectivec: ['mm', 'objc', 'obj-c'],
+  objectivec: ['mm', 'objc', 'obj-c'].concat(CustomLanguageAliases.objectivec),
   perl: ['pl', 'pm'],
   php: [],
   python: ['py', 'gyp', 'ipython'],
@@ -223,11 +228,14 @@ export function sanitizeMultilineNodes(element) {
  * @returns {string}
  */
 export function highlight(code, language) {
-  if (!hljs.getLanguage(language)) {
+  // normalize the language name in case it is a custom alias that highlight.js
+  // doesn't know about
+  const normalizedLang = getLanguageByAlias(language);
+  if (!hljs.getLanguage(normalizedLang)) {
     throw new Error(`Unsupported language for syntax highlighting: ${language}`);
   }
 
-  return hljs.highlight(code, { language, ignoreIllegals: true }).value;
+  return hljs.highlight(code, { language: normalizedLang, ignoreIllegals: true }).value;
 }
 
 /**

--- a/tests/unit/utils/syntax-highlight.spec.js
+++ b/tests/unit/utils/syntax-highlight.spec.js
@@ -279,6 +279,14 @@ describe("syntax-highlight", () => {
     }
   );
 
+  describe('custom aliases', () => {
+    it('does not throw an error when the language is "objective-c"', async () => {
+      const language = 'objective-c';
+      await registerHighlightLanguage(language);
+      expect(tryHighlight("foo", language)).not.toThrow();
+    });
+  });
+
   it("throws an error for unsupported languages", () => {
     expect(tryHighlight("foo", "bash")).toThrowError(
       /Unsupported language for syntax highlighting: bash/


### PR DESCRIPTION
- **Rationale:** Allows "objective-c" as language in fenced code blocks for syntax highlighting.
- **Risk:** Low
- **Risk Detail:** Minor JS adjustments to syntax highlighting logic.
- **Reward:** High
- **Reward Details:** Added flexibility/convenience for users writing docs for ObjC APIs.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/233
- **Issue:** rdar://92454948
- **Code Reviewed By:** @dobromir-hristov 
- **Testing Details:** Added unit test, manually tested that "objective-c" can be used in a fenced code block using DocC and syntax highlighting works as expected.