### PR TITLE
[5.7] Add test for new language switcher prop for DocumentationHero

### DIFF
--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -19,6 +19,7 @@ const defaultProps = {
   role: TopicTypes.class,
   enhanceBackground: true,
   shortHero: true,
+  shouldShowLanguageSwitcher: true,
 };
 
 const createWrapper = ({ propsData, ...others } = {}) => shallowMount(DocumentationHero, {
@@ -75,6 +76,18 @@ describe('DocumentationHero', () => {
       shortHero: false,
     });
     expect(wrapper.find('.short-hero').exists()).toBe(false);
+  });
+
+  it('renders the right classes based on `shouldShowLanguageSwitcher` prop', () => {
+    const wrapper = createWrapper();
+    const content = wrapper.find('.documentation-hero__content');
+    
+    expect(content.classes()).toContain('extra-bottom-padding');
+
+    wrapper.setProps({
+      shouldShowLanguageSwitcher: false,
+    });
+    expect(content.classes()).not.toContain('extra-bottom-padding');
   });
 
   it('finds aliases, for the color', () => {


### PR DESCRIPTION
- **Rationale:** Added missing test for the new language switcher prop for DocumentationHero
- **Risk:** Low
- **Risk Detail:** Only modified test
- **Reward:** High
- **Reward Details:** Fixes a cue warning in CI 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/321
- **Issue:** rdar://93050293
- **Code Reviewed By:** @dobromir-hristov 
- **Testing Details:** Only updated test, run `npm run test` to verify