### PR TITLE
[5.7] Do not open all items, if Hide Deprecated tag is picked

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -351,7 +351,7 @@ export default {
      */
     filteredChildren({
       hasFilter, children, filterPattern, selectedTags,
-      apiChangesObject, apiChanges,
+      apiChangesObject, apiChanges, deprecatedHidden,
     }) {
       if (!hasFilter) return [];
       const tagsSet = new Set(selectedTags);
@@ -375,8 +375,10 @@ export default {
         }
         // find items, that have API changes
         const hasAPIChanges = apiChanges ? apiChangesObject[path] : true;
+        // group markers are hidden when filtering, unless "Hide Deprecated" is ON.
+        const isGroupMarker = deprecatedHidden ? false : type === TopicTypes.groupMarker;
         // make sure groupMarker's dont get matched
-        return titleMatch && tagMatch && hasAPIChanges && type !== TopicTypes.groupMarker;
+        return titleMatch && tagMatch && hasAPIChanges && !isGroupMarker;
       });
     },
     /**
@@ -424,6 +426,14 @@ export default {
     hasFilter({ debouncedFilter, selectedTags, apiChanges }) {
       return Boolean(debouncedFilter.length || selectedTags.length || apiChanges);
     },
+    /**
+     * Determine if "Hide Deprecated" tag is selected.
+     * If we enable multiple tags, this should be an include instead.
+     * @returns boolean
+     */
+    deprecatedHidden: ({ selectedTags, debouncedFilter }) => (
+      selectedTags[0] === HIDE_DEPRECATED_TAG && !debouncedFilter.length
+    ),
     apiChangesObject() {
       return this.apiChanges || {};
     },
@@ -486,8 +496,9 @@ export default {
       // if the activePath items change, we navigated to another page
       const pageChange = !isEqual(activePathChildrenBefore, activePathChildren);
       // decide which items are open
-      // if there is no filter or navigate to page while filtering, ensure activeUID is visible
-      const nodes = (pageChange && this.hasFilter) || !this.hasFilter
+      // if "Hide Deprecated" is picked, there is no filter,
+      // or navigate to page while filtering, we open the items leading to the activeUID
+      const nodes = this.deprecatedHidden || (pageChange && this.hasFilter) || !this.hasFilter
         ? activePathChildren
         // get all parents of the current filter match, excluding it in the process
         : filteredChildren.flatMap(({ uid }) => this.getParents(uid).slice(0, -1));
@@ -495,7 +506,9 @@ export default {
       const newOpenNodes = Object.fromEntries(nodes
         .map(({ uid }) => [uid, true]));
       // if we navigate across pages, persist the previously open nodes
-      this.openNodes = Object.assign(pageChange ? this.openNodes : {}, newOpenNodes);
+      const baseNodes = pageChange ? this.openNodes : {};
+      // merge in the new open nodes with the base nodes
+      this.openNodes = Object.assign(baseNodes, newOpenNodes);
       this.generateNodesToRender();
       // update the focus index, based on the activeUID
       this.updateFocusIndexExternally();

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1518,9 +1518,24 @@ describe('NavigatorCard', () => {
       ...root0Child0,
       deprecated: true,
     };
+    const groupMarker = {
+      type: TopicTypes.groupMarker,
+      title: 'First Child Group Marker',
+      uid: 22,
+      parent: root0.uid,
+      depth: 1,
+      index: 4,
+      childUIDs: [],
+    };
+    const root0Updated = {
+      ...root0,
+      childUIDs: root0.childUIDs.concat(groupMarker.uid),
+    };
     const wrapper = createWrapper({
       propsData: {
-        children: [root0, updatedChild, root0Child1, root0Child1GrandChild0, root1],
+        children: [
+          root0Updated, updatedChild, groupMarker, root0Child1, root0Child1GrandChild0, root1,
+        ],
         activePath: [root0.path],
       },
     });
@@ -1533,13 +1548,28 @@ describe('NavigatorCard', () => {
     await flushPromises();
     // assert no other tags are shown now
     expect(filter.props('tags')).toEqual([]);
-    const allItems = wrapper.findAll(NavigatorCardItem);
+    let allItems = wrapper.findAll(NavigatorCardItem);
     // assert the deprecated item is filtered out
     expect(allItems).toHaveLength(4);
-    expect(allItems.at(0).props('item')).toEqual(root0);
+    // assert root is rendered
+    expect(allItems.at(0).props('item')).toEqual(root0Updated);
+    // assert the group marker is rendered
+    expect(allItems.at(1).props('item')).toEqual(groupMarker);
+    // assert the none-deprecated child is rendered, but its not expanded
+    expect(allItems.at(2).props()).toMatchObject({
+      item: root0Child1,
+      expanded: false,
+    });
+    expect(allItems.at(3).props('item')).toEqual(root1);
+    // Ensure all first children should show up
+    filter.vm.$emit('input', 'First Child');
+    await flushPromises();
+    allItems = wrapper.findAll(NavigatorCardItem);
+    // assert that filtering opens everything as usual, hiding groupMarkers
+    expect(allItems).toHaveLength(3);
+    expect(allItems.at(0).props('item')).toEqual(root0Updated);
     expect(allItems.at(1).props('item')).toEqual(root0Child1);
     expect(allItems.at(2).props('item')).toEqual(root0Child1GrandChild0);
-    expect(allItems.at(3).props('item')).toEqual(root1);
   });
 
   describe('navigating', () => {


### PR DESCRIPTION
- **Rationale:** Makes sure to not open all items, when "Hide Deprecated" tag is picked in the navigator
- **Risk:** Medium
- **Risk Detail:** Changes the logic to open items and keep track of visible items
- **Reward:** High
- **Reward Details:** Users will not get every single item level expanded, if they dont want to see deprecated items.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/331
- **Issue:** rdar://93506254
- **Code Reviewed By:** @marinaaisa 
- **Testing Details:** Added automation tests and tested manually in the browser