### PR TITLE
[5.7] Use the `hierarchy.path`, closest to the current page URL

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -196,8 +196,18 @@ export default {
     // The `hierarchy.paths` array will contain zero or more subarrays, each
     // representing a "path" of parent topic IDs that could be considered the
     // hierarchy/breadcrumb for a given topic. We choose to render only the
-    // first one.
-    parentTopicIdentifiers: ({ topicProps: { hierarchy: { paths: [ids = []] = [] } } }) => ids,
+    // one, that has the same path as the current URL.
+    parentTopicIdentifiers: ({ topicProps: { hierarchy: { paths = [] }, references }, $route }) => {
+      if (!paths.length) return [];
+      return paths.find((identifiers) => {
+        const rootIdentifier = identifiers.find(id => references[id] && references[id].kind !== 'technologies');
+        const rootReference = rootIdentifier && references[rootIdentifier];
+        // if there is an item, check if the current url starts with it
+        return rootReference && $route.path.toLowerCase().startsWith(
+          rootReference.url.toLowerCase(),
+        );
+      }) || paths[0];
+    },
     technology: ({
       $route,
       topicProps: {

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -357,6 +357,25 @@ describe('DocumentationTopic', () => {
     expect(wrapper.find('.topic-wrapper').classes()).toContain('static-width-container');
   });
 
+  it('finds the parentTopicIdentifiers, that have the closest url structure to the current page', () => {
+    wrapper.setData({
+      topicData: {
+        ...topicData,
+        references: {
+          ...topicData.references,
+          // add pages that match with the `mocks.$route.path`
+          'topic://baz': { url: '/documentation/somepath' },
+          'topic://baq': { url: '/documentation/somepath/page' },
+        },
+        schemaVersion: schemaVersionWithSidebar,
+      },
+    });
+    expect(wrapper.find(Navigator).props('parentTopicIdentifiers'))
+      .toEqual(topicData.hierarchy.paths[1]);
+    expect(wrapper.find(Nav).props('parentTopicIdentifiers'))
+      .toEqual(topicData.hierarchy.paths[1]);
+  });
+
   it('handles the `@close`, on Navigator', async () => {
     wrapper.setData({
       topicData: {


### PR DESCRIPTION
- **Rationale:** Ensures we show breadcrumbs that are as close to the current page as possible, in cases where one page is linked from multiple places.
- **Risk:** Medium
- **Risk Detail:** affects the breadcrumbs order in the nav
- **Reward:** High
- **Reward Details:** Users with docs linked from multiple packages will get better breadcrumbs suggestions
- **Original PR:** https://github.com/apple/swift-docc-render/pull/234
- **Issue:** rdar://92105815
- **Code Reviewed By:** @mportiz08  
- **Testing Details:** Breadcrumbs should show up as normal for plain doccarchives, and should show the technology closest to the URL you are on.