### PR TITLE
[5.7] Fix issue where sidebar says "Fetching..." indefinitely when index is empty

### DIFF
--- a/src/components/Navigator/NavigatorDataProvider.vue
+++ b/src/components/Navigator/NavigatorDataProvider.vue
@@ -58,7 +58,7 @@ export default {
       let currentLangTechnologies = navigationIndex[interfaceLanguage] || [];
       // if no such items, we use the default swift one
       if (!currentLangTechnologies.length) {
-        currentLangTechnologies = navigationIndex[Language.swift.key.url];
+        currentLangTechnologies = navigationIndex[Language.swift.key.url] || [];
       }
       // find the current technology
       return currentLangTechnologies.find(t => (

--- a/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
+++ b/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
@@ -189,4 +189,18 @@ describe('NavigatorDataProvider', () => {
       technology: undefined,
     });
   });
+
+  it('returns undefined technology when index response is empty', async () => {
+    const emptyResponse = { interfaceLanguages: {} };
+    fetchIndexPathsData.mockResolvedValue(emptyResponse);
+    createWrapper();
+    await flushPromises();
+    expect(props).toEqual({
+      apiChanges: null,
+      isFetchingAPIChanges: false,
+      isFetching: false,
+      technology: undefined,
+      errorFetching: false,
+    });
+  });
 });


### PR DESCRIPTION
- **Rationale:** Fixes bug where sidebar says "Fetching..." forever if it successfully fetches an index without any navigator tree data.
- **Risk:** Low
- **Risk Detail:** Updates existing JS logic with a single additional OR case with a default empty array.
- **Reward:** High
- **Reward Details:** Fixes UX issue that is uncommon but could be very confusing for users.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/238
- **Issue:** rdar://91959429
- **Code Reviewed By:** @marinaaisa 
- **Testing Details:** Added unit tests, manually reproduced problematic scenario and verified that the sidebar now says "No data" instead of "Fetching...".