### PR TITLE
[5.7] make sure ParametersTable changes dont go outside of bounds

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/ParametersTable.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/ParametersTable.vue
@@ -86,6 +86,7 @@ $param-spacing: rem(28px);
     .change-added,
     .change-removed {
       display: inline-block;
+      max-width: 100%;
     }
 
     .change-removed,


### PR DESCRIPTION
- **Rationale:** ParameterTable changes should not go outside of container bounds, no matter screen size.
- **Risk:** Low
- **Risk Detail:** css only fix for very specific component
- **Reward:** Medium
- **Reward Details:** Users will not see occasional overflowing content, on narrow devices with expanded navigator
- **Original PR:** https://github.com/apple/swift-docc-render/pull/285
- **Issue:** rdar://92961798
- **Code Reviewed By:** @marinaaisa 
- **Testing Details:** Make sure rest components that have API changes, do not overflow content.