### PR TITLE
[5.7] Optimize padding on either side of body content

### DIFF
--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -17,12 +17,12 @@ $breakpoint-attributes: (
       min-width: 1920px
     ),
     large: (
-      min-width: 1069px,
+      min-width: 1251px,
       content-width: 980px,
     ),
     medium: (
       min-width: 736px,
-      max-width: 1068px,
+      max-width: 1250px,
       content-width: 692px,
     ),
     small: (


### PR DESCRIPTION
**Rationale:** Optimize the timing of adding extra padding to the side of the body content
**Risk:** Low
**Risk Detail:** only breakpoint change.
**Reward:** High
**Reward Details:** Better experience reading documentation in a medium to large viewport when navigator is expanded.
**Original PR:** https://github.com/apple/swift-docc-render/pull/239
**Issue:** rdar://91071765
**Code Reviewed By:** @marinaaisa 
**Testing Details:** Manually test in browser and verify that padding becomes 120px when the window width reaches 1251px.
