### PR TITLE
[5.7] Simplify layout of `BetaLegalText`

### DIFF
--- a/src/components/DocumentationTopic/BetaLegalText.vue
+++ b/src/components/DocumentationTopic/BetaLegalText.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -12,10 +12,7 @@
   <div class="betainfo">
     <div class="betainfo-container">
       <GridRow>
-        <GridColumn
-          :span="{ large: 8, medium: 8, small: 12 }"
-          :isCentered="{ large: true, medium: true, small: true }"
-        >
+        <GridColumn :span="{ large: 12 }">
           <p class="betainfo-label">Beta Software</p>
           <div class="betainfo-content">
             <slot name="content">

--- a/tests/unit/components/DocumentationTopic/BetaLegalText.spec.js
+++ b/tests/unit/components/DocumentationTopic/BetaLegalText.spec.js
@@ -21,12 +21,7 @@ describe('BetaLegalText', () => {
   it('renders the BetaLegalText inside a grid', () => {
     expect(wrapper.find(GridRow).exists()).toBe(true);
     expect(wrapper.find(GridColumn).exists()).toBe(true);
-    expect(wrapper.find(GridColumn).props('span')).toEqual({ large: 8, medium: 8, small: 12 });
-    expect(wrapper.find(GridColumn).props('isCentered')).toEqual({
-      large: true,
-      medium: true,
-      small: true,
-    });
+    expect(wrapper.find(GridColumn).props('span')).toEqual({ large: 12 });
   });
 
   it('renders a title', () => {


### PR DESCRIPTION
- **Rationale:** Updates layout of beta API disclaimer to be simpler to better align with recent design changes for documentation content.
- **Risk:** Low
- **Risk Detail:** Minor JS change to remove CSS classes.
- **Reward:** High
- **Reward Details:** Improves suboptimal visual layout of component used on all beta SDK content pages.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/283
- **Issue:** rdar://92980768
- **Code Reviewed By:** @dobromir-hristov
- **Testing Details:** Updated unit tests, visually inspected pages with updated layout.