### PR TITLE
Fix navigator height on mobile devices

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -194,6 +194,7 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .navigator {
+  --nav-height: #{$nav-height};
   height: 100%;
   display: flex;
   flex-flow: column;

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1054,7 +1054,7 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
   }
 
   .navigator-card-inner {
-    height: calc(100vh - #{$nav-height} - #{$filter-height});
+    --nav-card-inner-vertical-offset: #{$filter-height};
   }
 
   .head-wrapper {

--- a/src/components/Navigator/NavigatorCardInner.vue
+++ b/src/components/Navigator/NavigatorCardInner.vue
@@ -20,9 +20,10 @@ export default { name: 'NavigatorCardInner' };
 @import 'docc-render/styles/_core.scss';
 
 .navigator-card-inner {
+  --nav-card-inner-vertical-offset: 0px;
   position: sticky;
-  top: $nav-height;
-  height: calc(100vh - #{$nav-height});
+  top: var(--nav-height);
+  height: calc(100vh - var(--nav-height) - var(--nav-card-inner-vertical-offset));
   display: flex;
   flex-flow: column;
   @include breakpoint(medium, nav) {


### PR DESCRIPTION
Bug/issue #, if applicable: 93162464

## Summary

Fixes the navigator height on mobile devices, because it was getting cutoff at the bottom.

## Dependencies

NA

## Testing

Steps:
1. On a mobile device, try to open the navigator and expand a few items
2. Assert it no longer cutsoff the bottom

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
