### PR TITLE
[5.7] Fix column layout in Relationships section when API Change is on

### DIFF
--- a/src/components/DocumentationTopic/RelationshipsList.vue
+++ b/src/components/DocumentationTopic/RelationshipsList.vue
@@ -156,6 +156,11 @@ export default {
     &:after {
       margin-top: $change-coin-y-offset-reduced;
     }
+
+     // ensure that column layout stays a block content
+    &.column {
+      display: block;
+    }
   }
 }
 


### PR DESCRIPTION
**Rationale:** Fixes a UI regression where column layout is broken in the Relationships section when API Change is turned on.
**Risk:** Low
**Risk Detail:** only CSS changes affecting the Relationship section when API Change is on.
**Reward:** High
**Reward Details:** Fixes a bad UI regression introduced by the content style changes. 
**Original PR:** https://github.com/apple/swift-docc-render/pull/246
**Issue:** rdar://92325863
**Code Reviewed By:** @marinaaisa @dobromir-hristov  
**Testing Details:** Navigate to a page that has API Changes turned on in the Relationships section; Verify that the content in Relationships section is displayed vertically in a column form, instead of horizontally.
