### PR TITLE
Refactor hero icon position; center on long hero sections 

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -14,7 +14,8 @@
       <DocumentationHero
         :role="role"
         :enhanceBackground="enhanceBackground"
-        :extraPadding="extraPadding"
+        :shortHero="shortHero"
+        :shouldShowLanguageSwitcher="shouldShowLanguageSwitcher"
       >
         <template #above-content>
           <slot name="above-hero-content" />
@@ -303,14 +304,16 @@ export default {
       objcPath && swiftPath && isTargetIDE
     ),
     enhanceBackground: ({ symbolKind }) => (symbolKind ? (symbolKind === 'module') : true),
-    extraPadding: ({
+    shortHero: ({
       roleHeading,
       abstract,
       sampleCodeDownload,
       hasAvailability,
+      shouldShowLanguageSwitcher,
     }) => (
       // apply extra padding when there are less than 2 items in the Hero section other than `title`
-      (!!roleHeading + !!abstract + !!sampleCodeDownload + !!hasAvailability) <= 1
+      (!!roleHeading + !!abstract + !!sampleCodeDownload
+        + !!hasAvailability + !!shouldShowLanguageSwitcher) <= 1
     ),
     technologies({ modules = [] }) {
       const technologyList = modules.reduce((list, module) => {

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -301,7 +301,7 @@ export default {
       abstract ? extractFirstParagraphText(abstract) : null
     ),
     shouldShowLanguageSwitcher: ({ objcPath, swiftPath, isTargetIDE }) => (
-      objcPath && swiftPath && isTargetIDE
+      !!(objcPath && swiftPath && isTargetIDE)
     ),
     enhanceBackground: ({ symbolKind }) => (symbolKind ? (symbolKind === 'module') : true),
     shortHero: ({
@@ -313,7 +313,7 @@ export default {
     }) => (
       // apply extra padding when there are less than 2 items in the Hero section other than `title`
       (!!roleHeading + !!abstract + !!sampleCodeDownload
-        + !!hasAvailability + !!shouldShowLanguageSwitcher) <= 1
+        + !!hasAvailability + shouldShowLanguageSwitcher) <= 1
     ),
     technologies({ modules = [] }) {
       const technologyList = modules.reduce((list, module) => {

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -133,6 +133,7 @@ $doc-hero-icon-dimension: 250px;
     margin-right: $doc-hero-icon-spacing;
     right: 0;
     width: $doc-hero-icon-dimension;
+    // create icon box with spacing in hero section
     height: calc(100% - #{$doc-hero-icon-vertical-spacing * 2});
     box-sizing: border-box;
 
@@ -148,6 +149,7 @@ $doc-hero-icon-dimension: 250px;
     height: auto;
     opacity: $doc-hero-icon-opacity;
     position: absolute;
+    // center in icon box
     top: 50%;
     left: 0;
     transform: translateY(-50%);

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -93,6 +93,7 @@ $doc-hero-overlay-background: transparent !default;
 $doc-hero-icon-opacity: 1 !default;
 $doc-hero-icon-color: dark-color(fill-secondary) !default;
 $doc-hero-icon-spacing: 25px;
+$doc-hero-icon-vertical-spacing: 10px;
 $doc-hero-icon-dimension: 250px;
 
 .documentation-hero {
@@ -128,9 +129,12 @@ $doc-hero-icon-dimension: 250px;
 
   .icon {
     position: absolute;
-    margin-top: 10px;
+    margin-top: $doc-hero-icon-vertical-spacing;
     margin-right: $doc-hero-icon-spacing;
     right: 0;
+    width: $doc-hero-icon-dimension;
+    height: calc(100% - #{$doc-hero-icon-vertical-spacing * 2});
+    box-sizing: border-box;
 
     @include breakpoint(small) {
       display: none;
@@ -143,6 +147,11 @@ $doc-hero-icon-dimension: 250px;
     width: $doc-hero-icon-dimension;
     height: auto;
     opacity: $doc-hero-icon-opacity;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    transform: translateY(-50%);
+    max-height: 100%;
 
     /deep/ svg {
       width: 100%;

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -26,8 +26,8 @@
       <slot name="above-content" />
     </div>
     <div
-    class="documentation-hero__content"
-    :class="{ 'extra-padding': extraPadding }"
+      class="documentation-hero__content"
+      :class="{ 'short-hero': shortHero, 'extra-bottom-padding': shouldShowLanguageSwitcher }"
     >
       <slot />
     </div>
@@ -53,7 +53,11 @@ export default {
       type: Boolean,
       required: true,
     },
-    extraPadding: {
+    shortHero: {
+      type: Boolean,
+      required: true,
+    },
+    shouldShowLanguageSwitcher: {
       type: Boolean,
       required: true,
     },
@@ -188,9 +192,15 @@ $doc-hero-icon-dimension: 250px;
   }
 }
 
-.extra-padding {
+.short-hero {
+  // apply extra top and bottom padding for pages with short hero section
   padding-top: rem(60px);
   padding-bottom: rem(60px);
+}
+
+.extra-bottom-padding {
+  // apply extra bottom padding when shouldShowLanguageSwitcher
+  padding-bottom: rem(65px);
 }
 
 .theme-dark /deep/ a:not(.button-cta) {

--- a/src/components/Tutorial/MobileCodePreview.vue
+++ b/src/components/Tutorial/MobileCodePreview.vue
@@ -132,7 +132,6 @@ $-preview-padding: 60px;
   /deep/ img:not(.file-icon) {
     border-radius: $border-radius;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.4);
-    min-height: 320px;
     max-height: 80vh;
     width: auto;
     display: block;

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -216,7 +216,8 @@ describe('DocumentationTopic', () => {
     expect(hero.props()).toEqual({
       role: propsData.role,
       enhanceBackground: true,
-      extraPadding: false,
+      shortHero: false,
+      shouldShowLanguageSwitcher: false,
     });
   });
 
@@ -225,16 +226,17 @@ describe('DocumentationTopic', () => {
     expect(hero.props()).toEqual({
       role: TopicTypes.collection,
       enhanceBackground: true,
-      extraPadding: false,
+      shortHero: false,
+      shouldShowLanguageSwitcher: false,
     });
   });
 
-  it('computes `extraPadding correctly', () => {
+  it('computes `shortHero correctly', () => {
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props('extraPadding')).toBe(false);
+    expect(hero.props('shortHero')).toBe(false);
 
     wrapper.setProps({ abstract: '', roleHeading: '', sampleCodeDownload: '' });
-    expect(hero.props('extraPadding')).toBe(true);
+    expect(hero.props('shortHero')).toBe(true);
   });
 
   it('render a `DocumentationHero`, disabled, if symbol page', () => {
@@ -254,7 +256,8 @@ describe('DocumentationTopic', () => {
     expect(hero.props()).toEqual({
       role: 'symbol',
       enhanceBackground: false,
-      extraPadding: false,
+      shortHero: false,
+      shouldShowLanguageSwitcher: false,
     });
   });
 

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -18,7 +18,7 @@ import { TopicRole } from '@/constants/roles';
 const defaultProps = {
   role: TopicTypes.class,
   enhanceBackground: true,
-  extraPadding: true,
+  shortHero: true,
 };
 
 const createWrapper = ({ propsData, ...others } = {}) => shallowMount(DocumentationHero, {
@@ -67,14 +67,14 @@ describe('DocumentationHero', () => {
     });
   });
 
-  it('renders the right classes based on `extraPadding` prop', () => {
+  it('renders the right classes based on `shortHero` prop', () => {
     const wrapper = createWrapper();
-    expect(wrapper.find('.extra-padding').exists()).toBe(true);
+    expect(wrapper.find('.short-hero').exists()).toBe(true);
 
     wrapper.setProps({
-      extraPadding: false,
+      shortHero: false,
     });
-    expect(wrapper.find('.extra-padding').exists()).toBe(false);
+    expect(wrapper.find('.short-hero').exists()).toBe(false);
   });
 
   it('finds aliases, for the color', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 93050293

## Summary
Current icon positioning looks odd on pages with longer hero sections.
This refactor centers the icons on those page, instead of pinning them to the top.

## Testing
Steps:
1. Navigate to a page that has a few items in the hero section
2. Verify that icons is centered in the hero section.
3. Navigate to a page with short hero section
4. Verify that in bigger viewports, the icon is still pinned to the top of the page. As we shrink the viewport to medium and increase the size of the sidebar, verify that the icon is dynamically positioned in the center as well.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
