### PR TITLE
[5.7] Fix scrollbars not showing for CodeListing in Safari

### DIFF
--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -154,7 +154,8 @@ export default {
 pre {
   padding: $code-listing-with-numbers-padding;
   display: flex;
-  overflow: auto;
+  // set as `unset` to fix a Safari issue, where the scrollbar is hidden until you resize window
+  overflow: unset;
   -webkit-overflow-scrolling: touch;
   white-space: pre;
   word-wrap: normal;


### PR DESCRIPTION
- **Rationale:** Fixes a bug where codelisting scrollbars are sometimes hidden in Safari, until you resize the screen.
- **Risk:** Low
- **Risk Detail:** Small isolated CSS fix
- **Reward:** Medium
- **Reward Details:** Safari users will always see scrollbars, when they are needed
- **Original PR:** https://github.com/apple/swift-docc-render/pull/305
- **Issue:** rdar://78783950
- **Code Reviewed By:** @mportiz08
- **Testing Details:** Tested manually in the browser