### PR TITLE
[5.7] Fix height for tutorial previews

### DIFF
--- a/src/components/Tutorial/MobileCodePreview.vue
+++ b/src/components/Tutorial/MobileCodePreview.vue
@@ -132,7 +132,6 @@ $-preview-padding: 60px;
   /deep/ img:not(.file-icon) {
     border-radius: $border-radius;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.4);
-    min-height: 320px;
     max-height: 80vh;
     width: auto;
     display: block;


### PR DESCRIPTION
- Rationale: Fix height for tutorial previews
- Risk: Low
- Risk Detail: only affects tutorial previews
- Reward: Low since it's a use case
- Reward Details: Improves UI
- Original PR: https://github.com/apple/swift-docc-render/pull/266
- Issue: rdar://76652132
- Code Reviewed By: @dobromir-hristov @mportiz08 
- Testing Details:
1. - Run a .doccarchive with tutorials containing screenshots of watchOS
2. In the narrowest client (320px width) assert that previews containing screenshots of watchOS look correct