### PR TITLE
[5.7] Remove extra spacing from navigator bottom

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -157,13 +157,19 @@ export default {
   },
   async mounted() {
     window.addEventListener('keydown', this.onEscapeKeydown);
-    window.addEventListener('resize', this.storeWindowSize);
-    window.addEventListener('orientationchange', this.storeWindowSize);
+    window.addEventListener('resize', this.storeWindowSize, { passive: true });
+    window.addEventListener('orientationchange', this.storeWindowSize, { passive: true });
+
+    this.storeTopOffset();
+    if (!(this.topOffset === 0 && window.scrollY === 0)) {
+      window.addEventListener('scroll', this.storeTopOffset, { passive: true });
+    }
 
     this.$once('hook:beforeDestroy', () => {
       window.removeEventListener('keydown', this.onEscapeKeydown);
       window.removeEventListener('resize', this.storeWindowSize);
       window.removeEventListener('orientationchange', this.storeWindowSize);
+      window.removeEventListener('scroll', this.storeTopOffset);
       if (this.openExternally) {
         this.toggleScrollLock(false);
       }
@@ -172,7 +178,6 @@ export default {
 
     await this.$nextTick();
     this.focusTrapInstance = new FocusTrap(this.$refs.aside);
-    this.topOffset = this.getTopOffset();
   },
   watch: {
     // make sure a route navigation closes the sidebar
@@ -292,6 +297,9 @@ export default {
         changeElementVOVisibility.show(this.$refs.aside);
       }
     },
+    storeTopOffset: throttle(function storeTopOffset() {
+      this.topOffset = this.getTopOffset();
+    }, 60),
   },
 };
 </script>

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1196,6 +1196,7 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
   box-sizing: border-box;
   padding: var(--card-vertical-spacing) 0;
   padding-bottom: calc(var(--top-offset, 0px) + var(--card-vertical-spacing));
+  transition: padding-bottom ease-in 0.15s;
 
   @include breakpoint(medium, nav) {
     padding-bottom: $nav-menu-items-ios-bottom-spacing;


### PR DESCRIPTION
- **Rationale:** Fixes a bug where there is always extra space at the bottom of the navigator, when there are extra items above the navigation
- **Risk:** Low
- **Risk Detail:** Animates the extra space away as you scroll down, noticeable in very specific conditions
- **Reward:** Low
- **Reward Details:** Users will not have extra space when they scroll down to the end of the Navigator list.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/298
- **Issue:** rdar://91002984
- **Code Reviewed By:** @mportiz08
- **Testing Details:** Tested manually in the browser and added unit tests