### PR TITLE
[5.7] Fix iOS navigator not calculating height properly

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -104,6 +104,7 @@ export default {
   },
   data() {
     const windowWidth = window.innerWidth;
+    const windowHeight = window.innerHeight;
     const breakpoint = BreakpointName.large;
     // get the min width, in case we dont have a previously saved value
     const minWidth = calcWidthPercent(minWidthResponsivePercents[breakpoint]);
@@ -121,6 +122,7 @@ export default {
       width: Math.min(Math.max(storedWidth, minWidth), maxWidth),
       isTouch: false,
       windowWidth,
+      windowHeight,
       breakpoint,
       noTransition: false,
       isTransitioning: false,
@@ -138,10 +140,13 @@ export default {
     minWidth: ({ minWidthPercent, windowWidth }) => calcWidthPercent(minWidthPercent, windowWidth),
     widthInPx: ({ width }) => `${width}px`,
     events: ({ isTouch }) => (isTouch ? eventsMap.touch : eventsMap.mouse),
-    asideStyles: ({ widthInPx, mobileTopOffset, topOffset }) => ({
+    asideStyles: ({
+      widthInPx, mobileTopOffset, topOffset, windowHeight,
+    }) => ({
       width: widthInPx,
       '--top-offset': topOffset ? `${topOffset}px` : null,
       '--top-offset-mobile': `${mobileTopOffset}px`,
+      '--app-height': `${windowHeight}px`,
     }),
     asideClasses: ({
       isDragging, openExternally, noTransition, isTransitioning, mobileTopOffset,
@@ -220,6 +225,7 @@ export default {
     storeWindowSize: throttle(async function storeWindowSize() {
       await this.$nextTick();
       this.windowWidth = window.innerWidth;
+      this.windowHeight = window.innerHeight;
     }, 100),
     closeMobileSidebar() {
       if (!this.openExternally) return;
@@ -337,7 +343,7 @@ export default {
     overflow: hidden;
     min-width: 0;
     max-width: 100%;
-    height: calc(100vh - var(--top-offset-mobile));
+    height: calc(var(--app-height) - var(--top-offset-mobile));
     position: fixed;
     top: var(--top-offset-mobile);
     bottom: 0;

--- a/src/components/Navigator/NavigatorCardInner.vue
+++ b/src/components/Navigator/NavigatorCardInner.vue
@@ -23,7 +23,7 @@ export default { name: 'NavigatorCardInner' };
   --nav-card-inner-vertical-offset: 0px;
   position: sticky;
   top: var(--nav-height);
-  height: calc(100vh - var(--nav-height) - var(--nav-card-inner-vertical-offset));
+  height: calc(var(--app-height) - var(--nav-height) - var(--nav-card-inner-vertical-offset));
   display: flex;
   flex-flow: column;
   @include breakpoint(medium, nav) {

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -23,3 +23,7 @@
 #main {
   outline-style: none;
 }
+
+:root {
+  --app-height: 100vh;
+}

--- a/tests/unit/components/AdjustableSidebarWidth.spec.js
+++ b/tests/unit/components/AdjustableSidebarWidth.spec.js
@@ -308,6 +308,23 @@ describe('AdjustableSidebarWidth', () => {
     assertWidth(wrapper, 250); // 20% out of 1000, as that is the min percentage
   });
 
+  it('stores the height of screen on orientationchange and resize', async () => {
+    const wrapper = createWrapper();
+
+    window.innerHeight = 500;
+    window.dispatchEvent(createEvent('resize'));
+    await flushPromises();
+    expect(wrapper.vm.asideStyles).toHaveProperty('--app-height', '500px');
+    window.innerHeight = 1000;
+    window.dispatchEvent(createEvent('resize'));
+    await flushPromises();
+    expect(wrapper.vm.asideStyles).toHaveProperty('--app-height', '1000px');
+    window.innerHeight = 700;
+    window.dispatchEvent(createEvent('orientationchange'));
+    await flushPromises();
+    expect(wrapper.vm.asideStyles).toHaveProperty('--app-height', '700px');
+  });
+
   it('allows dragging the handle to expand/contract the sidebar, with the mouse', () => {
     const wrapper = createWrapper();
     const aside = wrapper.find('.aside');


### PR DESCRIPTION
- **Rationale:** Fix a mis-calculation on iPads, where the height of the top and bottom safari navbars are not accounted for in the height of the navigator
- **Risk:** Low
- **Risk Detail:** Replaces a css only value with a JS generated one
- **Reward:** Low
- **Reward Details:** Only iOS users on a tablet will see a difference, when at the very top of the page
- **Original PR:** https://github.com/apple/swift-docc-render/pull/328
- **Issue:** rdar://93506244
- **Code Reviewed By:** @marinaaisa 
- **Testing Details:** Tested manually in the browser and added unit tests