### PR TITLE
[5.7] Avoid copying Deprecated and Beta tags when triple clicking to select the title

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -28,9 +28,12 @@
         />
         <Title :eyebrow="roleHeading">
           <WordBreak>{{ title }}</WordBreak>
-          <template v-if="isSymbolBeta || isSymbolDeprecated">&nbsp;</template>
-          <small v-if="isSymbolDeprecated" slot="after" class="deprecated">Deprecated</small>
-          <small v-else-if="isSymbolBeta" slot="after" class="beta">Beta</small>
+          <small
+            v-if="isSymbolDeprecated || isSymbolBeta"
+            slot="after"
+            :class="tagName"
+            :data-tag-name="tagName"
+          />
         </Title>
         <Abstract v-if="abstract" :content="abstract" />
         <div v-if="sampleCodeDownload">
@@ -330,6 +333,7 @@ export default {
       || (downloadNotAvailableSummary && downloadNotAvailableSummary.length)
       || (primaryContentSections && primaryContentSections.length)
     ),
+    tagName: ({ isSymbolDeprecated }) => (isSymbolDeprecated ? 'Deprecated' : 'Beta'),
   },
   methods: {
     normalizePath(path) {

--- a/src/components/DocumentationTopic/Title.vue
+++ b/src/components/DocumentationTopic/Title.vue
@@ -56,8 +56,13 @@ export default {
 
 small {
   @include font-styles(eyebrow);
+  padding-left: 10px;
 
-  &.beta {
+  &::before {
+    content: attr(data-tag-name);
+  }
+
+  &.Beta {
     color: var(--color-badge-beta);
 
     .theme-dark & {
@@ -65,7 +70,7 @@ small {
     }
   }
 
-  &.deprecated {
+  &.Deprecated {
     color: var(--color-badge-deprecated);
 
     .theme-dark & {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -281,36 +281,27 @@ describe('DocumentationTopic', () => {
       isSymbolDeprecated: true,
       isSymbolBeta: true,
     });
-    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Deprecated/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
-    expect(smalls.at(0).is('.beta')).toBe(false);
-    expect(smalls.at(0).is('.deprecated')).toBe(true);
-    expect(smalls.at(0).text()).toBe('Deprecated');
+    expect(smalls.at(0).attributes('data-tag-name')).toBe('Deprecated');
 
     // only beta
     wrapper.setProps({
       isSymbolDeprecated: false,
       isSymbolBeta: true,
     });
-    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Beta/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
-    expect(smalls.at(0).is('.beta')).toBe(true);
-    expect(smalls.at(0).is('.deprecated')).toBe(false);
-    expect(smalls.at(0).text()).toBe('Beta');
+    expect(smalls.at(0).attributes('data-tag-name')).toBe('Beta');
 
     // only deprecated
     wrapper.setProps({
       isSymbolDeprecated: true,
       isSymbolBeta: false,
     });
-    expect(title.text()).toEqual(expect.stringMatching(/FooKit\s+Deprecated/));
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
-    expect(smalls.at(0).is('.beta')).toBe(false);
-    expect(smalls.at(0).is('.deprecated')).toBe(true);
-    expect(smalls.at(0).text()).toBe('Deprecated');
+    expect(smalls.at(0).attributes('data-tag-name')).toBe('Deprecated');
   });
 
   it('renders an abstract', () => {


### PR DESCRIPTION
- **Rationale:** Users often triple click to select a paragraph and copy text. This PR fixes the issue where the Deprecated and Beta tags would be selected and copied as well when users attempt to select the title.
- **Risk:** Low
- **Risk Detail:** only affects selecting titles of each page
- **Reward:** High
- **Reward Details:** Improves the use case where users triple click to select the title and copy. Now they will only be able to copy the title, not the `Deprecated` and `Beta` tag.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/241
- **Issue:** rdar://92420916
- **Code Reviewed By:** @dobromir-hristov @marinaaisa 
- **Testing Details:** Navigate to a deprecated or beta page, triple click on the title and copy, paste the text and make sure only the title itself is copied.