### PR TITLE
[5.7] Vertically align ChapterTopicList links to icons, with no time estimations

### DIFF
--- a/src/components/TutorialsOverview/ChapterTopicList.vue
+++ b/src/components/TutorialsOverview/ChapterTopicList.vue
@@ -10,7 +10,12 @@
 
 <template>
   <ol class="topic-list">
-    <li v-for="topic in topics" class="topic" :class="kindClassFor(topic)" :key="topic.url">
+    <li
+      v-for="topic in topics"
+      :key="topic.url"
+      :class="[kindClassFor(topic), { 'no-time-estimate': !topic.estimatedTime }]"
+      class="topic"
+    >
       <div class="topic-icon">
         <component :is="iconComponent(topic)" />
       </div>
@@ -207,6 +212,15 @@ $circle-diameter: $circle-radius * 2;
   .topic {
     height: auto;
     align-items: flex-start;
+
+    &.no-time-estimate {
+      align-items: center;
+
+      .topic-icon {
+        align-self: flex-start;
+        top: 0;
+      }
+    }
 
     & + & {
       margin-top: rem(20px);

--- a/tests/unit/components/TutorialsOverview/ChapterTopicList.spec.js
+++ b/tests/unit/components/TutorialsOverview/ChapterTopicList.spec.js
@@ -35,7 +35,6 @@ describe('ChapterTopicList', () => {
       },
       {
         kind: TopicKind.article,
-        estimatedTime: '4min',
         title: 'Bar',
         url: '/tutorials/blah/bar',
       },
@@ -67,7 +66,7 @@ describe('ChapterTopicList', () => {
     items.wrappers.forEach((item, i) => {
       const topic = propsData.topics[i];
       const {
-        title, url, kind,
+        title, url, kind, estimatedTime,
       } = topic;
 
       const link = item.find(RouterLinkStub);
@@ -76,11 +75,16 @@ describe('ChapterTopicList', () => {
 
       expect(link.find('.link').text()).toBe(title);
       expect(link.attributes('aria-label'))
-        .toBe(`${title} - ${TopicKindIconLabel[kind]} - 4 minutes Estimated Time`);
+        .toBe(`${title} - ${TopicKindIconLabel[kind]}${estimatedTime ? ' - 4 minutes Estimated Time' : ''}`);
 
-      const time = item.find('.time');
-      expect(time.find('.time-label').text()).toBe(propsData.topics[i].estimatedTime);
-      expect(time.contains(TimerIcon)).toBe(true);
+      if (estimatedTime) {
+        const time = item.find('.time');
+        expect(time.find('.time-label').text()).toBe(estimatedTime);
+        expect(time.contains(TimerIcon)).toBe(true);
+      } else {
+        expect(item.classes()).toContain('no-time-estimate');
+        expect(item.find('.time').exists()).toBeFalsy();
+      }
     });
   });
 


### PR DESCRIPTION
- **Rationale:** In Tutorial Overviews, when there is no time estimate provided for a tutorial, on mobile the link text is not aligned with the icon.
- **Risk:** Low
- **Risk Detail:** Changes vertical alignment of the links, only on items without an estimation.
- **Reward:** Medium
- **Reward Details:** Users will get vertically offset items on mobile
- **Original PR:** https://github.com/apple/swift-docc-render/pull/317
- **Issue:** rdar://93444894
- **Code Reviewed By:** @mportiz08
- **Testing Details:** Updated tests and tested manually in the browser