### PR TITLE
Simplify layout of `BetaLegalText`

### DIFF
--- a/src/components/DocumentationTopic/BetaLegalText.vue
+++ b/src/components/DocumentationTopic/BetaLegalText.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -12,10 +12,7 @@
   <div class="betainfo">
     <div class="betainfo-container">
       <GridRow>
-        <GridColumn
-          :span="{ large: 8, medium: 8, small: 12 }"
-          :isCentered="{ large: true, medium: true, small: true }"
-        >
+        <GridColumn :span="{ large: 12 }">
           <p class="betainfo-label">Beta Software</p>
           <div class="betainfo-content">
             <slot name="content">

--- a/tests/unit/components/DocumentationTopic/BetaLegalText.spec.js
+++ b/tests/unit/components/DocumentationTopic/BetaLegalText.spec.js
@@ -21,12 +21,7 @@ describe('BetaLegalText', () => {
   it('renders the BetaLegalText inside a grid', () => {
     expect(wrapper.find(GridRow).exists()).toBe(true);
     expect(wrapper.find(GridColumn).exists()).toBe(true);
-    expect(wrapper.find(GridColumn).props('span')).toEqual({ large: 8, medium: 8, small: 12 });
-    expect(wrapper.find(GridColumn).props('isCentered')).toEqual({
-      large: true,
-      medium: true,
-      small: true,
-    });
+    expect(wrapper.find(GridColumn).props('span')).toEqual({ large: 12 });
   });
 
   it('renders a title', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 92980768

## Summary

With the most recent content layout changes, the `BetaLegalText` component looks a little out of place due to its centered layout. Now, it will flow like normal page content, which looks more natural with the updated sidebar layout.

## Testing

Steps:
1. Preview any content with beta APIs
2. Verify that the beta legal disclaimer now flows naturally along with the Overview/Topics content instead of being centered

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
