### PR TITLE
Prevent swift code samples from wrong highlighting keywords

### DIFF
--- a/src/utils/custom-highlight-lang/swift.js
+++ b/src/utils/custom-highlight-lang/swift.js
@@ -37,7 +37,7 @@ export default function (hljs) {
     // recognize class function declarations as class declarations
     language.contains[classModeIndex] = {
       ...classMode,
-      begin: /(struct|protocol|extension|enum|actor|class\b(?!.*\bfunc\b))/,
+      begin: /\b(struct|protocol|extension|enum|actor|class\b(?!.*\bfunc))\b/,
     };
   }
 

--- a/tests/unit/utils/custom-highlight-lang/swift.spec.js
+++ b/tests/unit/utils/custom-highlight-lang/swift.spec.js
@@ -37,7 +37,7 @@ describe('swift', () => {
 
     it('does have a new `begin` attribute', () => {
       expect(mode.begin)
-        .toEqual(/(struct|protocol|extension|enum|actor|class\b(?!.*\bfunc\b))/);
+        .toEqual(/\b(struct|protocol|extension|enum|actor|class\b(?!.*\bfunc))\b/);
     });
   });
 });

--- a/tests/unit/utils/syntax-highlight.spec.js
+++ b/tests/unit/utils/syntax-highlight.spec.js
@@ -134,7 +134,7 @@ describe("syntax-highlight", () => {
     );
   });
 
-  it("does not tokenizes swift keywords inside words", async () => {
+  it("does not tokenize swift keywords inside words", async () => {
     const content = [
       "var protocolMock = true  // 'protocol' is not highlighted",
       "var myenum = true  // 'enum' is not highlighted",

--- a/tests/unit/utils/syntax-highlight.spec.js
+++ b/tests/unit/utils/syntax-highlight.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 /* eslint-disable */
 

--- a/tests/unit/utils/syntax-highlight.spec.js
+++ b/tests/unit/utils/syntax-highlight.spec.js
@@ -6,14 +6,14 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 /* eslint-disable */
 
 import {
   LanguageAliasEntries,
   SupportedLanguagesSet,
-  sanitizeMultilineNodes
+  sanitizeMultilineNodes,
 } from "docc-render/utils/syntax-highlight";
 
 let hljs;
@@ -40,7 +40,7 @@ async function prepare(content, language) {
   const sanitizedCode = highlightContent(content, language);
   return {
     highlightedCode: tempElement.innerHTML,
-    sanitizedCode: sanitizedCode.join("\n") // revert back to string
+    sanitizedCode: sanitizedCode.join("\n"), // revert back to string
   };
 }
 
@@ -51,12 +51,8 @@ describe("syntax-highlight", () => {
   beforeEach(async () => {
     jest.resetModules();
     hljs = await import("highlight.js/lib/core");
-    ({
-      highlightContent,
-      highlight,
-      registerHighlightLanguage,
-      LanguageAliasCacheMap
-    } = await import("docc-render/utils/syntax-highlight"));
+    ({ highlightContent, highlight, registerHighlightLanguage, LanguageAliasCacheMap } =
+      await import("docc-render/utils/syntax-highlight"));
   });
 
   it("does nothing to single row syntax", async () => {
@@ -78,7 +74,7 @@ describe("syntax-highlight", () => {
       "        (___)(_(_/_(_ //_ (__",
       "                     /)",
       "                    (/",
-      '        """'
+      '        """',
     ];
     const { highlightedCode, sanitizedCode } = await prepare(content, "swift");
     expect(sanitizedCode).not.toEqual(highlightedCode);
@@ -100,7 +96,7 @@ describe("syntax-highlight", () => {
       "          bar,",
       "          baz) {",
       "  foo()",
-      "}"
+      "}",
     ];
     const { highlightedCode, sanitizedCode } = await prepare(content, "js");
     expect(sanitizedCode).not.toEqual(highlightedCode);
@@ -136,6 +132,24 @@ describe("syntax-highlight", () => {
     expect(highlightedCode).toMatchInlineSnapshot(
       `<span class="syntax-keyword">class</span> <span class="syntax-keyword">func</span> <span class="syntax-title function_">foo</span>() <span class="syntax-keyword">async</span> <span class="syntax-keyword">throws</span> -&gt; [<span class="syntax-type">Bar</span>]`
     );
+  });
+
+  it("does not tokenizes swift keywords inside words", async () => {
+    const content = [
+      "var protocolMock = true  // 'protocol' is not highlighted",
+      "var myenum = true  // 'enum' is not highlighted",
+      "if FooConfig.supportsReconstruction(.someClassification) {",
+      "    configuration.fooReconstruction = .someprotocolextensionclass",
+      "}",
+    ];
+    const { highlightedCode } = await prepare(content, "swift");
+    expect(highlightedCode).toMatchInlineSnapshot(`
+      <span class="syntax-keyword">var</span> protocolMock <span class="syntax-operator">=</span> <span class="syntax-literal">true</span> <span class="syntax-comment">// 'protocol' is not highlighted</span>
+      <span class="syntax-keyword">var</span> myenum <span class="syntax-operator">=</span> <span class="syntax-literal">true</span> <span class="syntax-comment">// 'enum' is not highlighted</span>
+      <span class="syntax-keyword">if</span> <span class="syntax-type">FooConfig</span>.supportsReconstruction(.someClassification) {
+      configuration.fooReconstruction <span class="syntax-operator">=</span> .someprotocolextensionclass
+      }
+    `);
   });
 
   it('tokenizes docc "documentation markup" for markdown language', async () => {
@@ -177,7 +191,7 @@ describe("syntax-highlight", () => {
       "",
       "<doc:FakeSymbol>",
       "",
-      "<doc:/path/to/fakesymbol>"
+      "<doc:/path/to/fakesymbol>",
     ];
     const { highlightedCode } = await prepare(content, "markdown");
     expect(highlightedCode).toMatchInlineSnapshot(`
@@ -273,15 +287,15 @@ describe("syntax-highlight", () => {
 
   it.each([...SupportedLanguagesSet])(
     'does not thrown an error when the language is "%s"',
-    async language => {
+    async (language) => {
       await registerHighlightLanguage(language);
       expect(tryHighlight("foo", language)).not.toThrow();
     }
   );
 
-  describe('custom aliases', () => {
+  describe("custom aliases", () => {
     it('does not throw an error when the language is "objective-c"', async () => {
-      const language = 'objective-c';
+      const language = "objective-c";
       await registerHighlightLanguage(language);
       expect(tryHighlight("foo", language)).not.toThrow();
     });


### PR DESCRIPTION
Bug/issue #, if applicable: 93358075
fixes #279 

## Summary

Fixes a custom regex logic we have for detecting class functions in Swift code samples.

![image](https://user-images.githubusercontent.com/9863944/169329527-2877e201-155e-45aa-9065-542e0924cfd3.png)


## Dependencies

NA

## Testing

You can use the archive attached

[TinyMixedLanguageLibrary 2.doccarchive.zip](https://github.com/apple/swift-docc-render/files/8730599/TinyMixedLanguageLibrary.2.doccarchive.zip)

Steps:
1. Go to http://localhost:8080/documentation/tinymixedlanguagelibrary?language=objc
2. Assert the code sample is correctly highlighted

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
