### PR TITLE
Fix issue where sidebar says "Fetching..." indefinitely when index is empty

### DIFF
--- a/src/components/Navigator/NavigatorDataProvider.vue
+++ b/src/components/Navigator/NavigatorDataProvider.vue
@@ -58,7 +58,7 @@ export default {
       let currentLangTechnologies = navigationIndex[interfaceLanguage] || [];
       // if no such items, we use the default swift one
       if (!currentLangTechnologies.length) {
-        currentLangTechnologies = navigationIndex[Language.swift.key.url];
+        currentLangTechnologies = navigationIndex[Language.swift.key.url] || [];
       }
       // find the current technology
       return currentLangTechnologies.find(t => (

--- a/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
+++ b/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
@@ -189,4 +189,18 @@ describe('NavigatorDataProvider', () => {
       technology: undefined,
     });
   });
+
+  it('returns undefined technology when index response is empty', async () => {
+    const emptyResponse = { interfaceLanguages: {} };
+    fetchIndexPathsData.mockResolvedValue(emptyResponse);
+    createWrapper();
+    await flushPromises();
+    expect(props).toEqual({
+      apiChanges: null,
+      isFetchingAPIChanges: false,
+      isFetching: false,
+      technology: undefined,
+      errorFetching: false,
+    });
+  });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 91959429

## Summary

Fixes a bug where the sidebar says "Fetching..." and stays like that indefinitely when the request for index data succeeds but is empty. There was one place in the code that was crashing and needed a default value.

## Testing

Steps:
1. Download/unzip [empty-example.zip](https://github.com/apple/swift-docc-render/files/8592351/empty-example.zip) fixture
2. Run `env VUE_APP_DEV_SERVER_PROXY=/path/to/empty-example npm run serve`
3. Open http://localhost:8080/documentation/examplepackage
4. Verify that the sidebar promptly says "No data available." instead of getting stuck at "Fetching..."

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
