### PR TITLE
Properly align ChapterTopicList links to the icon, when no time estimate is passed

### DIFF
--- a/src/components/TutorialsOverview/ChapterTopicList.vue
+++ b/src/components/TutorialsOverview/ChapterTopicList.vue
@@ -10,7 +10,12 @@
 
 <template>
   <ol class="topic-list">
-    <li v-for="topic in topics" class="topic" :class="kindClassFor(topic)" :key="topic.url">
+    <li
+      v-for="topic in topics"
+      :key="topic.url"
+      :class="[kindClassFor(topic), { 'no-time-estimate': !topic.estimatedTime }]"
+      class="topic"
+    >
       <div class="topic-icon">
         <component :is="iconComponent(topic)" />
       </div>
@@ -207,6 +212,15 @@ $circle-diameter: $circle-radius * 2;
   .topic {
     height: auto;
     align-items: flex-start;
+
+    &.no-time-estimate {
+      align-items: center;
+
+      .topic-icon {
+        align-self: flex-start;
+        top: 0;
+      }
+    }
 
     & + & {
       margin-top: rem(20px);

--- a/tests/unit/components/TutorialsOverview/ChapterTopicList.spec.js
+++ b/tests/unit/components/TutorialsOverview/ChapterTopicList.spec.js
@@ -35,7 +35,6 @@ describe('ChapterTopicList', () => {
       },
       {
         kind: TopicKind.article,
-        estimatedTime: '4min',
         title: 'Bar',
         url: '/tutorials/blah/bar',
       },
@@ -67,7 +66,7 @@ describe('ChapterTopicList', () => {
     items.wrappers.forEach((item, i) => {
       const topic = propsData.topics[i];
       const {
-        title, url, kind,
+        title, url, kind, estimatedTime,
       } = topic;
 
       const link = item.find(RouterLinkStub);
@@ -76,11 +75,16 @@ describe('ChapterTopicList', () => {
 
       expect(link.find('.link').text()).toBe(title);
       expect(link.attributes('aria-label'))
-        .toBe(`${title} - ${TopicKindIconLabel[kind]} - 4 minutes Estimated Time`);
+        .toBe(`${title} - ${TopicKindIconLabel[kind]}${estimatedTime ? ' - 4 minutes Estimated Time' : ''}`);
 
-      const time = item.find('.time');
-      expect(time.find('.time-label').text()).toBe(propsData.topics[i].estimatedTime);
-      expect(time.contains(TimerIcon)).toBe(true);
+      if (estimatedTime) {
+        const time = item.find('.time');
+        expect(time.find('.time-label').text()).toBe(estimatedTime);
+        expect(time.contains(TimerIcon)).toBe(true);
+      } else {
+        expect(item.classes()).toContain('no-time-estimate');
+        expect(item.find('.time').exists()).toBeFalsy();
+      }
     });
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 93444894

## Summary

In TutorialOverviews, when there is no time estimate provided for a tutorial, on mobile the link text is not aligned with the icon.

![image](https://user-images.githubusercontent.com/9863944/169004302-32d9621e-0099-441c-8b42-819197583c05.png)


## Dependencies

NA

## Testing

Steps:
1. Use an archive that has tutorials without time estimates
2. On mobile size, assert that links are properly alligned

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
