### PR TITLE
Tags and text should scroll as a unique element in filter input

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -553,13 +553,14 @@ $input-height: rem(28px);
     width: 100%;
     height: var(--input-height);
     padding: var(--input-vertical-padding) 0;
-    min-width: 130px; // set a min width, so user can select the area
 
     &::after {
       content: attr(data-value);
       visibility: hidden;
       width: auto;
       white-space: nowrap;
+      min-width: 130px; // set a min width, so user can select the area
+      display: block;
     }
   }
 

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -553,6 +553,7 @@ $input-height: rem(28px);
     width: 100%;
     height: var(--input-height);
     padding: var(--input-vertical-padding) 0;
+    min-width: 130px; // set a min width, so user can select the area
 
     &::after {
       content: attr(data-value);
@@ -577,7 +578,6 @@ $input-height: rem(28px);
     height: var(--input-height);
     border: none;
     width: 100%;
-    min-width: 130px; // set a min width, so user can select the area
     position: absolute;
     background: transparent;
     z-index: 1;

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -56,36 +56,36 @@
           <label
             id="filter-label"
             :for="FilterInputId"
-            class="visuallyhidden"
-            aria-hidden="true"
+            :input-value="modelValue"
+            :aria-label="placeholder"
+            class="filter__input-label"
           >
-            {{ placeholder }}
+            <input
+              :id="FilterInputId"
+              ref="input"
+              v-model="modelValue"
+              :placeholder="hasSelectedTags ? '' : placeholder"
+              :aria-expanded="displaySuggestedTags ? 'true' : 'false'"
+              :disabled="disabled"
+              v-bind="AXinputProperties"
+              type="text"
+              class="filter__input"
+              v-on="inputMultipleSelectionListeners"
+              @keydown.down.prevent="downHandler"
+              @keydown.up.prevent="upHandler"
+              @keydown.left="leftKeyInputHandler"
+              @keydown.right="rightKeyInputHandler"
+              @keydown.delete="deleteHandler"
+              @keydown.meta.a.prevent="selectInputAndTags"
+              @keydown.ctrl.a.prevent="selectInputAndTags"
+              @keydown.exact="inputKeydownHandler"
+              @keydown.enter.exact="enterHandler"
+              @keydown.shift.exact="inputKeydownHandler"
+              @keydown.shift.meta.exact="inputKeydownHandler"
+              @keydown.meta.exact="assignEventValues"
+              @keydown.ctrl.exact="assignEventValues"
+            >
           </label>
-          <input
-            :id="FilterInputId"
-            ref="input"
-            v-model="modelValue"
-            :placeholder="hasSelectedTags ? '' : placeholder"
-            :aria-expanded="displaySuggestedTags ? 'true' : 'false'"
-            :disabled="disabled"
-            v-bind="AXinputProperties"
-            type="text"
-            class="filter__input"
-            v-on="inputMultipleSelectionListeners"
-            @keydown.down.prevent="downHandler"
-            @keydown.up.prevent="upHandler"
-            @keydown.left="leftKeyInputHandler"
-            @keydown.right="rightKeyInputHandler"
-            @keydown.delete="deleteHandler"
-            @keydown.meta.a.prevent="selectInputAndTags"
-            @keydown.ctrl.a.prevent="selectInputAndTags"
-            @keydown.exact="inputKeydownHandler"
-            @keydown.enter.exact="enterHandler"
-            @keydown.shift.exact="inputKeydownHandler"
-            @keydown.shift.meta.exact="inputKeydownHandler"
-            @keydown.meta.exact="assignEventValues"
-            @keydown.ctrl.exact="assignEventValues"
-          >
         </div>
         <div class="filter__delete-button-wrapper">
           <button
@@ -548,6 +548,20 @@ $input-height: rem(28px);
     border-bottom-right-radius: $small-border-radius;
   }
 
+  &__input-label {
+    position: relative;
+    width: 100%;
+    height: var(--input-height);
+    padding: var(--input-vertical-padding) 0;
+
+    &::after {
+      content: attr(input-value);
+      visibility: hidden;
+      width: auto;
+      white-space: nowrap;
+    }
+  }
+
   &__input-box-wrapper {
     @include custom-horizontal-scrollbar;
     display: flex;
@@ -563,13 +577,12 @@ $input-height: rem(28px);
     height: var(--input-height);
     border: none;
     width: 100%;
-    min-width: 130px; // set a min width, so it does not get crushed by tags
+    min-width: 130px; // set a min width, so user can select the area
+    position: absolute;
     background: transparent;
-    padding: var(--input-vertical-padding) 0;
     z-index: 1;
     // Text indent is needed instead of padding so text inside <input> doesn't get cut off
     text-indent: rem(7px);
-    text-overflow: ellipsis;
 
     @include breakpoint(small) {
       text-indent: rem(3px);

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -56,7 +56,7 @@
           <label
             id="filter-label"
             :for="FilterInputId"
-            :input-value="modelValue"
+            :data-value="modelValue"
             :aria-label="placeholder"
             class="filter__input-label"
           >
@@ -555,7 +555,7 @@ $input-height: rem(28px);
     padding: var(--input-vertical-padding) 0;
 
     &::after {
-      content: attr(input-value);
+      content: attr(data-value);
       visibility: hidden;
       width: auto;
       white-space: nowrap;

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -550,7 +550,7 @@ $input-height: rem(28px);
 
   &__input-label {
     position: relative;
-    width: 100%;
+    flex-grow: 1;
     height: var(--input-height);
     padding: var(--input-vertical-padding) 0;
 
@@ -561,6 +561,11 @@ $input-height: rem(28px);
       white-space: nowrap;
       min-width: 130px; // set a min width, so user can select the area
       display: block;
+      text-indent: rem(7px);
+
+      @include breakpoint(small) {
+        text-indent: rem(3px);
+      }
     }
   }
 

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -95,8 +95,8 @@ describe('FilterInput', () => {
     expect(attrs).toHaveProperty('tabindex', '0');
     // labelled by these components
     expect(attrs).toHaveProperty('aria-labelledby', FilterInputId);
-    // check filter label text
-    expect(filterLabel.text()).toBe(propsData.placeholder);
+    // check aria-label for filter label
+    expect(filterLabel.attributes('aria-label')).toBe(propsData.placeholder);
     // check filter label is a label tag
     expect(filterLabel.is('label')).toBe(true);
     // check that label is associated to filter input
@@ -119,6 +119,15 @@ describe('FilterInput', () => {
     });
     await wrapper.vm.$nextTick();
     expect(input.element.value).toEqual('new-value');
+  });
+
+  it('renders an filter label element that has a input-value attrib to resize the input', () => {
+    wrapper.setProps({ value: inputValue });
+    const filterLabel = wrapper.find('#filter-label');
+    // check input-value attrib for filter label contains the input value
+    expect(filterLabel.attributes('input-value')).toBe(inputValue);
+    // check class for filter label
+    expect(filterLabel.classes('filter__input-label')).toBe(true);
   });
 
   it('renders a `scrolling` class inside the input box wrapper if `isScrolling` is true', () => {

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -125,7 +125,7 @@ describe('FilterInput', () => {
     wrapper.setProps({ value: inputValue });
     const filterLabel = wrapper.find('#filter-label');
     // check input-value attrib for filter label contains the input value
-    expect(filterLabel.attributes('input-value')).toBe(inputValue);
+    expect(filterLabel.attributes('data-value')).toBe(inputValue);
     // check class for filter label
     expect(filterLabel.classes('filter__input-label')).toBe(true);
   });


### PR DESCRIPTION
Bug/issue #90896758, if applicable: 

## Summary

Tags and text should scroll as a unique element in filter input

## Dependencies

NA

## Testing

Steps:
1. Open a .doccarchive that has navigation
2. Select a tag and write a long string in the filter input
3. Assert that when scrolling, tags and input scroll along the way. Before only the text was scrolling.
4. Assert that AX is correct

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
