### PR TITLE
[5.7] Use spinner icon to indicate indefinite progress while loading navigator

### DIFF
--- a/src/components/Icons/SpinnerIcon.vue
+++ b/src/components/Icons/SpinnerIcon.vue
@@ -1,0 +1,61 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2022 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <SVGIcon class="spinner-icon" viewBox="0 0 39.02 39.02">
+    <path d="m15.529 11.96-3.57 3.569-7.99-7.99 3.57-3.57z"/>
+    <path d="M0 22.072v-5.06h11.331v5.06z"/>
+    <path d="m7.54 35.096-3.57-3.569 7.99-7.99 3.57 3.569z"/>
+    <path d="M22.057 39.02H17.01v-11.3h5.047z"/>
+    <path d="m35.096 31.528-3.569 3.568-7.99-7.99 3.569-3.569z"/>
+    <path d="M39.02 17.01v5.046h-11.3V17.01z"/>
+    <path d="m31.528 3.97 3.569 3.57-7.99 7.99-3.57-3.57z"/>
+    <path d="M17.011 0h5.061v11.331h-5.061z"/>
+  </SVGIcon>
+</template>
+
+<script>
+import SVGIcon from 'docc-render/components/SVGIcon.vue';
+
+export default {
+  name: 'SpinnerIcon',
+  components: { SVGIcon },
+};
+</script>
+
+<style scoped lang="scss">
+@keyframes fadeout {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+path {
+  $num-rects: 8;
+  $animation-duration-full: 1000ms;
+  $animation-duration-per-rect: $animation-duration-full / $num-rects;
+
+  animation-duration: $animation-duration-full;
+  animation-iteration-count: infinite;
+  animation-name: fadeout;
+  fill: currentColor;
+
+  @for $i from 1 through $num-rects {
+    &:nth-of-type(#{$i}) {
+      $animation-delay: ($i - 1) * $animation-duration-per-rect * -1;
+      animation-delay: $animation-delay;
+    }
+  }
+}
+</style>

--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -23,14 +23,18 @@
       :api-changes="apiChanges"
       @close="$emit('close')"
     />
-    <div v-else class="loading-placeholder">
-      Fetching...
-    </div>
+    <NavigatorCardInner v-else class="loading-placeholder">
+      <transition name="delay-visibility" appear>
+        <SpinnerIcon class="loading-spinner" />
+      </transition>
+    </NavigatorCardInner>
   </nav>
 </template>
 
 <script>
 import NavigatorCard from 'theme/components/Navigator/NavigatorCard.vue';
+import SpinnerIcon from 'theme/components/Icons/SpinnerIcon.vue';
+import NavigatorCardInner from 'docc-render/components/Navigator/NavigatorCardInner.vue';
 import { INDEX_ROOT_KEY } from 'docc-render/constants/sidebar';
 import { TopicTypes } from 'docc-render/constants/TopicTypes';
 import { BreakpointName } from 'docc-render/utils/breakpoints';
@@ -57,6 +61,8 @@ export default {
   name: 'Navigator',
   components: {
     NavigatorCard,
+    NavigatorCardInner,
+    SpinnerIcon,
   },
   props: {
     parentTopicIdentifiers: {
@@ -203,8 +209,21 @@ export default {
 }
 
 .loading-placeholder {
+  align-items: center;
   color: var(--color-figure-gray-secondary);
-  padding: 12px;
-  @include font-styles(body-reduced);
+  justify-content: center;
+}
+
+.loading-spinner {
+  --spinner-size: 40px; // used for both width and height
+  --spinner-delay: 1s; // don't show spinner until this much time has passed
+
+  height: var(--spinner-size);
+  width: var(--spinner-size);
+
+  &.delay-visibility-enter-active {
+    transition: visibility var(--spinner-delay);
+    visibility: hidden;
+  }
 }
 </style>

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -11,7 +11,7 @@
 <template>
   <div class="navigator-card">
     <div class="navigator-card-full-height">
-      <div class="navigator-card-inner">
+      <NavigatorCardInner>
         <div class="head-wrapper">
           <button
             aria-label="Close documentation navigator"
@@ -74,7 +74,7 @@
             {{ assertiveAriaLive }}
           </div>
         </div>
-      </div>
+      </NavigatorCardInner>
     </div>
     <div class="filter-wrapper" v-if="!errorFetching">
       <div class="navigator-filter">
@@ -104,6 +104,7 @@ import debounce from 'docc-render/utils/debounce';
 import { sessionStorage } from 'docc-render/utils/storage';
 import { INDEX_ROOT_KEY, SIDEBAR_ITEM_SIZE } from 'docc-render/constants/sidebar';
 import { safeHighlightPattern } from 'docc-render/utils/search-utils';
+import NavigatorCardInner from 'docc-render/components/Navigator/NavigatorCardInner.vue';
 import NavigatorCardItem from 'docc-render/components/Navigator/NavigatorCardItem.vue';
 import SidenavIcon from 'theme/components/Icons/SidenavIcon.vue';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
@@ -174,6 +175,7 @@ export default {
   components: {
     FilterInput,
     SidenavIcon,
+    NavigatorCardInner,
     NavigatorCardItem,
     RecycleScroller,
     Reference,
@@ -1052,15 +1054,7 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
   }
 
   .navigator-card-inner {
-    position: sticky;
-    top: $nav-height;
     height: calc(100vh - #{$nav-height} - #{$filter-height});
-    display: flex;
-    flex-flow: column;
-    @include breakpoint(medium, nav) {
-      position: static;
-      height: 100%;
-    }
   }
 
   .head-wrapper {

--- a/src/components/Navigator/NavigatorCardInner.vue
+++ b/src/components/Navigator/NavigatorCardInner.vue
@@ -1,0 +1,33 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2022 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <div class="navigator-card-inner"><slot /></div>
+</template>
+
+<script>
+export default { name: 'NavigatorCardInner' };
+</script>
+
+<style scoped lang="scss">
+@import 'docc-render/styles/_core.scss';
+
+.navigator-card-inner {
+  position: sticky;
+  top: $nav-height;
+  height: calc(100vh - #{$nav-height});
+  display: flex;
+  flex-flow: column;
+  @include breakpoint(medium, nav) {
+    position: static;
+    height: 100%;
+  }
+}
+</style>

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -11,6 +11,7 @@
 import Navigator from '@/components/Navigator.vue';
 import { shallowMount } from '@vue/test-utils';
 import NavigatorCard from '@/components/Navigator/NavigatorCard.vue';
+import SpinnerIcon from '@/components/Icons/SpinnerIcon.vue';
 import { baseNavStickyAnchorId } from 'docc-render/constants/nav';
 import { TopicTypes } from '@/constants/TopicTypes';
 import { INDEX_ROOT_KEY } from '@/constants/sidebar';
@@ -141,7 +142,10 @@ describe('Navigator', () => {
     });
     // assert Navigator card is rendered
     expect(wrapper.find(NavigatorCard).exists()).toBe(false);
-    expect(wrapper.find('.loading-placeholder').text()).toBe('Fetching...');
+
+    const placeholder = wrapper.find('.loading-placeholder');
+    expect(placeholder.exists()).toBe(true);
+    expect(placeholder.contains(SpinnerIcon)).toBe(true);
   });
 
   it('falls back to using the `technology.url` for the `technology-path`', () => {

--- a/tests/unit/components/Navigator/NavigatorCardInner.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardInner.spec.js
@@ -1,0 +1,19 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import { shallowMount } from '@vue/test-utils';
+import NavigatorCardInner from 'docc-render/components/Navigator/NavigatorCardInner.vue';
+
+describe('NavigatorCardInner', () => {
+  it('renders a div.navigator-card-inner', () => {
+    const wrapper = shallowMount(NavigatorCardInner);
+    expect(wrapper.is('div.navigator-card-inner')).toBe(true);
+  });
+});


### PR DESCRIPTION
- **Rationale:** Updates navigator loading UI to show spinner icon if data takes more than 1 second to load (replaces "Fetching..." text).
- **Risk:** Low
- **Risk Detail:** Adds new icon and makes minor update to loading UI to use the new icon.
- **Reward:** High
- **Reward Details:** Improves the UX for the navigator when it takes a while to load.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/244
- **Issue:** rdar://92438279
- **Code Reviewed By:** @dobromir-hristov, @marinaaisa 
- **Testing Details:** Added/updated unit tests, visually tested that the spinner icon works/looks as expected for long loading navigator scenario.