### PR TITLE
[5.7] Tags and text should scroll as a unique element in filter input

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -56,36 +56,36 @@
           <label
             id="filter-label"
             :for="FilterInputId"
-            class="visuallyhidden"
-            aria-hidden="true"
+            :data-value="modelValue"
+            :aria-label="placeholder"
+            class="filter__input-label"
           >
-            {{ placeholder }}
+            <input
+              :id="FilterInputId"
+              ref="input"
+              v-model="modelValue"
+              :placeholder="hasSelectedTags ? '' : placeholder"
+              :aria-expanded="displaySuggestedTags ? 'true' : 'false'"
+              :disabled="disabled"
+              v-bind="AXinputProperties"
+              type="text"
+              class="filter__input"
+              v-on="inputMultipleSelectionListeners"
+              @keydown.down.prevent="downHandler"
+              @keydown.up.prevent="upHandler"
+              @keydown.left="leftKeyInputHandler"
+              @keydown.right="rightKeyInputHandler"
+              @keydown.delete="deleteHandler"
+              @keydown.meta.a.prevent="selectInputAndTags"
+              @keydown.ctrl.a.prevent="selectInputAndTags"
+              @keydown.exact="inputKeydownHandler"
+              @keydown.enter.exact="enterHandler"
+              @keydown.shift.exact="inputKeydownHandler"
+              @keydown.shift.meta.exact="inputKeydownHandler"
+              @keydown.meta.exact="assignEventValues"
+              @keydown.ctrl.exact="assignEventValues"
+            >
           </label>
-          <input
-            :id="FilterInputId"
-            ref="input"
-            v-model="modelValue"
-            :placeholder="hasSelectedTags ? '' : placeholder"
-            :aria-expanded="displaySuggestedTags ? 'true' : 'false'"
-            :disabled="disabled"
-            v-bind="AXinputProperties"
-            type="text"
-            class="filter__input"
-            v-on="inputMultipleSelectionListeners"
-            @keydown.down.prevent="downHandler"
-            @keydown.up.prevent="upHandler"
-            @keydown.left="leftKeyInputHandler"
-            @keydown.right="rightKeyInputHandler"
-            @keydown.delete="deleteHandler"
-            @keydown.meta.a.prevent="selectInputAndTags"
-            @keydown.ctrl.a.prevent="selectInputAndTags"
-            @keydown.exact="inputKeydownHandler"
-            @keydown.enter.exact="enterHandler"
-            @keydown.shift.exact="inputKeydownHandler"
-            @keydown.shift.meta.exact="inputKeydownHandler"
-            @keydown.meta.exact="assignEventValues"
-            @keydown.ctrl.exact="assignEventValues"
-          >
         </div>
         <div class="filter__delete-button-wrapper">
           <button
@@ -548,6 +548,27 @@ $input-height: rem(28px);
     border-bottom-right-radius: $small-border-radius;
   }
 
+  &__input-label {
+    position: relative;
+    flex-grow: 1;
+    height: var(--input-height);
+    padding: var(--input-vertical-padding) 0;
+
+    &::after {
+      content: attr(data-value);
+      visibility: hidden;
+      width: auto;
+      white-space: nowrap;
+      min-width: 130px; // set a min width, so user can select the area
+      display: block;
+      text-indent: rem(7px);
+
+      @include breakpoint(small) {
+        text-indent: rem(3px);
+      }
+    }
+  }
+
   &__input-box-wrapper {
     @include custom-horizontal-scrollbar;
     display: flex;
@@ -563,13 +584,11 @@ $input-height: rem(28px);
     height: var(--input-height);
     border: none;
     width: 100%;
-    min-width: 130px; // set a min width, so it does not get crushed by tags
+    position: absolute;
     background: transparent;
-    padding: var(--input-vertical-padding) 0;
     z-index: 1;
     // Text indent is needed instead of padding so text inside <input> doesn't get cut off
     text-indent: rem(7px);
-    text-overflow: ellipsis;
 
     @include breakpoint(small) {
       text-indent: rem(3px);

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -95,8 +95,8 @@ describe('FilterInput', () => {
     expect(attrs).toHaveProperty('tabindex', '0');
     // labelled by these components
     expect(attrs).toHaveProperty('aria-labelledby', FilterInputId);
-    // check filter label text
-    expect(filterLabel.text()).toBe(propsData.placeholder);
+    // check aria-label for filter label
+    expect(filterLabel.attributes('aria-label')).toBe(propsData.placeholder);
     // check filter label is a label tag
     expect(filterLabel.is('label')).toBe(true);
     // check that label is associated to filter input
@@ -119,6 +119,15 @@ describe('FilterInput', () => {
     });
     await wrapper.vm.$nextTick();
     expect(input.element.value).toEqual('new-value');
+  });
+
+  it('renders an filter label element that has a input-value attrib to resize the input', () => {
+    wrapper.setProps({ value: inputValue });
+    const filterLabel = wrapper.find('#filter-label');
+    // check input-value attrib for filter label contains the input value
+    expect(filterLabel.attributes('data-value')).toBe(inputValue);
+    // check class for filter label
+    expect(filterLabel.classes('filter__input-label')).toBe(true);
   });
 
   it('renders a `scrolling` class inside the input box wrapper if `isScrolling` is true', () => {


### PR DESCRIPTION
- Rationale: Adds support for scrolling tags and text on the filter input in navigator
- Risk: Low
- Risk Detail: Possible regressions on the filter input in navigator
- Reward: Medium
- Reward Details: Allows for improved nav UX where tags and text scroll as a unique element in filter input
- Original PR: https://github.com/apple/swift-docc-render/pull/291
- Issue: rdar://90896758
- Code Reviewed By: @dobromir-hristov
- Testing Details: unit and manual tests