### PR TITLE
Fix scrollbars not showing for CodeListing in Safari

### DIFF
--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -154,7 +154,8 @@ export default {
 pre {
   padding: $code-listing-with-numbers-padding;
   display: flex;
-  overflow: auto;
+  // set as `unset` to fix a Safari issue, where the scrollbar is hidden until you resize window
+  overflow: unset;
   -webkit-overflow-scrolling: touch;
   white-space: pre;
   word-wrap: normal;


### PR DESCRIPTION
Bug/issue #, if applicable: 78783950

## Summary

Fixes a bug where codelisting scrollbars are sometimes hidden in Safari, until you resize the screen.

## Dependencies

NA

## Testing

You can use SlothCreator to test.

Try setting scrollbars to `Always Show` in macOS settings.

Steps:
1. Use a resolution that would show horizontal scrollbars. Expand the navigator as much as possible.
2. Go to http://localhost:8082/documentation/slothcreator/sloth
3. Assert that scrollbars are always visible in safari and its fully scrollable
4. Try the same here - http://localhost:8082/tutorials/slothcreator/creating-custom-sloths

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~ - no need CSS only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
