### PR TITLE
[AX] VoiceOver should read when router changes into a new page, navigation is loading or is ready

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -89,6 +89,9 @@
       />
       <BetaLegalText v-if="!isTargetIDE && hasBetaContent" />
     </main>
+    <div aria-live="polite" class="visuallyhidden">
+      Current page is {{ pageTitle }}
+    </div>
   </div>
 </template>
 

--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -28,6 +28,9 @@
         <SpinnerIcon class="loading-spinner" />
       </transition>
     </NavigatorCardInner>
+    <div aria-live="polite" class="visuallyhidden">
+      Navigator is {{ isFetching ? 'loading' : 'ready' }}
+    </div>
   </nav>
 </template>
 

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -210,6 +210,11 @@ describe('DocumentationTopic', () => {
     expect(main.attributes('tabindex')).toBe('0');
   });
 
+  it('renders an aria live that tells which it is the current page content', () => {
+    expect(wrapper.find('[aria-live="polite"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-live="polite"]').text()).toBe(`Current page is ${propsData.title}`);
+  });
+
   it('renders a `DocumentationHero`, enabled', () => {
     const hero = wrapper.find(DocumentationHero);
     expect(hero.exists()).toBe(true);

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -210,7 +210,7 @@ describe('DocumentationTopic', () => {
     expect(main.attributes('tabindex')).toBe('0');
   });
 
-  it('renders an aria live that tells which it is the current page content', () => {
+  it('renders an aria live that tells VO users which it is the current page content', () => {
     expect(wrapper.find('[aria-live="polite"]').exists()).toBe(true);
     expect(wrapper.find('[aria-live="polite"]').text()).toBe(`Current page is ${propsData.title}`);
   });

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -148,6 +148,22 @@ describe('Navigator', () => {
     expect(placeholder.contains(SpinnerIcon)).toBe(true);
   });
 
+  it('renders an aria live that tells VO users when navigator is loading', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        isFetching: true,
+      },
+    });
+    expect(wrapper.find('[aria-live="polite"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-live="polite"]').text()).toBe('Navigator is loading');
+  });
+
+  it('renders an aria live that tells VO users when navigator is ready', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('[aria-live="polite"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-live="polite"]').text()).toBe('Navigator is ready');
+  });
+
   it('falls back to using the `technology.url` for the `technology-path`', () => {
     const wrapper = createWrapper({
       propsData: {


### PR DESCRIPTION
Bug/issue #91649938, if applicable: 

## Summary

The 3 states are:
-  Router changes into a new page
-  Navigation is loading
-  Navigation is ready

## Dependencies

NA

## Testing

Steps:
1. Open a .doccarchive that has navigator
2. Turn on VoiceOver
3. Assert that when navigator is loading VoiceOver notify the user about it
4. Assert that when navigator is reading VoiceOver notify the user about it
5. Click on another technology in the navigator and go to its page
6. Assert that VO notify that current page has been changed 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
