### PR TITLE
[5.7] [AX] Keyboard navigation shouldn't tag on hidden items in the navigator

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -283,9 +283,10 @@ export default {
     /**
      * Toggles the scroll lock on/off
      */
-    toggleScrollLock(lock) {
+    async toggleScrollLock(lock) {
       const scrollLockContainer = document.getElementById(this.scrollLockID);
       if (lock) {
+        await this.$nextTick();
         scrollLock.lockScroll(scrollLockContainer);
         // lock focus
         this.focusTrapInstance.start();

--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -20,10 +20,11 @@
     class="documentation-nav"
     aria-label="API Reference"
   >
-    <template #pre-title="{ closeNav }" v-if="isWideFormat">
+    <template #pre-title="{ closeNav, isOpen }" v-if="isWideFormat">
       <button
         aria-label="Open documentation navigator"
         class="sidenav-toggle"
+        :tabindex="isOpen ? -1 : null"
         @click.prevent="handleSidenavToggle(closeNav)"
       >
         <SidenavIcon class="icon-inline sidenav-icon" />

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -20,7 +20,7 @@
       <div v-if="hasOverlay" class="nav-overlay" @click="closeNav" />
       <div class="nav-content">
         <div class="pre-title">
-          <slot name="pre-title" :close-nav="closeNav" />
+          <slot name="pre-title" :close-nav="closeNav" :is-open="isOpen" />
         </div>
         <div v-if="$slots.default" class="nav-title">
           <slot />

--- a/src/utils/FocusTrap.js
+++ b/src/utils/FocusTrap.js
@@ -45,11 +45,15 @@ export default class FocusTrap {
    */
   start() {
     this.collectTabTargets();
-
     // If the current active element is not in the container,
     // focus the first tab target available.
     if (this.firstTabTarget) {
-      if (!this.focusContainer.contains(document.activeElement)) {
+      if (
+        // check if the focus container does not contain the current element
+        !this.focusContainer.contains(document.activeElement)
+        // or if if the current element should not be focusable (mouse click still focuses)
+        || !TabManager.isTabbableElement(document.activeElement)
+      ) {
         this.firstTabTarget.focus();
       }
     } else {
@@ -88,7 +92,14 @@ export default class FocusTrap {
       event.preventDefault();
       this.collectTabTargets();
 
-      if (this.lastFocusedElement === this.lastTabTarget || !this.lastFocusedElement) {
+      if (
+        // if we are at the end of the tabbing list
+        this.lastFocusedElement === this.lastTabTarget
+        // or there is was no focused element at all
+        || !this.lastFocusedElement
+        // or the document no longer holds the reference to that element
+        || !document.contains(this.lastFocusedElement)
+      ) {
         this.firstTabTarget.focus();
         this.lastFocusedElement = this.firstTabTarget;
         return;

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -39,17 +39,20 @@
               :api-changes-version="store.state.selectedAPIChangesVersion"
             >
               <template #default="slotProps">
-                <Navigator
-                  :parent-topic-identifiers="parentTopicIdentifiers"
-                  :technology="slotProps.technology || technology"
-                  :is-fetching="slotProps.isFetching"
-                  :error-fetching="slotProps.errorFetching"
-                  :api-changes="slotProps.apiChanges"
-                  :references="topicProps.references"
-                  :scrollLockID="scrollLockID"
-                  :breakpoint="breakpoint"
-                  @close="isSideNavOpen = false"
-                />
+                <transition name="delay-hiding">
+                  <Navigator
+                    v-show="isSideNavOpen || breakpoint === BreakpointName.large"
+                    :parent-topic-identifiers="parentTopicIdentifiers"
+                    :technology="slotProps.technology || technology"
+                    :is-fetching="slotProps.isFetching"
+                    :error-fetching="slotProps.errorFetching"
+                    :api-changes="slotProps.apiChanges"
+                    :references="topicProps.references"
+                    :scrollLockID="scrollLockID"
+                    :breakpoint="breakpoint"
+                    @close="isSideNavOpen = false"
+                  />
+                </transition>
               </template>
             </NavigatorDataProvider>
           </aside>
@@ -88,6 +91,7 @@ import AdjustableSidebarWidth from 'docc-render/components/AdjustableSidebarWidt
 import Navigator from 'docc-render/components/Navigator.vue';
 import DocumentationNav from 'theme/components/DocumentationTopic/DocumentationNav.vue';
 import { compareVersions, combineVersions } from 'docc-render/utils/schema-version-check';
+import { BreakpointName } from 'docc-render/utils/breakpoints';
 
 const MIN_RENDER_JSON_VERSION_WITH_INDEX = '0.3.0';
 
@@ -109,6 +113,7 @@ export default {
       topicDataObjc: null,
       isSideNavOpen: false,
       store: DocumentationTopicStore,
+      BreakpointName,
     };
   },
   computed: {
@@ -349,9 +354,15 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .doc-topic-view {
+  --delay: 1s;
   display: flex;
   flex-flow: column;
   background: var(--colors-text-background, var(--color-text-background));
+
+  .delay-hiding-leave-active {
+    // don't hide navigator until delay time has passed
+    transition: display var(--delay);
+  }
 }
 
 .doc-topic-aside {

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -81,7 +81,7 @@ describe('DocumentationHero', () => {
   it('renders the right classes based on `shouldShowLanguageSwitcher` prop', () => {
     const wrapper = createWrapper();
     const content = wrapper.find('.documentation-hero__content');
-    
+
     expect(content.classes()).toContain('extra-bottom-padding');
 
     wrapper.setProps({

--- a/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
@@ -276,11 +276,14 @@ describe('DocumentationNav', () => {
   it('closes the nav, if open and clicking on the sidenavtoggle', async () => {
     wrapper.find('.nav-menucta').trigger('click');
     expect(wrapper.classes()).toContain('nav--is-open');
-    wrapper.find('.sidenav-toggle').trigger('click');
+    const toggle = wrapper.find('.sidenav-toggle');
+    expect(toggle.attributes()).toHaveProperty('tabindex', '-1');
+    toggle.trigger('click');
     expect(wrapper.classes()).not.toContain('nav--is-open');
     expect(wrapper.emitted('toggle-sidenav')).toBeFalsy();
     await flushPromises();
     expect(wrapper.emitted('toggle-sidenav')).toBeTruthy();
+    expect(toggle.attributes()).not.toHaveProperty('tabindex');
   });
 
   it('renders the nav, with `isWideFormat` to `false`', () => {

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -161,6 +161,19 @@ describe('NavBase', () => {
     expect(preTitle.find('.pre-title-slot').text()).toBe('Pre Title');
     expect(preTitleProps).toEqual({
       closeNav: expect.any(Function),
+      isOpen: false,
+    });
+    wrapper.find('a.nav-menucta').trigger('click');
+    expect(wrapper.classes()).toContain(NavStateClasses.isOpen);
+    expect(preTitleProps).toEqual({
+      closeNav: expect.any(Function),
+      isOpen: true,
+    });
+    preTitleProps.closeNav();
+    expect(wrapper.classes()).not.toContain(NavStateClasses.isOpen);
+    expect(preTitleProps).toEqual({
+      closeNav: expect.any(Function),
+      isOpen: false,
     });
   });
 

--- a/tests/unit/utils/FocusTrap.spec.js
+++ b/tests/unit/utils/FocusTrap.spec.js
@@ -17,6 +17,7 @@ const DOM = parseHTMLString(`
     <input class="first">
     <button class="second">Button</button>
     <a href="#" class="third">Anchor</a>
+    <a href="" tabindex="-1" class="none-tabbable">None Tabbable</a>
   </div>
   <button class="after">After</button>
 `);
@@ -28,6 +29,7 @@ const firstElement = DOM.querySelector('.first');
 const secondElement = DOM.querySelector('.second');
 const thirdElement = DOM.querySelector('.third');
 const afterElement = DOM.querySelector('.after');
+const noneTabbable = DOM.querySelector('.none-tabbable');
 
 let focusInstance;
 
@@ -62,8 +64,23 @@ describe('FocusTrap', () => {
     expect(document.activeElement).toEqual(firstElement);
   });
 
+  it('on start, moves focuses the first tabbable element, if `activeElement` is in container, but its not tabbable', () => {
+    // stop focus tracking
+    focusInstance.stop();
+    // focus a none tabbable element
+    noneTabbable.focus();
+    expect(document.activeElement).toEqual(noneTabbable);
+    // start the focus tracking again
+    focusInstance.start();
+    expect(document.activeElement).toEqual(firstElement);
+  });
+
   it('on start, does not focus the first target, if active element is inside container', () => {
+    focusInstance.stop();
+    expect(document.activeElement).toEqual(firstElement);
     thirdElement.focus();
+    expect(document.activeElement).toEqual(thirdElement);
+    focusInstance.start();
     expect(document.activeElement).toEqual(thirdElement);
   });
 
@@ -87,6 +104,19 @@ describe('FocusTrap', () => {
     beforeElement.focus();
     // assert the new focus target is the last available element
     expect(document.activeElement).toEqual(thirdElement);
+  });
+
+  it('on focus, moves focus the first element if focusing element that was focused last, but is no longer in DOM', () => {
+    // focus the last element
+    thirdElement.focus();
+    // now delete the last element
+    thirdElement.parentElement.removeChild(thirdElement);
+    // move focus outside
+    afterElement.focus();
+    // assert the new focus target is the first available element
+    expect(document.activeElement).toEqual(firstElement);
+    // revert the removal
+    containerElement.appendChild(thirdElement);
   });
 
   it('updates the container', () => {


### PR DESCRIPTION
- Rationale: Keyboard navigation shouldn't tag on hidden items in the navigator
- Risk: Low
- Risk Detail: It fixes FocusTrap and keyboard navigation
- Reward: Medium for keyboard navigation
- Reward Details: Keyboard navigation users won't tab on hidden elements
- Original PR: https://github.com/apple/swift-docc-render/pull/296
- Issue: rdar://91660503
- Code Reviewed By: @dobromir-hristov
- Testing Details: Tested manually in the browser and added unit tests