### PR TITLE
[5.7] Fix API Changes highlight cut off for relationship section in S viewport

### DIFF
--- a/src/components/DocumentationTopic/RelationshipsList.vue
+++ b/src/components/DocumentationTopic/RelationshipsList.vue
@@ -160,6 +160,7 @@ export default {
      // ensure that column layout stays a block content
     &.column {
       display: block;
+      box-sizing: border-box;
     }
   }
 }


### PR DESCRIPTION
- Rationale: Fix a regression caused by the content style redesign where API changes highlight box is cut off on the right in S viewport
- Risk: Low
- Risk Detail: Change only affects small viewport when API change is turned on
- Reward: High
- Reward Details: Fixes regression and broken UI
- Original PR: https://github.com/apple/swift-docc-render/pull/313
- Issue: rdar://93456752
- Code Reviewed By: @dobromir-hristov
- Testing Details: Manual test in browser