### PR TITLE
[5.7-04252022] [regression] Fix bug where long titles are now broken at arbitrary characters

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -27,7 +27,8 @@
           :swiftPath="swiftPath"
         />
         <Title :eyebrow="roleHeading">
-          {{ title }}
+          <WordBreak>{{ title }}</WordBreak>
+          <template v-if="isSymbolBeta || isSymbolDeprecated">&nbsp;</template>
           <small v-if="isSymbolDeprecated" slot="after" class="deprecated">Deprecated</small>
           <small v-else-if="isSymbolBeta" slot="after" class="beta">Beta</small>
         </Title>
@@ -95,6 +96,7 @@ import Aside from 'docc-render/components/ContentNode/Aside.vue';
 import BetaLegalText from 'theme/components/DocumentationTopic/BetaLegalText.vue';
 import LanguageSwitcher from 'theme/components/DocumentationTopic/Summary/LanguageSwitcher.vue';
 import DocumentationHero from 'docc-render/components/DocumentationTopic/DocumentationHero.vue';
+import WordBreak from 'docc-render/components/WordBreak.vue';
 import Abstract from './DocumentationTopic/Description/Abstract.vue';
 import ContentNode from './DocumentationTopic/ContentNode.vue';
 import CallToActionButton from './CallToActionButton.vue';
@@ -141,6 +143,7 @@ export default {
     SeeAlso,
     Title,
     Topics,
+    WordBreak,
   },
   props: {
     abstract: {

--- a/src/components/DocumentationTopic/Title.vue
+++ b/src/components/DocumentationTopic/Title.vue
@@ -11,19 +11,16 @@
 <template>
   <div class="topictitle">
     <span v-if="eyebrow" class="eyebrow">{{eyebrow}}</span>
-    <WordBreak class="title" tag="h1">
+    <h1 class="title">
       <slot />
       <slot name="after" />
-    </WordBreak>
+    </h1>
   </div>
 </template>
 
 <script>
-import WordBreak from 'docc-render/components/WordBreak.vue';
-
 export default {
   name: 'Title',
-  components: { WordBreak },
   props: {
     eyebrow: {
       type: String,

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -29,6 +29,7 @@ const {
   Topics,
   Title,
   BetaLegalText,
+  WordBreak,
 } = DocumentationTopic.components;
 
 const foo = {
@@ -259,10 +260,14 @@ describe('DocumentationTopic', () => {
 
   it('renders a `Title`', () => {
     const hero = wrapper.find(DocumentationHero);
+
     const title = hero.find(Title);
     expect(title.exists()).toBe(true);
     expect(title.props('eyebrow')).toBe(propsData.roleHeading);
-    expect(title.text()).toBe(propsData.title);
+
+    const wb = title.find(WordBreak);
+    expect(wb.exists()).toBe(true);
+    expect(wb.text()).toBe(propsData.title);
   });
 
   it('renders smaller "Beta" and "Deprecated" text in title when relevant', () => {
@@ -276,6 +281,7 @@ describe('DocumentationTopic', () => {
       isSymbolDeprecated: true,
       isSymbolBeta: true,
     });
+    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Deprecated/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).is('.beta')).toBe(false);
@@ -287,6 +293,7 @@ describe('DocumentationTopic', () => {
       isSymbolDeprecated: false,
       isSymbolBeta: true,
     });
+    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Beta/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).is('.beta')).toBe(true);
@@ -298,6 +305,7 @@ describe('DocumentationTopic', () => {
       isSymbolDeprecated: true,
       isSymbolBeta: false,
     });
+    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Deprecated/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).is('.beta')).toBe(false);

--- a/tests/unit/components/DocumentationTopic/Title.spec.js
+++ b/tests/unit/components/DocumentationTopic/Title.spec.js
@@ -36,11 +36,9 @@ describe('Title', () => {
     expect(eyebrow.text()).toBe('Thing');
   });
 
-  it('renders a `WordBreak` with an <h1> tag for the default slot', () => {
-    const { WordBreak } = Title.components;
-    const wb = wrapper.find(WordBreak);
-    expect(wb.classes('title')).toBe(true);
-    expect(wb.attributes('tag')).toBe('h1');
-    expect(wb.text()).toBe('FooKit');
+  it('renders <h1> tag for the default slot', () => {
+    const h1 = wrapper.find('h1');
+    expect(h1.classes('title')).toBe(true);
+    expect(h1.text()).toBe('FooKit');
   });
 });


### PR DESCRIPTION
- **Rationale:** Fixes regression where documentation page titles no longer wrap as nicely as before.
- **Risk:** Low
- **Risk Detail:** Minor shuffling of DOM elements for page title.
- **Reward:** High
- **Reward Details:** Fixes regression, improves readability of page titles.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/220
- **Issue:** rdar://92417513
- **Code Reviewed By:** @hqhhuang, @dobromir-hristov 
- **Testing Details:** Updated unit tests, visually tested that titles wrap in the manner they previously did.