### PR TITLE
[5.7] Persist navigator data across technologies

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -63,7 +63,7 @@
               @toggle="toggle"
               @toggle-full="toggleFullTree"
               @toggle-siblings="toggleSiblings"
-              @navigate="setActiveUID"
+              @navigate="handleNavigationChange"
               @focus-parent="focusNodeParent"
             />
           </RecycleScroller>
@@ -114,15 +114,7 @@ import keyboardNavigation from 'docc-render/mixins/keyboardNavigation';
 import { isEqual, last } from 'docc-render/utils/arrays';
 import { ChangeNames, ChangeNameToType } from 'docc-render/constants/Changes';
 
-const STORAGE_KEYS = {
-  filter: 'navigator.filter',
-  technology: 'navigator.technology',
-  openNodes: 'navigator.openNodes',
-  nodesToRender: 'navigator.nodesToRender',
-  selectedTags: 'navigator.selectedTags',
-  apiChanges: 'navigator.apiChanges',
-  activeUID: 'navigator.activeUID',
-};
+const STORAGE_KEY = 'navigator.state';
 
 const NO_RESULTS = 'No results found.';
 const NO_CHILDREN = 'No data available.';
@@ -166,7 +158,7 @@ const TOPIC_TYPE_TO_TAG = {
 export default {
   name: 'NavigatorCard',
   constants: {
-    STORAGE_KEYS,
+    STORAGE_KEY,
     FILTER_TAGS,
     FILTER_TAGS_TO_LABELS,
     FILTER_LABELS_TO_TAGS,
@@ -418,6 +410,7 @@ export default {
     isLargeBreakpoint: ({ breakpoint }) => breakpoint === BreakpointName.large,
     hasNodes: ({ nodesToRender }) => !!nodesToRender.length,
     totalItemsToNavigate: ({ nodesToRender }) => nodesToRender.length,
+    lastActivePathItem: ({ activePath }) => last(activePath),
   },
   created() {
     this.restorePersistedState();
@@ -425,12 +418,6 @@ export default {
   watch: {
     filter: 'debounceInput',
     nodeChangeDeps: 'trackOpenNodes',
-    debouncedFilter(value) {
-      sessionStorage.set(STORAGE_KEYS.filter, value);
-    },
-    selectedTags(value) {
-      sessionStorage.set(STORAGE_KEYS.selectedTags, value);
-    },
     activePath: 'handleActivePathChange',
     apiChanges(value) {
       if (value) return;
@@ -466,11 +453,11 @@ export default {
     ) {
       // skip in case this is a first mount and we are syncing the `filter` and `selectedTags`.
       if (
-        (filter !== filterBefore && !filterBefore && sessionStorage.get(STORAGE_KEYS.filter))
+        (filter !== filterBefore && !filterBefore && this.getFromStorage('filter'))
         || (
           !isEqual(selectedTags, selectedTagsBefore)
           && !selectedTagsBefore.length
-          && sessionStorage.get(STORAGE_KEYS.selectedTags, []).length
+          && this.getFromStorage('selectedTags', []).length
         )
       ) {
         return;
@@ -695,35 +682,78 @@ export default {
       this.persistState();
     },
     /**
+     * Get items from PersistedStorage, for the current technology.
+     * Can fetch a specific `key` or the entire state.
+     * @param {string} [key] - key to fetch
+     * @param {*} [fallback] - fallback property, if `key is not found`
+     * @return *
+     */
+    getFromStorage(key, fallback = null) {
+      const state = sessionStorage.get(STORAGE_KEY, {});
+      const technologyState = state[this.technologyPath];
+      if (!technologyState) return fallback;
+      if (key) {
+        return technologyState[key] || fallback;
+      }
+      return technologyState;
+    },
+    /**
      * Persists the current state, so its not lost if you refresh or navigate away
      */
     persistState() {
-      sessionStorage.set(STORAGE_KEYS.technology, this.technology);
-      sessionStorage.set(STORAGE_KEYS.apiChanges, !!this.apiChanges);
-      // store the keys of the openNodes map, converting to number, to reduce space
-      sessionStorage.set(STORAGE_KEYS.openNodes, Object.keys(this.openNodes).map(Number));
-      // we need only the UIDs
-      sessionStorage.set(STORAGE_KEYS.nodesToRender, this.nodesToRender.map(({ uid }) => uid));
+      // fallback to using the activePath items
+      const fallback = { path: this.lastActivePathItem };
+      // try to get the `path` for the current activeUID
+      const { path } = this.activeUID
+        ? (this.childrenMap[this.activeUID] || fallback)
+        : fallback;
+      const technologyState = {
+        technology: this.technology,
+        // find the path buy the activeUID, because the lastActivePath wont be updated at this point
+        path,
+        hasApiChanges: !!this.apiChanges,
+        // store the keys of the openNodes map, converting to number, to reduce space
+        openNodes: Object.keys(this.openNodes).map(Number),
+        // we need only the UIDs
+        nodesToRender: this.nodesToRender.map(({ uid }) => uid),
+        activeUID: this.activeUID,
+        filter: this.filter,
+        selectedTags: this.selectedTags,
+      };
+      const state = {
+        ...sessionStorage.get(STORAGE_KEY, {}),
+        [this.technologyPath]: technologyState,
+      };
+      sessionStorage.set(STORAGE_KEY, state);
     },
     clearPersistedState() {
-      sessionStorage.set(STORAGE_KEYS.technology, '');
-      sessionStorage.set(STORAGE_KEYS.apiChanges, false);
-      sessionStorage.set(STORAGE_KEYS.openNodes, []);
-      sessionStorage.set(STORAGE_KEYS.nodesToRender, []);
-      sessionStorage.set(STORAGE_KEYS.activeUID, null);
-      sessionStorage.set(STORAGE_KEYS.filter, '');
-      sessionStorage.set(STORAGE_KEYS.selectedTags, []);
+      const state = {
+        ...sessionStorage.get(STORAGE_KEY, {}),
+        [this.technologyPath]: {},
+      };
+      sessionStorage.set(STORAGE_KEY, state);
     },
     /**
      * Restores the persisted state from sessionStorage. Called on `create` hook.
      */
     restorePersistedState() {
-      const technology = sessionStorage.get(STORAGE_KEYS.technology);
-      const nodesToRender = sessionStorage.get(STORAGE_KEYS.nodesToRender, []);
-      const filter = sessionStorage.get(STORAGE_KEYS.filter, '');
-      const hasAPIChanges = sessionStorage.get(STORAGE_KEYS.apiChanges);
-      const activeUID = sessionStorage.get(STORAGE_KEYS.activeUID, null);
-      const selectedTags = sessionStorage.get(STORAGE_KEYS.selectedTags, []);
+      // get the entire state for the technology
+      const persistedState = this.getFromStorage();
+      // if there is no state or it's last path is not the same, clear the storage
+      if (!persistedState || persistedState.path !== this.lastActivePathItem) {
+        this.clearPersistedState();
+        this.handleActivePathChange(this.activePath);
+        return;
+      }
+      const {
+        technology,
+        nodesToRender = [],
+        filter = '',
+        hasAPIChanges = false,
+        activeUID = null,
+        selectedTags = [],
+        openNodes,
+      } = persistedState;
       // if for some reason there are no nodes and no filter, we can assume its bad cache
       if (!nodesToRender.length && !filter && !selectedTags.length) {
         // clear the sessionStorage before continuing
@@ -733,15 +763,10 @@ export default {
       }
       // make sure all nodes exist in the childrenMap
       const allNodesMatch = nodesToRender.every(uid => this.childrenMap[uid]);
-      let activeUIDMatchesCurrentPath = true;
       // check if activeUID node matches the current page path
-      if (activeUID && this.activePath.length) {
-        activeUIDMatchesCurrentPath = (this.childrenMap[activeUID] || {}).path
-          === last(this.activePath);
-        // set ot `false`, if there is no `activeUID`, but there are `activePath` items
-      } else if (!activeUID && this.activePath.length) {
-        activeUIDMatchesCurrentPath = false;
-      }
+      const activeUIDMatchesCurrentPath = activeUID
+        ? ((this.childrenMap[activeUID] || {}).path === this.lastActivePathItem)
+        : this.activePath.length === 1;
       // take a second pass at validating data
       if (
         // if the technology is different
@@ -759,8 +784,6 @@ export default {
         this.handleActivePathChange(this.activePath);
         return;
       }
-      // get all open nodes
-      const openNodes = sessionStorage.get(STORAGE_KEYS.openNodes, []);
       // create the openNodes map
       this.openNodes = Object.fromEntries(openNodes.map(n => [n, true]));
       // get all the nodes to render
@@ -870,7 +893,16 @@ export default {
     setActiveUID(uid) {
       this.activeUID = uid;
       this.resetScroll = false;
-      sessionStorage.set(STORAGE_KEYS.activeUID, uid);
+    },
+    /**
+     * Handles the `navigate` event from NavigatorCardItem, guarding from selecting an item,
+     * that points to another technology.
+     */
+    handleNavigationChange(uid) {
+      // if the path is outside of this technology tree, dont store the uid
+      if (this.childrenMap[uid].path.startsWith(this.technologyPath)) {
+        this.setActiveUID(uid);
+      }
     },
     /**
      * Returns an array of {NavigatorFlatItem}, from a breadcrumbs list

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -30,7 +30,7 @@ jest.mock('docc-render/utils/loading');
 sessionStorage.get.mockImplementation((key, def) => def);
 
 const {
-  STORAGE_KEYS,
+  STORAGE_KEY,
   FILTER_TAGS,
   FILTER_TAGS_TO_LABELS,
   NO_CHILDREN,
@@ -47,8 +47,8 @@ const RecycleScrollerStub = {
   },
 };
 const root0 = {
-  type: 'overview',
-  path: '/tutorials/fookit',
+  type: TopicTypes.collection,
+  path: '/documentation/testkit',
   title: 'TopLevel',
   uid: 1,
   parent: INDEX_ROOT_KEY,
@@ -61,8 +61,8 @@ const root0 = {
 };
 
 const root0Child0 = {
-  type: 'tutorial',
-  path: '/tutorials/fookit/first-child-depth-1',
+  type: TopicTypes.struct,
+  path: '/documentation/testkit/first-child-depth-1',
   title: 'First Child, Depth 1',
   uid: 2,
   parent: root0.uid,
@@ -72,8 +72,8 @@ const root0Child0 = {
 };
 
 const root0Child1 = {
-  type: 'tutorial',
-  path: '/tutorials/fookit/second-child-depth-1',
+  type: TopicTypes.func,
+  path: '/documentation/testkit/second-child-depth-1',
   title: 'Second Child, Depth 1',
   uid: 3,
   parent: root0.uid,
@@ -85,8 +85,8 @@ const root0Child1 = {
 };
 
 const root0Child1GrandChild0 = {
-  type: 'tutorial',
-  path: '/tutorials/fookit/second-child-depth-1/first-child-depth-2',
+  type: TopicTypes.article,
+  path: '/documentation/testkit/second-child-depth-1/first-child-depth-2',
   title: 'First Child, Depth 2',
   uid: 4,
   parent: root0Child1.uid,
@@ -100,8 +100,8 @@ const root1 = {
     text: 'Create a tutorial.',
     type: 'text',
   }],
-  type: 'article',
-  path: '/documentation/fookit/gettingstarted',
+  type: TopicTypes.project,
+  path: '/tutorials/testkit/gettingstarted',
   title: 'Getting Started',
   uid: 5,
   parent: INDEX_ROOT_KEY,
@@ -122,7 +122,7 @@ const activePath = [root0.path, root0Child0.path];
 
 const defaultProps = {
   technology: 'TestKit',
-  technologyPath: '/path/to/technology',
+  technologyPath: '/documentation/testkit',
   children,
   activePath,
   type: TopicTypes.module,
@@ -145,6 +145,28 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(NavigatorC
 
 const clearPersistedStateSpy = jest.spyOn(NavigatorCard.methods, 'clearPersistedState');
 let getChildPositionInScroller;
+
+const DEFAULT_STORED_STATE = {
+  [defaultProps.technologyPath]: {
+    technology: defaultProps.technology,
+    openNodes: [root0.uid, root0Child0.uid],
+    nodesToRender: [root0.uid, root0Child0.uid, root0Child1.uid, root1.uid],
+    hasApiChanges: false,
+    activeUID: root0Child0.uid,
+    filter: '',
+    selectedTags: [],
+    path: activePath[1],
+  },
+};
+
+function mergeSessionState(state) {
+  return {
+    [defaultProps.technologyPath]: {
+      ...DEFAULT_STORED_STATE[defaultProps.technologyPath],
+      ...state,
+    },
+  };
+}
 
 describe('NavigatorCard', () => {
   beforeEach(() => {
@@ -205,8 +227,8 @@ describe('NavigatorCard', () => {
       shouldTruncateTags: false,
       tags: [
         // Sample Code is missing, because no sample code in test data
-        'Tutorials',
         'Articles',
+        'Tutorials',
       ],
       value: '',
       clearFilterOnTagSelect: false,
@@ -991,8 +1013,10 @@ describe('NavigatorCard', () => {
     expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenLastCalledWith(0);
     // assert only the parens of the match are visible
     const all = wrapper.findAll(NavigatorCardItem);
-    expect(all).toHaveLength(1);
-    expect(all.at(0).props('item')).toEqual(root1);
+    expect(all).toHaveLength(3);
+    expect(all.at(0).props('item')).toEqual(root0);
+    expect(all.at(1).props('item')).toEqual(root0Child1);
+    expect(all.at(2).props('item')).toEqual(root0Child1GrandChild0);
     // assert we reset the scroll to the top
   });
 
@@ -1006,35 +1030,32 @@ describe('NavigatorCard', () => {
     expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledWith(0);
     // assert only the parens of the match are visible
     const all = wrapper.findAll(NavigatorCardItem);
-    expect(all).toHaveLength(4);
-    expect(all.at(0).props('item')).toEqual(root0);
-    expect(all.at(1).props('item')).toEqual(root0Child0);
-    expect(all.at(2).props('item')).toEqual(root0Child1);
-    expect(all.at(3).props('item')).toEqual(root0Child1GrandChild0);
+    expect(all).toHaveLength(1);
+    expect(all.at(0).props('item')).toEqual(root1);
   });
 
   it('allows filtering the items with filter and Tags, opening all items, that have matches in children', async () => {
     const wrapper = createWrapper();
     const filter = wrapper.find(FilterInput);
     await flushPromises();
-    filter.vm.$emit('update:selectedTags', [FILTER_TAGS_TO_LABELS.tutorials]);
+    filter.vm.$emit('update:selectedTags', [FILTER_TAGS_TO_LABELS.articles]);
     await flushPromises();
     expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(1);
     expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledWith(0);
     // assert only the parens of the match are visible
     let all = wrapper.findAll(NavigatorCardItem);
-    expect(all).toHaveLength(4);
+    expect(all).toHaveLength(3);
     expect(all.at(0).props('item')).toEqual(root0);
-    expect(all.at(1).props('item')).toEqual(root0Child0);
-    expect(all.at(2).props('item')).toEqual(root0Child1);
-    expect(all.at(3).props('item')).toEqual(root0Child1GrandChild0);
-    // add filtering in top
-    filter.vm.$emit('input', root0Child0.title);
+    expect(all.at(1).props('item')).toEqual(root0Child1);
+    expect(all.at(2).props('item')).toEqual(root0Child1GrandChild0);
+    // add filtering on top
+    filter.vm.$emit('input', root0Child1GrandChild0.title);
     await flushPromises();
     all = wrapper.findAll(NavigatorCardItem);
-    expect(all).toHaveLength(2);
+    expect(all).toHaveLength(3);
     expect(all.at(0).props('item')).toEqual(root0);
-    expect(all.at(1).props('item')).toEqual(root0Child0);
+    expect(all.at(1).props('item')).toEqual(root0Child1);
+    expect(all.at(2).props('item')).toEqual(root0Child1GrandChild0);
   });
 
   it('allows opening an item, that has a filter match', async () => {
@@ -1201,57 +1222,37 @@ describe('NavigatorCard', () => {
     expect(wrapper.emitted('close')).toHaveLength(1);
   });
 
-  it('persists the filtered state', async () => {
+  it('persists the filtered state, per technology path', async () => {
     const wrapper = createWrapper();
     await flushPromises();
     // called to reset the state initially, then called to store the changed state
-    expect(sessionStorage.set).toHaveBeenCalledTimes(7 + 5);
+    expect(sessionStorage.set).toHaveBeenCalledTimes(2);
     expect(clearPersistedStateSpy).toHaveBeenCalledTimes(1);
     expect(sessionStorage.set)
-      .toHaveBeenCalledWith(STORAGE_KEYS.technology, defaultProps.technology);
-    expect(sessionStorage.set)
-      .toHaveBeenCalledWith(STORAGE_KEYS.openNodes, [root0.uid, root0Child0.uid]);
-    expect(sessionStorage.set)
-      .toHaveBeenCalledWith(STORAGE_KEYS.nodesToRender, [
-        root0.uid, root0Child0.uid, root0Child1.uid, root1.uid,
-      ]);
-    expect(sessionStorage.set)
-      .toHaveBeenCalledWith(STORAGE_KEYS.apiChanges, false);
-    expect(sessionStorage.set)
-      .toHaveBeenCalledWith(STORAGE_KEYS.activeUID, root0Child0.uid);
+      .toHaveBeenCalledWith(STORAGE_KEY, DEFAULT_STORED_STATE);
     await flushPromises();
-    sessionStorage.set.mockClear();
     wrapper.find(FilterInput).vm.$emit('input', root0Child1GrandChild0.title);
-    wrapper.find(FilterInput).vm.$emit('update:selectedTags', [FILTER_TAGS_TO_LABELS.tutorials]);
+    wrapper.find(FilterInput).vm.$emit('update:selectedTags', [FILTER_TAGS_TO_LABELS.articles]);
     await flushPromises();
-    expect(sessionStorage.set).toHaveBeenCalledTimes(6);
+    expect(sessionStorage.set).toHaveBeenCalledTimes(3);
     expect(sessionStorage.set)
-      .toHaveBeenCalledWith(STORAGE_KEYS.filter, root0Child1GrandChild0.title);
-    expect(sessionStorage.set)
-      .toHaveBeenCalledWith(STORAGE_KEYS.selectedTags, [FILTER_TAGS.tutorials]);
-    expect(sessionStorage.set)
-      .toHaveBeenCalledWith(STORAGE_KEYS.openNodes, [root0.uid, root0Child1.uid]);
-    expect(sessionStorage.set)
-      .toHaveBeenCalledWith(STORAGE_KEYS.nodesToRender, [
-        root0.uid, root0Child1.uid, root0Child1GrandChild0.uid,
-      ]);
-    expect(sessionStorage.set)
-      .toHaveBeenCalledWith(STORAGE_KEYS.apiChanges, false);
-    expect(sessionStorage.set)
-      .toHaveBeenCalledWith(STORAGE_KEYS.technology, defaultProps.technology);
+      .toHaveBeenCalledWith(STORAGE_KEY, mergeSessionState({
+        selectedTags: [FILTER_TAGS.articles],
+        openNodes: [root0.uid, root0Child1.uid],
+        nodesToRender: [root0.uid, root0Child1.uid, root0Child1GrandChild0.uid],
+        filter: root0Child1GrandChild0.title,
+      }));
   });
 
   it('restores the persisted state, from sessionStorage', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.filter) return root0.title;
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
-      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid];
-      if (key === STORAGE_KEYS.openNodes) return [root0.uid];
-      if (key === STORAGE_KEYS.selectedTags) return [FILTER_TAGS.tutorials];
-      if (key === STORAGE_KEYS.apiChanges) return false;
-      if (key === STORAGE_KEYS.activeUID) return root0.uid;
-      return '';
-    });
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      filter: root0.title,
+      nodesToRender: [root0.uid],
+      openNodes: [root0.uid],
+      selectedTags: [FILTER_TAGS.tutorials],
+      activeUID: root0.uid,
+      path: activePath[0],
+    }));
 
     const wrapper = createWrapper({
       propsData: {
@@ -1267,12 +1268,23 @@ describe('NavigatorCard', () => {
     expect(clearPersistedStateSpy).toHaveBeenCalledTimes(0);
   });
 
+  it('does not restore state, if path is different', async () => {
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      path: '/documentation/other/path',
+      nodesToRender: [root0.uid],
+    }));
+    const wrapper = createWrapper();
+    await flushPromises();
+    // assert we are render more than just the single item in the store
+    expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(4);
+    expect(clearPersistedStateSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('does not restore the state, if the technology is different', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.technology) return 'some-other';
-      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid];
-      return '';
-    });
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      technology: 'some-other',
+      nodesToRender: [root0.uid],
+    }));
     const wrapper = createWrapper();
     await flushPromises();
     // assert we are render more than just the single item in the store
@@ -1281,17 +1293,9 @@ describe('NavigatorCard', () => {
   });
 
   it('does not restore the state, if the activeUID is not in the rendered items', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.filter) return '';
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
-      // simulate we have collapses all, but the top item
-      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid, root0Child0.uid, root0Child1.uid];
-      if (key === STORAGE_KEYS.openNodes) return [root0.uid, root0Child1.uid];
-      if (key === STORAGE_KEYS.selectedTags) return [];
-      if (key === STORAGE_KEYS.apiChanges) return true;
-      if (key === STORAGE_KEYS.activeUID) return root0Child1GrandChild0.uid;
-      return '';
-    });
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      activeUID: root0Child1GrandChild0.uid,
+    }));
     const wrapper = createWrapper();
     await flushPromises();
     // assert we are render more than just the single item in the store
@@ -1302,16 +1306,10 @@ describe('NavigatorCard', () => {
   });
 
   it('does not restore the state, if the activeUID path does not match the current last path', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.filter) return root0.title;
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
-      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid];
-      if (key === STORAGE_KEYS.openNodes) return [root0.uid];
-      if (key === STORAGE_KEYS.selectedTags) return [FILTER_TAGS.tutorials];
-      if (key === STORAGE_KEYS.apiChanges) return false;
-      if (key === STORAGE_KEYS.activeUID) return root0.uid;
-      return '';
-    });
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      activeUID: root0.uid,
+      nodesToRender: [root0.uid],
+    }));
 
     const wrapper = createWrapper({
       propsData: {
@@ -1327,16 +1325,13 @@ describe('NavigatorCard', () => {
   });
 
   it('restores the state, if the activeUID is not in the rendered items, but there is a filter', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.filter) return root0Child1.title;
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
-      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid, root0Child0.uid, root0Child1.uid];
-      if (key === STORAGE_KEYS.openNodes) return [root0.uid, root0Child1.uid];
-      if (key === STORAGE_KEYS.selectedTags) return [];
-      if (key === STORAGE_KEYS.apiChanges) return false;
-      if (key === STORAGE_KEYS.activeUID) return root0Child1GrandChild0.uid;
-      return '';
-    });
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      filter: root0Child1.title,
+      nodesToRender: [root0.uid, root0Child0.uid, root0Child1.uid],
+      openNodes: [root0.uid, root0Child1.uid],
+      activeUID: root0Child1GrandChild0.uid,
+      path: root0Child1GrandChild0.path,
+    }));
     const wrapper = createWrapper({
       propsData: {
         activePath: [root0.path, root0Child1.path, root0Child1GrandChild0.path],
@@ -1351,11 +1346,9 @@ describe('NavigatorCard', () => {
   });
 
   it('does not restore the state, if the nodesToRender do not match what we have', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
-      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid, 'something-different'];
-      return '';
-    });
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      nodesToRender: [root0.uid, 'something-different'],
+    }));
     const wrapper = createWrapper();
     await flushPromises();
     // assert we are render more than just the single item in the store
@@ -1363,12 +1356,10 @@ describe('NavigatorCard', () => {
   });
 
   it('does not restore the state, if the nodesToRender and filter are empty', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
-      if (key === STORAGE_KEYS.nodesToRender) return [];
-      if (key === STORAGE_KEYS.filter) return '';
-      return '';
-    });
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      nodesToRender: [],
+      filter: '',
+    }));
     const wrapper = createWrapper();
     await flushPromises();
     // assert we are render more than just the single item in the store
@@ -1377,16 +1368,12 @@ describe('NavigatorCard', () => {
   });
 
   it('restores the state, if the nodesToRender and filter are empty, but there are selectedTags', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
-      if (key === STORAGE_KEYS.nodesToRender) return [];
-      if (key === STORAGE_KEYS.selectedTags) return [FILTER_TAGS.tutorials];
-      if (key === STORAGE_KEYS.filter) return '';
-      if (key === STORAGE_KEYS.openNodes) return [];
-      if (key === STORAGE_KEYS.apiChanges) return false;
-      if (key === STORAGE_KEYS.activeUID) return root0Child0.uid;
-      return '';
-    });
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      nodesToRender: [],
+      selectedTags: [FILTER_TAGS.tutorials],
+      openNodes: [],
+      activeUID: root0Child0.uid,
+    }));
     const wrapper = createWrapper();
     await flushPromises();
     // assert we are render more than just the single item in the store
@@ -1395,49 +1382,39 @@ describe('NavigatorCard', () => {
   });
 
   it('does not restore the state, if the API changes mismatch', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.filter) return '';
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
-      // simulate we have collapses all, but the top item
-      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid];
-      if (key === STORAGE_KEYS.openNodes) return [root0.uid];
-      if (key === STORAGE_KEYS.selectedTags) return [];
-      if (key === STORAGE_KEYS.apiChanges) return true;
-      return '';
-    });
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      // simulate we have collapsed all, but the top item
+      nodesToRender: [root0.uid],
+      openNodes: [root0.uid],
+      apiChanges: true,
+    }));
     const wrapper = createWrapper();
     await flushPromises();
     expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(4);
   });
 
   it('does not restore the state, if `activeUID` is null, but there are activePath items', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.filter) return '';
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
       // simulate we have collapses all, but the top item
-      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid];
-      if (key === STORAGE_KEYS.openNodes) return [root0.uid];
-      if (key === STORAGE_KEYS.selectedTags) return [];
-      if (key === STORAGE_KEYS.apiChanges) return false;
-      if (key === STORAGE_KEYS.activeUID) return null;
-      return '';
-    });
+      nodesToRender: [root0.uid],
+      openNodes: [root0.uid],
+      selectedTags: [],
+      apiChanges: false,
+      activeUID: null,
+    }));
     const wrapper = createWrapper();
     await flushPromises();
     expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(4);
   });
 
   it('keeps the open state, if there are API changes', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.filter) return '';
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
       // simulate we have collapses all, but the top item
-      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid, root0Child0.uid, root0Child1.uid];
-      if (key === STORAGE_KEYS.openNodes) return [root0.uid];
-      if (key === STORAGE_KEYS.selectedTags) return [];
-      if (key === STORAGE_KEYS.apiChanges) return true;
-      return '';
-    });
+      nodesToRender: [root0.uid, root0Child0.uid, root0Child1.uid],
+      openNodes: [root0.uid],
+      selectedTags: [],
+      apiChanges: true,
+    }));
     const wrapper = createWrapper({
       propsData: {
         apiChanges: {
@@ -1451,17 +1428,14 @@ describe('NavigatorCard', () => {
   });
 
   it('keeps the open state, even if there is a title filter', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.filter) return root0Child1GrandChild0.title;
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      filter: root0Child1GrandChild0.title,
       // simulate we have collapses all, but the top item
-      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid, root0Child1.uid];
-      if (key === STORAGE_KEYS.openNodes) return [root0.uid];
-      if (key === STORAGE_KEYS.selectedTags) return [];
-      if (key === STORAGE_KEYS.apiChanges) return false;
-      if (key === STORAGE_KEYS.activeUID) return root0.uid;
-      return '';
-    });
+      nodesToRender: [root0.uid, root0Child1.uid],
+      openNodes: [root0.uid],
+      activeUID: root0.uid,
+      path: root0.path,
+    }));
     const wrapper = createWrapper({
       propsData: {
         activePath: [root0.path],
@@ -1474,17 +1448,13 @@ describe('NavigatorCard', () => {
   });
 
   it('keeps the open state, even if there is a Tag filter applied', async () => {
-    sessionStorage.get.mockImplementation((key) => {
-      if (key === STORAGE_KEYS.filter) return '';
-      if (key === STORAGE_KEYS.technology) return defaultProps.technology;
-      // simulate we have collapses all, but the top item
-      if (key === STORAGE_KEYS.nodesToRender) return [root0.uid, root0Child1.uid];
-      if (key === STORAGE_KEYS.openNodes) return [root0.uid];
-      if (key === STORAGE_KEYS.selectedTags) return [FILTER_TAGS.tutorials];
-      if (key === STORAGE_KEYS.apiChanges) return false;
-      if (key === STORAGE_KEYS.activeUID) return root0.uid;
-      return '';
-    });
+    sessionStorage.get.mockImplementation(() => mergeSessionState({
+      nodesToRender: [root0.uid, root0Child1.uid],
+      openNodes: [root0.uid],
+      selectedTags: [FILTER_TAGS.tutorials],
+      activeUID: root0.uid,
+      path: root0.path,
+    }));
     const wrapper = createWrapper({
       propsData: {
         activePath: [root0.path],
@@ -1513,7 +1483,7 @@ describe('NavigatorCard', () => {
       type: 'sampleCode',
       path: '/documentation/fookit/sample-code',
       title: 'Sample Code',
-      uid: 5,
+      uid: 6,
       parent: INDEX_ROOT_KEY,
       depth: 0,
       index: 1,
@@ -1525,7 +1495,7 @@ describe('NavigatorCard', () => {
     };
     const wrapper = createWrapper({
       propsData: {
-        children: [root0, root0Child0, sampleCode],
+        children: [root0, root0Child0, root1, sampleCode],
         activePath: [root0.path],
       },
     });
@@ -1642,7 +1612,14 @@ describe('NavigatorCard', () => {
       targetChild.vm.$emit('navigate', root0Child1.uid);
       await wrapper.vm.$nextTick();
       expect(sessionStorage.set)
-        .toHaveBeenCalledWith(STORAGE_KEYS.activeUID, root0Child1.uid);
+        .toHaveBeenLastCalledWith(STORAGE_KEY, mergeSessionState({
+          activeUID: root0Child1.uid,
+          openNodes: [root0.uid, root0Child0.uid, root0Child1.uid],
+          nodesToRender: [
+            root0.uid, root0Child0.uid, root0Child1.uid, root0Child1GrandChild0.uid, root1.uid,
+          ],
+          path: root0Child1.path,
+        }));
       // assert all items are still there, even the new one is open
       expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(5);
       // assert the target child is active
@@ -1817,6 +1794,19 @@ describe('NavigatorCard', () => {
       expect(all).toHaveLength(3);
       expect(all.at(0).props('item')).toEqual(root0Dupe);
       expect(all.at(1).props('item')).toEqual(root0Child0Dupe);
+    });
+
+    it('does not store the activeUID of clicked items, with different path than the `technologyPath`', async () => {
+      const wrapper = createWrapper();
+      await flushPromises();
+      const allItems = wrapper.findAll(NavigatorCardItem);
+      const target = allItems.at(3);
+      expect(target.props('item')).toEqual(root1);
+      // trigger a navigation
+      target.vm.$emit('navigate', root1.uid);
+      expect(sessionStorage.set).toHaveBeenCalledTimes(2);
+      await wrapper.vm.$nextTick();
+      expect(sessionStorage.set).toHaveBeenCalledTimes(2);
     });
   });
 


### PR DESCRIPTION
- **Rationale:** If there is an item in the navigator, that links to another technology/documentation, going back should still re-apply the old filters.
- **Risk:** Medium
- **Risk Detail:** affects the way we persist navigator data across website/technology navigation/refreshes
- **Reward:** High
- **Reward Details:** Users will no longer get the navigator state reset, when they move across technologies
- **Original PR:** https://github.com/apple/swift-docc-render/pull/235
- **Issue:** rdar://91188362
- **Code Reviewed By:** @marinaaisa
- **Testing Details:** 

1. Assert there are no regressions when working with normal doccarchives.
2. When moving across technologies, you should not lose navigator state, when going back (open items, search input etc)
