### PR TITLE
Fix issue with navigating up/down in navigator

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -205,10 +205,10 @@ export default {
       this.toggleTree();
     },
     clickReference() {
-      this.$refs.reference.$el.click();
+      (this.$refs.reference.$el || this.$refs.reference).click();
     },
     focusReference() {
-      this.$refs.reference.$el.focus();
+      (this.$refs.reference.$el || this.$refs.reference).focus();
     },
     handleClick() {
       if (this.isGroupMarker) return;


### PR DESCRIPTION
Bug/issue #, if applicable: 93332275

## Summary

Fixes a bug where if you navigate down in the navigator, it skips the Headings and throws errors in the console.

This is caused by a recent refactor, where we call `$refs.reference.$el.focus()`, but the `reference` can be a Vue component or a DOM element, in the second case it throws an error. That would be when we render an H3 instead of the Reference component.

## Dependencies

NA

## Testing

Steps:
1. Navigate down the navigator using arrow keys.
2. Assert no errors are visible in console.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
