### PR TITLE
[5.7] Prevent Beta legal text getting cut off on the right when resizing window 

### DIFF
--- a/src/components/DocumentationTopic/BetaLegalText.vue
+++ b/src/components/DocumentationTopic/BetaLegalText.vue
@@ -46,7 +46,7 @@ export default {
   background-color: var(--color-fill-secondary);
 
   &-container {
-    @include breakpoint-content;
+    @include dynamic-content-container;
   }
 
   &-label {


### PR DESCRIPTION
- **Rationale:** Prevent Beta legal text getting cut off on the right when resizing window when navigator is enabled
- **Risk:** Small
- **Risk Detail:** Only affects the Beta legal text badge at the bottom of the page.
- **Reward:** High
- **Reward Details:** Beta pages with navigators will no longer have broken UI
- **Original PR:** https://github.com/apple/swift-docc-render/pull/260
- **Issue:** rdar://92669937
- **Code Reviewed By:** @dobromir-hristov 
- **Testing Details:** 
1. Navigate to a window with Beta legal text at the bottom of the page.
2. Verify that the text resizes correctly when going from L vp to M vp.