### PR TITLE
[5.7] Make sure navigator item focus styles are only applied with keyboard navigation

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -248,13 +248,15 @@ $nesting-spacing: $card-horizontal-spacing + $card-horizontal-spacing-small;
   display: flex;
   align-items: center;
 
-  &:focus-within {
-    margin: $card-horizontal-spacing-small;
-    height: $item-height - 10px;
-    @include focus-outline();
+  .fromkeyboard & {
+    &:focus-within {
+      margin: $card-horizontal-spacing-small;
+      height: $item-height - 10px;
+      @include focus-outline();
 
-    .depth-spacer {
-      margin-left: -$card-horizontal-spacing-small;
+      .depth-spacer {
+        margin-left: -$card-horizontal-spacing-small;
+      }
     }
   }
 }


### PR DESCRIPTION
- **Rationale:** Fixes a small css bug, where focus outlines are shown when mouse clicks are used, causing issues both visually, and when clicking on the edge of the item as well.
- **Risk:** Low
- **Risk Detail:** Minor CSS refactor on isolated item
- **Reward:** High
- **Reward Details:** Removes keyboard-only navigation styling when using mouse, and fixes click area of navigator items
- **Original PR:** https://github.com/apple/swift-docc-render/pull/307
- **Issue:** rdar://93331047
- **Code Reviewed By:** @marinaaisa  
- **Testing Details:** Visually inspected in the browser