### PR TITLE
Prevent Beta legal text getting cut off on the right when resizing window

### DIFF
--- a/src/components/DocumentationTopic/BetaLegalText.vue
+++ b/src/components/DocumentationTopic/BetaLegalText.vue
@@ -46,7 +46,7 @@ export default {
   background-color: var(--color-fill-secondary);
 
   &-container {
-    @include breakpoint-dynamic-sidebar-content;
+    @include dynamic-content-container;
   }
 
   &-label {

--- a/src/components/DocumentationTopic/BetaLegalText.vue
+++ b/src/components/DocumentationTopic/BetaLegalText.vue
@@ -46,7 +46,7 @@ export default {
   background-color: var(--color-fill-secondary);
 
   &-container {
-    @include breakpoint-content;
+    @include breakpoint-dynamic-sidebar-content;
   }
 
   &-label {


### PR DESCRIPTION
Bug/issue #, if applicable: 92669937

## Summary
Prevent Beta legal text from getting cut off on the right when resizing window

## Testing
Steps:
1. Navigate to a window with Beta legal text at the bottom of the page.
2. Verify that the text resizes correctly when going from L vp to M vp.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
