### PR TITLE
Ensure navigator unlocks scrolling when navigating away

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -280,7 +280,6 @@ export default {
      */
     toggleScrollLock(lock) {
       const scrollLockContainer = document.getElementById(this.scrollLockID);
-      if (!scrollLockContainer) return;
       if (lock) {
         scrollLock.lockScroll(scrollLockContainer);
         // lock focus

--- a/src/components/Tutorial/MobileCodePreview.vue
+++ b/src/components/Tutorial/MobileCodePreview.vue
@@ -132,7 +132,6 @@ $-preview-padding: 60px;
   /deep/ img:not(.file-icon) {
     border-radius: $border-radius;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.4);
-    min-height: 320px;
     max-height: 80vh;
     width: auto;
     display: block;

--- a/src/utils/scroll-lock.js
+++ b/src/utils/scroll-lock.js
@@ -131,7 +131,7 @@ export default {
     if (!isIosDevice()) {
       simpleLock();
     } else {
-      advancedLock(targetElement);
+      advancedLock(targetElement || {});
     }
     isLocked = true;
   },
@@ -144,7 +144,7 @@ export default {
 
     if (isIosDevice()) {
       // revert the old scroll position
-      advancedUnlock(targetElement);
+      advancedUnlock(targetElement || {});
     } else {
       // remove all inline styles
       document.body.style.cssText = '';

--- a/src/utils/scroll-lock.js
+++ b/src/utils/scroll-lock.js
@@ -63,8 +63,10 @@ function simpleLock() {
 function advancedUnlock(targetElement) {
   /* eslint-disable no-param-reassign */
   // remove the touch listeners on the target
-  targetElement.ontouchstart = null;
-  targetElement.ontouchmove = null;
+  if (targetElement) {
+    targetElement.ontouchstart = null;
+    targetElement.ontouchmove = null;
+  }
   // remove the body event listener
   document.removeEventListener('touchmove', preventDefault);
 }
@@ -97,6 +99,9 @@ function handleScroll(event, targetElement) {
  * @param targetElement
  */
 function advancedLock(targetElement) {
+  // add a scroll listener to the body
+  document.addEventListener('touchmove', preventDefault, { passive: false });
+  if (!targetElement) return;
   /* eslint-disable no-param-reassign */
   // add inline listeners to the target, for easier removal later.
   targetElement.ontouchstart = (event) => {
@@ -111,8 +116,6 @@ function advancedLock(targetElement) {
       handleScroll(event, targetElement);
     }
   };
-  // add a scroll listener to the body
-  document.addEventListener('touchmove', preventDefault, { passive: false });
 }
 
 /**
@@ -131,7 +134,7 @@ export default {
     if (!isIosDevice()) {
       simpleLock();
     } else {
-      advancedLock(targetElement || {});
+      advancedLock(targetElement);
     }
     isLocked = true;
   },
@@ -144,7 +147,7 @@ export default {
 
     if (isIosDevice()) {
       // revert the old scroll position
-      advancedUnlock(targetElement || {});
+      advancedUnlock(targetElement);
     } else {
       // remove all inline styles
       document.body.style.cssText = '';

--- a/tests/unit/utils/scroll-lock.spec.js
+++ b/tests/unit/utils/scroll-lock.spec.js
@@ -112,6 +112,17 @@ describe('scroll-lock', () => {
       expect(preventDefault).toHaveBeenCalledTimes(1);
     });
 
+    it('does not throw, if not passed an element', () => {
+      expect(() => scrollLock.lockScroll(null)).not.toThrow();
+      // assert body scroll is getting prevented when swiping up/down
+      document.dispatchEvent(createEvent('touchmove', {
+        preventDefault,
+        touches: [1],
+      }));
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      expect(() => scrollLock.unlockScroll(null)).not.toThrow();
+    });
+
     it('attaches only once event listeners', () => {
       // enable scroll locking
       scrollLock.lockScroll(container);


### PR DESCRIPTION
Bug/issue #, if applicable:  closes #293

## Summary

Fixes a bug where the navigator would not unlock scrolling on mobile devices.

## Dependencies

NA

## Testing

You need an archive with Tutorials, like sloth creator

Steps:
1. From a doc page open the navigator on a mobile device
2. Click on a link, that leads to a tutorial
3. Assert scrolling is possible again

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
