### PR TITLE
[AX] Localnav should not FocusTrap for documentation pages

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -12,6 +12,7 @@
   <NavBase
     :breakpoint="BreakpointName.medium"
     :hasOverlay="false"
+    preventFocusTrap
     hasSolidBackground
     :hasNoBorder="hasNoBorder"
     :isDark="isDark"

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -146,6 +146,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    preventFocusTrap: {
+      type: Boolean,
+      default: false,
+    },
   },
   mixins: [onIntersect],
   data() {
@@ -193,6 +197,7 @@ export default {
     document.addEventListener('click', this.handleClickOutside);
     this.handleFlashOnMount();
     await this.$nextTick();
+    if (this.preventFocusTrap) return;
     this.focusTrapInstance = new FocusTrap(this.$refs.wrapper);
   },
   beforeDestroy() {
@@ -203,6 +208,7 @@ export default {
     if (this.isOpen) {
       this.toggleScrollLock(false);
     }
+    if (this.preventFocusTrap) return;
     this.focusTrapInstance.destroy();
   },
   methods: {
@@ -226,6 +232,7 @@ export default {
       this.isTransitioning = false;
       if (this.isOpen) {
         this.$emit('opened');
+        if (this.preventFocusTrap) return;
         // toggle the scroll lock on/off if needed
         this.toggleScrollLock(true);
       } else {
@@ -298,6 +305,7 @@ export default {
     },
     onExpand() {
       this.$emit('open');
+      if (this.preventFocusTrap) return;
       // lock focus
       this.focusTrapInstance.start();
       // hide sibling elements from VO
@@ -305,6 +313,7 @@ export default {
     },
     onClose() {
       this.$emit('close');
+      if (this.preventFocusTrap) return;
       // stop the scroll lock
       this.toggleScrollLock(false);
       this.focusTrapInstance.stop();

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -450,6 +450,15 @@ describe('NavBase', () => {
     expect(FocusTrap.mock.results[0].value.start).toHaveBeenCalledTimes(1);
   });
 
+  it('does not locks the focus on expand if preventFocusTrap is true', async () => {
+    wrapper = await createWrapper({
+      propsData: {
+        preventFocusTrap: true,
+      },
+    });
+    expect(FocusTrap).toHaveBeenCalledTimes(0);
+  });
+
   it('unlocks the focus on close', async () => {
     wrapper = await createWrapper();
     wrapper.find({ ref: 'axToggle' }).trigger('click');


### PR DESCRIPTION
Bug/issue #94044029, if applicable: 

## Summary

Localnav should not FocusTrap for documentation pages but we should keep it for the rest of the pages.

This is because localnav in small viewports in documentation pages is very small, only has 2 items, and it doesn’t feel like a modal, it’s more like a collapse element.

## Dependencies

NA

## Testing

Steps:
1. Using SlothCreator, run DocC Render
2. Go to http://localhost:8080/documentation/slothcreator
3. Go into a small viewport
4. Open the localnav
5. Assert that when tabbing focus doesn't get trap in the localnav

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
