### PR TITLE
[5.7] Fix console error when navigating up/down in navigator

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -205,10 +205,10 @@ export default {
       this.toggleTree();
     },
     clickReference() {
-      this.$refs.reference.$el.click();
+      (this.$refs.reference.$el || this.$refs.reference).click();
     },
     focusReference() {
-      this.$refs.reference.$el.focus();
+      (this.$refs.reference.$el || this.$refs.reference).focus();
     },
     handleClick() {
       if (this.isGroupMarker) return;


### PR DESCRIPTION
- **Rationale:** Fixes a bug where a console error gets thrown and headings are skipped, when navigating up/down in Navigator.
- **Risk:** Low
- **Risk Detail:** Minor JS change to allow focusing across headings in navigator.
- **Reward:** High
- **Reward Details:** Users will not get errors in JS console and skipped items in Navigator
- **Original PR:** https://github.com/apple/swift-docc-render/pull/306
- **Issue:** rdar://93332275
- **Code Reviewed By:** @marinaaisa @hqhhuang 
- **Testing Details:** Updated unit tests and manually tested in the browser.