### PR TITLE
Remove focus outline for mouse clicks and allow clicking on edge of navigator items

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -248,13 +248,15 @@ $nesting-spacing: $card-horizontal-spacing + $card-horizontal-spacing-small;
   display: flex;
   align-items: center;
 
-  &:focus-within {
-    margin: $card-horizontal-spacing-small;
-    height: $item-height - 10px;
-    @include focus-outline();
+  .fromkeyboard & {
+    &:focus-within {
+      margin: $card-horizontal-spacing-small;
+      height: $item-height - 10px;
+      @include focus-outline();
 
-    .depth-spacer {
-      margin-left: -$card-horizontal-spacing-small;
+      .depth-spacer {
+        margin-left: -$card-horizontal-spacing-small;
+      }
     }
   }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 93331047

## Summary

Fixes a small css bug, where focus outlines are shown when mouse clicks are used, causing issues both visually, and when clicking on the edge of the item as well.

I tried an alternative approach to the outlines, which uses box-shadows instead, but I think the current code can stay as well

```scss
  .fromkeyboard & {
    &:focus-within {
      // simulate outline with box-shadow instead of border so it does not move items.
      // outline is getting cutoff, so we cannot use it.
      box-shadow: 0 $form-focus-size 0 0 inset var(--color-focus-color),
      0 -#{$form-focus-size} 0 0 inset var(--color-focus-color);
      box-sizing: border-box;
      // add a small vertical padding, so active elements dont hide the box-shadow.
      padding: $form-focus-size 0;
    }
  }
}
```

## Dependencies

NA

## Testing

Steps:
1. Click on items with mouse
2. Assert outline is not shown anymore
3. Click on the very edge of the items
4. Assert clicks are registered

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added tests~ - no need, css only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
