### PR TITLE
Remove background color for topics section in IDE

### DIFF
--- a/src/components/DocumentationTopic/ContentTable.vue
+++ b/src/components/DocumentationTopic/ContentTable.vue
@@ -43,12 +43,6 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-.contenttable {
-  @include inTargetIde {
-    background: var(--color-content-table-content-color);
-  }
-}
-
 .container {
   @include dynamic-content-container;
   padding-bottom: $section-spacing-single-side;

--- a/src/styles/core/colors/_light.scss
+++ b/src/styles/core/colors/_light.scss
@@ -77,7 +77,6 @@
   --color-code-line-highlight: #{change-color(light-color(figure-blue), $alpha: 0.08)};
   --color-code-line-highlight-border: var(--color-figure-blue);
   --color-code-plain: var(--color-figure-gray);
-  --color-content-table-content-color: var(--color-fill-secondary);
   --color-dropdown-background: #{transparentize(light-color(fill), 0.2)};
   --color-dropdown-border: #{light-color(fill-gray)};
   --color-dropdown-option-text: #{light-color(figure-gray-secondary)};


### PR DESCRIPTION
Bug/issue #, if applicable: 92993225

## Summary
Remove the background for topics section in IDE mode to be consistent with the web view.

## Testing
Steps:
1. Verify that in IDE mode, there is no background color for topics section.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded 
- [ ] Updated documentation if necessary - NA
