### PR TITLE
[5.7] Remove the license header from generated HTML files

### DIFF
--- a/bin/check-source
+++ b/bin/check-source
@@ -61,7 +61,7 @@ EOF
 EOF
       ;;
       markup)
-        matching_files=( -name '*.html' -o -name '*.vue' -o -name '*.svg' )
+        matching_files=( -name '*.vue' -o -name '*.svg' )
         cat > "$tmp" <<"EOF"
 <!--
   This source file is part of the Swift.org open source project

--- a/src/setup-utils/license-header-built-files.js
+++ b/src/setup-utils/license-header-built-files.js
@@ -19,34 +19,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for Swift project authors`;
 
-const wrapCommentHTML = str => `<!--\n  ${str
-  .replace(/\*\//g, '* /')
-  .split('\n')
-  .join('\n  ')
-  .replace(/\s+\n/g, '\n\n')
-  .trimRight()}\n-->\n\n`;
-
-/**
- * Adds license header to HTML built files
- * @param {string} - license header
- */
-class HTMLBannerPlugin {
-  constructor(licenseHeader) {
-    this.licenseHeader = wrapCommentHTML(licenseHeader);
-  }
-
-  apply(compiler) {
-    compiler.hooks.compilation.tap('HTMLBannerPlugin', (compilation) => {
-      compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tap(
-        'HTMLBannerPlugin',
-        (data) => {
-          const HTMLData = data;
-          HTMLData.html = this.licenseHeader + HTMLData.html;
-          return HTMLData;
-        },
-      );
-    });
-  }
-}
-
-module.exports = { BannerPlugin, HTMLBannerPlugin, LICENSE_HEADER };
+module.exports = { BannerPlugin, LICENSE_HEADER };

--- a/src/setup-utils/vue-config-utils.js
+++ b/src/setup-utils/vue-config-utils.js
@@ -13,7 +13,7 @@ const path = require('path');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const ThemeResolverPlugin = require('webpack-theme-resolver-plugin');
 const themeUtils = require('./theme-build-utils');
-const { BannerPlugin, HTMLBannerPlugin, LICENSE_HEADER } = require('./license-header-built-files');
+const { BannerPlugin, LICENSE_HEADER } = require('./license-header-built-files');
 
 function addENVDefaults() {
   if (typeof process.env.VUE_APP_TITLE === 'undefined') {
@@ -70,13 +70,6 @@ function baseChainWebpack(config) {
     .use(BannerPlugin, [{
       banner: LICENSE_HEADER,
     }]);
-
-  // Add license header to HTML built files
-  if (process.env.NODE_ENV === 'production') {
-    config
-      .plugin('HTMLBannerPlugin')
-      .use(HTMLBannerPlugin, [LICENSE_HEADER]);
-  }
 }
 
 function baseDevServer({ defaultDevServerProxy = 'http://localhost:8000' } = {}) {


### PR DESCRIPTION
- **Rationale:** Removes the license header from generated HTML files.
- **Risk:** Low
- **Risk Detail:** Minor build-time configuration change.
- **Reward:** High
- **Reward Details:** Users will not get the apple license embedded into their public facing HTML pages.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/316
- **Issue:** rdar://93453002
- **Code Reviewed By:** @mportiz08
- **Testing Details:** Updated tests and ran test-builds to manually verify