### PR TITLE
[5.7] Remove background color for topics section in IDE 

### DIFF
--- a/src/components/DocumentationTopic/ContentTable.vue
+++ b/src/components/DocumentationTopic/ContentTable.vue
@@ -43,12 +43,6 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-.contenttable {
-  @include inTargetIde {
-    background: var(--color-content-table-content-color);
-  }
-}
-
 .container {
   @include dynamic-content-container;
   padding-bottom: $section-spacing-single-side;

--- a/src/styles/core/colors/_light.scss
+++ b/src/styles/core/colors/_light.scss
@@ -77,7 +77,6 @@
   --color-code-line-highlight: #{change-color(light-color(figure-blue), $alpha: 0.08)};
   --color-code-line-highlight-border: var(--color-figure-blue);
   --color-code-plain: var(--color-figure-gray);
-  --color-content-table-content-color: var(--color-fill-secondary);
   --color-dropdown-background: #{transparentize(light-color(fill), 0.2)};
   --color-dropdown-border: #{light-color(fill-gray)};
   --color-dropdown-option-text: #{light-color(figure-gray-secondary)};


### PR DESCRIPTION
- Rationale: Remove the background for topics section in IDE mode to be consistent with the web view.
- Risk: Low
- Risk Detail: Only CSS changes
- Reward: High
- Reward Details: Fix broken UI in IDE mode and make sure the UI is consistent with web view
- Original PR: https://github.com/apple/swift-docc-render/pull/300
- Issue: rdar://92993225
- Code Reviewed By: @dobromir-hristov @mportiz08 
- Testing Details: Manual test in IDE to verify that the background color in the topics section is removed.