### PR TITLE
Fix column layout in `Relationships` section when API Change is on

### DIFF
--- a/src/components/DocumentationTopic/RelationshipsList.vue
+++ b/src/components/DocumentationTopic/RelationshipsList.vue
@@ -156,6 +156,11 @@ export default {
     &:after {
       margin-top: $change-coin-y-offset-reduced;
     }
+
+     // ensure that column layout stays a block content
+    &.column {
+      display: block;
+    }
   }
 }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 92325863

## Summary
Fixes a UI regression where column layout is broken in the `Relationships` section when API Change is turned on.

## Testing
Steps:
1. Navigate to a page that has API Changes turned on in the `Relationships` section
2. Verify that the content in `Relationships` section is displayed vertically in a column form, instead of horizontally.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
