### PR TITLE
[5.7-04252022] Ensure navigator unlocks scrolling when navigating away

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -280,7 +280,6 @@ export default {
      */
     toggleScrollLock(lock) {
       const scrollLockContainer = document.getElementById(this.scrollLockID);
-      if (!scrollLockContainer) return;
       if (lock) {
         scrollLock.lockScroll(scrollLockContainer);
         // lock focus

--- a/src/utils/scroll-lock.js
+++ b/src/utils/scroll-lock.js
@@ -63,8 +63,10 @@ function simpleLock() {
 function advancedUnlock(targetElement) {
   /* eslint-disable no-param-reassign */
   // remove the touch listeners on the target
-  targetElement.ontouchstart = null;
-  targetElement.ontouchmove = null;
+  if (targetElement) {
+    targetElement.ontouchstart = null;
+    targetElement.ontouchmove = null;
+  }
   // remove the body event listener
   document.removeEventListener('touchmove', preventDefault);
 }
@@ -97,6 +99,9 @@ function handleScroll(event, targetElement) {
  * @param targetElement
  */
 function advancedLock(targetElement) {
+  // add a scroll listener to the body
+  document.addEventListener('touchmove', preventDefault, { passive: false });
+  if (!targetElement) return;
   /* eslint-disable no-param-reassign */
   // add inline listeners to the target, for easier removal later.
   targetElement.ontouchstart = (event) => {
@@ -111,8 +116,6 @@ function advancedLock(targetElement) {
       handleScroll(event, targetElement);
     }
   };
-  // add a scroll listener to the body
-  document.addEventListener('touchmove', preventDefault, { passive: false });
 }
 
 /**

--- a/tests/unit/utils/scroll-lock.spec.js
+++ b/tests/unit/utils/scroll-lock.spec.js
@@ -112,6 +112,17 @@ describe('scroll-lock', () => {
       expect(preventDefault).toHaveBeenCalledTimes(1);
     });
 
+    it('does not throw, if not passed an element', () => {
+      expect(() => scrollLock.lockScroll(null)).not.toThrow();
+      // assert body scroll is getting prevented when swiping up/down
+      document.dispatchEvent(createEvent('touchmove', {
+        preventDefault,
+        touches: [1],
+      }));
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      expect(() => scrollLock.unlockScroll(null)).not.toThrow();
+    });
+
     it('attaches only once event listeners', () => {
       // enable scroll locking
       scrollLock.lockScroll(container);


### PR DESCRIPTION
- **Rationale:** Fixes a bug where scrolling is locked, when navigating to a tutorial page from docs on mobile
- **Risk:** Low
- **Risk Detail:** Minor JS change to allow unlocking scrolling, even if lock target is no longer in the DOM.
- **Reward:** High
- **Reward Details:** Users can scroll the page
- **Original PR:** https://github.com/apple/swift-docc-render/pull/303
- **Issue:** rdar://93478881
- **Code Reviewed By:** @mportiz08 
- **Testing Details:** Updated unit tests and manually tested in the browser.