### PR TITLE
Fix API Changes highlight cut off for relationship section in S viewport

### DIFF
--- a/src/components/DocumentationTopic/RelationshipsList.vue
+++ b/src/components/DocumentationTopic/RelationshipsList.vue
@@ -160,6 +160,7 @@ export default {
      // ensure that column layout stays a block content
     &.column {
       display: block;
+      box-sizing: border-box;
     }
   }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 93456752

## Summary
Fix a regression caused by the content style redesign where API changes highlight box is cut off on the right in S viewport

## Testing
Manually verify in browser

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
