### PR TITLE
Avoid copying `Deprecated` and `Beta` tags when triple clicking to select the title

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -32,7 +32,8 @@
             v-if="isSymbolDeprecated || isSymbolBeta"
             slot="after"
             :class="tagName"
-            :data-tag-name="tagName"></small>
+            :data-tag-name="tagName"
+          />
         </Title>
         <Abstract v-if="abstract" :content="abstract" />
         <div v-if="sampleCodeDownload">

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -29,8 +29,11 @@
         <Title :eyebrow="roleHeading">
           <WordBreak>{{ title }}</WordBreak>
           <template v-if="isSymbolBeta || isSymbolDeprecated">&nbsp;</template>
-          <small v-if="isSymbolDeprecated" slot="after" class="deprecated">Deprecated</small>
-          <small v-else-if="isSymbolBeta" slot="after" class="beta">Beta</small>
+          <small
+            v-if="isSymbolDeprecated || isSymbolBeta"
+            slot="after"
+            :class="tagName"
+            :tag-name="tagName"></small>
         </Title>
         <Abstract v-if="abstract" :content="abstract" />
         <div v-if="sampleCodeDownload">
@@ -330,6 +333,7 @@ export default {
       || (downloadNotAvailableSummary && downloadNotAvailableSummary.length)
       || (primaryContentSections && primaryContentSections.length)
     ),
+    tagName: ({ isSymbolDeprecated }) => (isSymbolDeprecated ? 'Deprecated' : 'Beta'),
   },
   methods: {
     normalizePath(path) {

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -28,12 +28,11 @@
         />
         <Title :eyebrow="roleHeading">
           <WordBreak>{{ title }}</WordBreak>
-          <template v-if="isSymbolBeta || isSymbolDeprecated">&nbsp;</template>
           <small
             v-if="isSymbolDeprecated || isSymbolBeta"
             slot="after"
             :class="tagName"
-            :tag-name="tagName"></small>
+            :data-tag-name="tagName"></small>
         </Title>
         <Abstract v-if="abstract" :content="abstract" />
         <div v-if="sampleCodeDownload">

--- a/src/components/DocumentationTopic/Title.vue
+++ b/src/components/DocumentationTopic/Title.vue
@@ -54,17 +54,14 @@ export default {
   }
 }
 
-.beta, .deprecated {
-  user-select: none; /* standard syntax */
-  -webkit-user-select: none; /* webkit (safari, chrome) browsers */
-  -moz-user-select: none; /* mozilla browsers */
-  -ms-user-select: none; /* IE10+ */
-}
-
 small {
   @include font-styles(eyebrow);
 
-  &.beta {
+  &::before {
+    content: attr(tag-name);
+  }
+
+  &.Beta {
     color: var(--color-badge-beta);
 
     .theme-dark & {
@@ -72,7 +69,7 @@ small {
     }
   }
 
-  &.deprecated {
+  &.Deprecated {
     color: var(--color-badge-deprecated);
 
     .theme-dark & {

--- a/src/components/DocumentationTopic/Title.vue
+++ b/src/components/DocumentationTopic/Title.vue
@@ -56,9 +56,10 @@ export default {
 
 small {
   @include font-styles(eyebrow);
+  padding-left: 10px;
 
   &::before {
-    content: attr(tag-name);
+    content: attr(data-tag-name);
   }
 
   &.Beta {

--- a/src/components/DocumentationTopic/Title.vue
+++ b/src/components/DocumentationTopic/Title.vue
@@ -54,6 +54,13 @@ export default {
   }
 }
 
+.beta, .deprecated {
+  user-select: none; /* standard syntax */
+  -webkit-user-select: none; /* webkit (safari, chrome) browsers */
+  -moz-user-select: none; /* mozilla browsers */
+  -ms-user-select: none; /* IE10+ */
+}
+
 small {
   @include font-styles(eyebrow);
 

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -281,36 +281,27 @@ describe('DocumentationTopic', () => {
       isSymbolDeprecated: true,
       isSymbolBeta: true,
     });
-    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Deprecated/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
-    expect(smalls.at(0).is('.beta')).toBe(false);
-    expect(smalls.at(0).is('.deprecated')).toBe(true);
-    expect(smalls.at(0).text()).toBe('Deprecated');
+    expect(smalls.at(0).attributes('tag-name')).toBe('Deprecated');
 
     // only beta
     wrapper.setProps({
       isSymbolDeprecated: false,
       isSymbolBeta: true,
     });
-    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Beta/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
-    expect(smalls.at(0).is('.beta')).toBe(true);
-    expect(smalls.at(0).is('.deprecated')).toBe(false);
-    expect(smalls.at(0).text()).toBe('Beta');
+    expect(smalls.at(0).attributes('tag-name')).toBe('Beta');
 
     // only deprecated
     wrapper.setProps({
       isSymbolDeprecated: true,
       isSymbolBeta: false,
     });
-    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Deprecated/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
-    expect(smalls.at(0).is('.beta')).toBe(false);
-    expect(smalls.at(0).is('.deprecated')).toBe(true);
-    expect(smalls.at(0).text()).toBe('Deprecated');
+    expect(smalls.at(0).attributes('tag-name')).toBe('Deprecated');
   });
 
   it('renders an abstract', () => {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -283,7 +283,7 @@ describe('DocumentationTopic', () => {
     });
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
-    expect(smalls.at(0).attributes('tag-name')).toBe('Deprecated');
+    expect(smalls.at(0).attributes('data-tag-name')).toBe('Deprecated');
 
     // only beta
     wrapper.setProps({
@@ -292,7 +292,7 @@ describe('DocumentationTopic', () => {
     });
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
-    expect(smalls.at(0).attributes('tag-name')).toBe('Beta');
+    expect(smalls.at(0).attributes('data-tag-name')).toBe('Beta');
 
     // only deprecated
     wrapper.setProps({
@@ -301,7 +301,7 @@ describe('DocumentationTopic', () => {
     });
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
-    expect(smalls.at(0).attributes('tag-name')).toBe('Deprecated');
+    expect(smalls.at(0).attributes('data-tag-name')).toBe('Deprecated');
   });
 
   it('renders an abstract', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 92420916

## Summary
Users often triple click to select a paragraph and copy text. This PR fixes the issue where the `Deprecated` and `Beta` tags would be selected and copied as well.

## Testing
Steps:
1. Triple clicking on the title of a documentation that has the `Deprecated` and `Beta` tag in different browsers.
2. Copy the text
3. Verify that only the title is copied, not also the `Deprecated` and `Beta` text

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
