### PR TITLE
Optimize padding on either side of body content

### DIFF
--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -17,8 +17,8 @@ $breakpoint-attributes: (
       min-width: 1920px
     ),
     large: (
-      min-width: 1069px,
-      content-width: 980px,
+      min-width: 1160px,
+      content-width: 920px,
     ),
     medium: (
       min-width: 736px,

--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -17,12 +17,12 @@ $breakpoint-attributes: (
       min-width: 1920px
     ),
     large: (
-      min-width: 1511px,
+      min-width: 1251px,
       content-width: 980px,
     ),
     medium: (
       min-width: 736px,
-      max-width: 1510px,
+      max-width: 1250px,
       content-width: 692px,
     ),
     small: (

--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -17,12 +17,12 @@ $breakpoint-attributes: (
       min-width: 1920px
     ),
     large: (
-      min-width: 1160px,
-      content-width: 920px,
+      min-width: 1511px,
+      content-width: 980px,
     ),
     medium: (
       min-width: 736px,
-      max-width: 1068px,
+      max-width: 1510px,
       content-width: 692px,
     ),
     small: (


### PR DESCRIPTION
Bug/issue #, if applicable: 91071765

## Summary
Optimize the timing of adding extra padding to the side of the body content

## Testing
Steps:
1. Manually verify that padding becomes 120px when the window width reaches 1251px. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
