### PR TITLE
Add test for new language switcher prop for DocumentationHero 

### DIFF
--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -80,12 +80,14 @@ describe('DocumentationHero', () => {
 
   it('renders the right classes based on `shouldShowLanguageSwitcher` prop', () => {
     const wrapper = createWrapper();
-    expect(wrapper.find('.extra-bottom-padding').exists()).toBe(true);
+    const content = wrapper.find('.documentation-hero__content');
+    
+    expect(content.classes()).toContain('extra-bottom-padding');
 
     wrapper.setProps({
       shouldShowLanguageSwitcher: false,
     });
-    expect(wrapper.find('.extra-bottom-padding').exists()).toBe(false);
+    expect(content.classes()).not.toContain('extra-bottom-padding');
   });
 
   it('finds aliases, for the color', () => {

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -19,6 +19,7 @@ const defaultProps = {
   role: TopicTypes.class,
   enhanceBackground: true,
   shortHero: true,
+  shouldShowLanguageSwitcher: true,
 };
 
 const createWrapper = ({ propsData, ...others } = {}) => shallowMount(DocumentationHero, {
@@ -75,6 +76,16 @@ describe('DocumentationHero', () => {
       shortHero: false,
     });
     expect(wrapper.find('.short-hero').exists()).toBe(false);
+  });
+
+  it('renders the right classes based on `shouldShowLanguageSwitcher` prop', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('.extra-bottom-padding').exists()).toBe(true);
+
+    wrapper.setProps({
+      shouldShowLanguageSwitcher: false,
+    });
+    expect(wrapper.find('.extra-bottom-padding').exists()).toBe(false);
   });
 
   it('finds aliases, for the color', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 93050293

## Summary
This PR adds a test for the new language switchr prop for DocumentationHero and will fix vue warning in CI

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
