### PR TITLE
[5.7] Allow non-menu-closing tray links

### DIFF
--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -77,11 +77,12 @@ import BreakpointEmitter from 'docc-render/components/BreakpointEmitter.vue';
 
 import FocusTrap from 'docc-render/utils/FocusTrap';
 import scrollLock from 'docc-render/utils/scroll-lock';
-import { baseNavStickyAnchorId } from 'docc-render/constants/nav';
+import { baseNavStickyAnchorId, MenuLinkModifierClasses } from 'docc-render/constants/nav';
 import { isBreakpointAbove } from 'docc-render/utils/breakpoints';
 import changeElementVOVisibility from 'docc-render/utils/changeElementVOVisibility';
 import { waitFrames } from 'docc-render/utils/loading';
 
+const { noClose } = MenuLinkModifierClasses;
 const { BreakpointName, BreakpointScopes } = BreakpointEmitter.constants;
 
 const NoBGTransitionFrames = 8;
@@ -270,8 +271,11 @@ export default {
      * @param {EventTarget} event.target
      */
     handleTrayClick({ target }) {
-      // if the target is a link and has a `href` property, close the nav
-      if (target.href) this.closeNav();
+      // If the target is a link and has a `href` property, close the nav.
+      // Targets can opt out of this default behavior with the "noclose" class.
+      if (target.href && !target.classList.contains(noClose)) {
+        this.closeNav();
+      }
     },
     /**
      * Closes the nav, if clicking outside of it.

--- a/src/constants/nav.js
+++ b/src/constants/nav.js
@@ -8,7 +8,10 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-// eslint-disable-next-line import/prefer-default-export
 export const baseNavHeight = 52;
 export const baseNavHeightSmallBreakpoint = 48;
 export const baseNavStickyAnchorId = 'nav-sticky-anchor';
+
+export const MenuLinkModifierClasses = {
+  noClose: 'noclose',
+};

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -15,7 +15,7 @@ import BreakpointEmitter from 'docc-render/components/BreakpointEmitter.vue';
 import scrollLock from 'docc-render/utils/scroll-lock';
 import FocusTrap from 'docc-render/utils/FocusTrap';
 import changeElementVOVisibility from 'docc-render/utils/changeElementVOVisibility';
-import { baseNavStickyAnchorId } from 'docc-render/constants/nav';
+import { baseNavStickyAnchorId, MenuLinkModifierClasses } from 'docc-render/constants/nav';
 import { waitFrames } from 'docc-render/utils/loading';
 import { createEvent } from '../../../test-utils';
 
@@ -225,6 +225,21 @@ describe('NavBase', () => {
     expect(wrapper.classes()).toContain(NavStateClasses.isOpen);
     tray.find('.with-anchor a').trigger('click');
     expect(wrapper.classes()).not.toContain(NavStateClasses.isOpen);
+  });
+
+  it('does not close the navigation if clicked on a .noclose link inside the tray', async () => {
+    const { noClose } = MenuLinkModifierClasses;
+    wrapper = await createWrapper({
+      data: () => ({ isOpen: true }),
+      slots: {
+        'menu-items': `
+          <li class="with-anchor"><a class="${noClose}" href="#">Somewhere</a></li>
+          <li class="without-anchor"><div class="foo">Foo</div></li>`,
+      },
+    });
+    const tray = wrapper.find(NavMenuItems);
+    tray.find('.with-anchor a').trigger('click');
+    expect(wrapper.classes()).toContain(NavStateClasses.isOpen);
   });
 
   it('adds extra classes to stop scrolling while animating the tray up/down', async () => {


### PR DESCRIPTION
- **Rationale:** Adds support for overriding default behavior of links automatically closing the mobile nav.
- **Risk:** Low
- **Risk Detail:** Minor JS conditional change to check if element has a class.
- **Reward:** High
- **Reward Details:** Allows for improved nav UX where links don't always close the nav when clicked.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/284
- **Issue:** rdar://92984703
- **Code Reviewed By:** @dobromir-hristov
- **Testing Details:** Added unit tests