### PR TITLE
Remove the license header from generated HTML files

### DIFF
--- a/src/setup-utils/license-header-built-files.js
+++ b/src/setup-utils/license-header-built-files.js
@@ -19,34 +19,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for Swift project authors`;
 
-const wrapCommentHTML = str => `<!--\n  ${str
-  .replace(/\*\//g, '* /')
-  .split('\n')
-  .join('\n  ')
-  .replace(/\s+\n/g, '\n\n')
-  .trimRight()}\n-->\n\n`;
-
-/**
- * Adds license header to HTML built files
- * @param {string} - license header
- */
-class HTMLBannerPlugin {
-  constructor(licenseHeader) {
-    this.licenseHeader = wrapCommentHTML(licenseHeader);
-  }
-
-  apply(compiler) {
-    compiler.hooks.compilation.tap('HTMLBannerPlugin', (compilation) => {
-      compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tap(
-        'HTMLBannerPlugin',
-        (data) => {
-          const HTMLData = data;
-          HTMLData.html = this.licenseHeader + HTMLData.html;
-          return HTMLData;
-        },
-      );
-    });
-  }
-}
-
-module.exports = { BannerPlugin, HTMLBannerPlugin, LICENSE_HEADER };
+module.exports = { BannerPlugin, LICENSE_HEADER };

--- a/src/setup-utils/vue-config-utils.js
+++ b/src/setup-utils/vue-config-utils.js
@@ -13,7 +13,7 @@ const path = require('path');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const ThemeResolverPlugin = require('webpack-theme-resolver-plugin');
 const themeUtils = require('./theme-build-utils');
-const { BannerPlugin, HTMLBannerPlugin, LICENSE_HEADER } = require('./license-header-built-files');
+const { BannerPlugin, LICENSE_HEADER } = require('./license-header-built-files');
 
 function addENVDefaults() {
   if (typeof process.env.VUE_APP_TITLE === 'undefined') {
@@ -70,13 +70,6 @@ function baseChainWebpack(config) {
     .use(BannerPlugin, [{
       banner: LICENSE_HEADER,
     }]);
-
-  // Add license header to HTML built files
-  if (process.env.NODE_ENV === 'production') {
-    config
-      .plugin('HTMLBannerPlugin')
-      .use(HTMLBannerPlugin, [LICENSE_HEADER]);
-  }
 }
 
 function baseDevServer({ defaultDevServerProxy = 'http://localhost:8000' } = {}) {


### PR DESCRIPTION
Bug/issue #, if applicable: 93453002. closes #271 

## Summary

Removes the license headers from the generated HTML files

## Dependencies

NA

## Testing

Steps:
1. run `npm run build`
2. Assert there no license headers in the generated HTML files

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
