### PR TITLE
[5.7-04252022] Add ability to hide deprecated items in the Navigator

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -158,6 +158,8 @@ const TOPIC_TYPE_TO_TAG = {
   [TopicTypes.project]: FILTER_TAGS.tutorials,
 };
 
+const HIDE_DEPRECATED_TAG = 'Hide Deprecated';
+
 /**
  * Renders the card for a technology and it's child symbols, in the navigator.
  * For performance reasons, the component uses watchers over computed, so we can more precisely
@@ -175,6 +177,7 @@ export default {
     NO_CHILDREN,
     ERROR_FETCHING,
     ITEMS_FOUND,
+    HIDE_DEPRECATED_TAG,
   },
   components: {
     FilterInput,
@@ -268,41 +271,51 @@ export default {
       const apiChangesTypesSet = new Set(Object.values(apiChangesObject));
 
       const tagLabelsSet = new Set(tagLabels);
-
-      const availableTags = [];
+      const generalTags = new Set([HIDE_DEPRECATED_TAG]);
+      const availableTags = {
+        type: [],
+        changes: [],
+        other: [],
+      };
       const children = Object.values(renderableChildNodesMap);
       const len = children.length;
       let i;
       // iterate over the nodes to render
       for (i = 0; i < len; i += 1) {
         // if there are no more tags to iterate over, end early
-        if (!tagLabelsSet.size && !apiChangesTypesSet.size) return availableTags;
+        if (!tagLabelsSet.size && !apiChangesTypesSet.size && !generalTags.size) {
+          break;
+        }
         // extract the type
-        const { type, path } = children[i];
+        const { type, path, deprecated } = children[i];
         // grab the tagLabel
         const tagLabel = FILTER_TAGS_TO_LABELS[TOPIC_TYPE_TO_TAG[type]];
         const changeType = apiChangesObject[path];
         // try to match a tag
         if (tagLabelsSet.has(tagLabel)) {
           // if we have a match, store it
-          availableTags.push(tagLabel);
+          availableTags.type.push(tagLabel);
           // remove the match, so we can end the filter early
           tagLabelsSet.delete(tagLabel);
         }
         if (changeType && apiChangesTypesSet.has(changeType)) {
-          availableTags.push(ChangeNames[changeType]);
+          availableTags.changes.push(ChangeNames[changeType]);
           apiChangesTypesSet.delete(changeType);
         }
+        if (deprecated && generalTags.has(HIDE_DEPRECATED_TAG)) {
+          availableTags.other.push(HIDE_DEPRECATED_TAG);
+          generalTags.delete(HIDE_DEPRECATED_TAG);
+        }
       }
-      return availableTags;
+      return availableTags.type.concat(availableTags.changes, availableTags.other);
     },
     selectedTagsModelValue: {
       get: ({ selectedTags }) => selectedTags.map(tag => (
-        FILTER_TAGS_TO_LABELS[tag] || ChangeNames[tag]
+        FILTER_TAGS_TO_LABELS[tag] || ChangeNames[tag] || tag
       )),
       set(values) {
         this.selectedTags = values.map(label => (
-          FILTER_LABELS_TO_TAGS[label] || ChangeNameToType[label]
+          FILTER_LABELS_TO_TAGS[label] || ChangeNameToType[label] || label
         ));
         this.resetScroll = true;
       },
@@ -349,7 +362,9 @@ export default {
       if (!hasFilter) return [];
       const tagsSet = new Set(selectedTags);
       // find children that match current filters
-      return children.filter(({ title, path, type }) => {
+      return children.filter(({
+        title, path, type, deprecated,
+      }) => {
         // check if `title` matches the pattern, if provided
         const titleMatch = filterPattern ? filterPattern.test(title) : true;
         // check if `type` matches any of the selected tags
@@ -359,6 +374,9 @@ export default {
           // if there are API changes and there is no tag match, try to match change types
           if (apiChanges && !tagMatch) {
             tagMatch = tagsSet.has(apiChangesObject[path]);
+          }
+          if (!deprecated && tagsSet.has(HIDE_DEPRECATED_TAG)) {
+            tagMatch = true;
           }
         }
         // find items, that have API changes

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1555,7 +1555,7 @@ describe('NavigatorCard', () => {
     await flushPromises();
     const filter = wrapper.find(FilterInput);
     // assert there are no Articles for example
-    expect(filter.props('tags')).toEqual(['Articles', 'Tutorials', HIDE_DEPRECATED_TAG]);
+    expect(filter.props('tags')).toEqual(['Tutorials', 'Articles', HIDE_DEPRECATED_TAG]);
     // apply a filter
     filter.vm.$emit('update:selectedTags', [HIDE_DEPRECATED_TAG]);
     await flushPromises();

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -37,6 +37,7 @@ const {
   NO_RESULTS,
   ERROR_FETCHING,
   ITEMS_FOUND,
+  HIDE_DEPRECATED_TAG,
 } = NavigatorCard.constants;
 
 const RecycleScrollerStub = {
@@ -1538,6 +1539,35 @@ describe('NavigatorCard', () => {
     wrapper.setProps({ apiChanges });
     await flushPromises();
     expect(filter.props('tags')).toEqual(['Sample Code', ChangeNames.modified]);
+  });
+
+  it('shows "Hide Deprecated" tag, if there are deprecated items', async () => {
+    const updatedChild = {
+      ...root0Child0,
+      deprecated: true,
+    };
+    const wrapper = createWrapper({
+      propsData: {
+        children: [root0, updatedChild, root0Child1, root0Child1GrandChild0, root1],
+        activePath: [root0.path],
+      },
+    });
+    await flushPromises();
+    const filter = wrapper.find(FilterInput);
+    // assert there are no Articles for example
+    expect(filter.props('tags')).toEqual(['Articles', 'Tutorials', HIDE_DEPRECATED_TAG]);
+    // apply a filter
+    filter.vm.$emit('update:selectedTags', [HIDE_DEPRECATED_TAG]);
+    await flushPromises();
+    // assert no other tags are shown now
+    expect(filter.props('tags')).toEqual([]);
+    const allItems = wrapper.findAll(NavigatorCardItem);
+    // assert the deprecated item is filtered out
+    expect(allItems).toHaveLength(4);
+    expect(allItems.at(0).props('item')).toEqual(root0);
+    expect(allItems.at(1).props('item')).toEqual(root0Child1);
+    expect(allItems.at(2).props('item')).toEqual(root0Child1GrandChild0);
+    expect(allItems.at(3).props('item')).toEqual(root1);
   });
 
   describe('navigating', () => {


### PR DESCRIPTION
- **Rationale:** Add tag to hide deprecated items in the Navigator
- **Risk:** Medium
- **Risk Detail:** Adds a new filtering method, on top of the already complex filtering 
- **Reward:** High
- **Reward Details:** Users will now be able to filter out any deprecated items
- **Original PR:** https://github.com/apple/swift-docc-render/pull/251
- **Issue:** rdar://92735740
- **Code Reviewed By:** @marinaaisa @biamx3
- **Testing Details:** 

1. Assert you can see Hide Deprecated as a tag.
2. Assert that picking it, hides all deprecated items.