### PR TITLE
Adjust min-height value to match the lowest height to support WatchOS' screen ratio on the narrowest client

### DIFF
--- a/src/components/Tutorial/MobileCodePreview.vue
+++ b/src/components/Tutorial/MobileCodePreview.vue
@@ -132,7 +132,9 @@ $-preview-padding: 60px;
   /deep/ img:not(.file-icon) {
     border-radius: $border-radius;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.4);
-    min-height: 320px;
+    // Min-height matches the lowest height to support
+    // WatchOS' screen ratio on the narrowest client: 320px width
+    min-height: 243px;
     max-height: 80vh;
     width: auto;
     display: block;

--- a/src/components/Tutorial/MobileCodePreview.vue
+++ b/src/components/Tutorial/MobileCodePreview.vue
@@ -132,9 +132,6 @@ $-preview-padding: 60px;
   /deep/ img:not(.file-icon) {
     border-radius: $border-radius;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.4);
-    // Min-height matches the lowest height to support
-    // WatchOS' screen ratio on the narrowest client: 320px width
-    min-height: 243px;
     max-height: 80vh;
     width: auto;
     display: block;


### PR DESCRIPTION
Bug/issue #76652132, if applicable: 

## Summary

Adjust min-height value to match the lowest height to support WatchOS' screen ratio on the narrowest client

### Before
<img width="497" alt="Screenshot 2022-05-06 at 18 29 03" src="https://user-images.githubusercontent.com/8567677/167174049-58007602-21d7-4276-b2d6-72a4c3aee4c4.png">

### After
<img width="479" alt="Screenshot 2022-05-06 at 18 28 45" src="https://user-images.githubusercontent.com/8567677/167174070-a2b27fde-a79e-4866-832a-11854080a4c2.png">


## Dependencies

NA

## Testing

Steps:
1. Run a .doccarchive with tutorials containing screenshots of watchOS
2. In the narrowest client (320px width) assert that previews containing screenshots of watchOS look correct

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
