### PR TITLE
[5.7-04252022] fix NavigatorCardInner height for mobile devices

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -194,6 +194,7 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .navigator {
+  --nav-height: #{$nav-height};
   height: 100%;
   display: flex;
   flex-flow: column;

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -987,7 +987,7 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
   }
 
   .navigator-card-inner {
-    height: calc(100vh - #{$nav-height} - #{$filter-height});
+    --nav-card-inner-vertical-offset: #{$filter-height};
   }
 
   .head-wrapper {

--- a/src/components/Navigator/NavigatorCardInner.vue
+++ b/src/components/Navigator/NavigatorCardInner.vue
@@ -20,9 +20,10 @@ export default { name: 'NavigatorCardInner' };
 @import 'docc-render/styles/_core.scss';
 
 .navigator-card-inner {
+  --nav-card-inner-vertical-offset: 0px;
   position: sticky;
-  top: $nav-height;
-  height: calc(100vh - #{$nav-height});
+  top: var(--nav-height);
+  height: calc(100vh - var(--nav-height) - var(--nav-card-inner-vertical-offset));
   display: flex;
   flex-flow: column;
   @include breakpoint(medium, nav) {


### PR DESCRIPTION
- **Rationale:** Fixes a CSS layout bug, which was causing the navigator to have very large empty space at the bottom on Mobile devices
- **Risk:** Low
- **Risk Detail:** Minor CSS refactor
- **Reward:** High
- **Reward Details:** Removes unnecessary large empty space for mobile devices
- **Original PR:** https://github.com/apple/swift-docc-render/pull/297
- **Issue:** rdar://93346870
- **Code Reviewed By:** @mportiz08 
- **Testing Details:** Visually inspected in the browser