### PR TITLE
[5.7] [AX] Aside element not needed as parent of Navigator and Navigator needs aria-label

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -9,7 +9,10 @@
 -->
 
 <template>
-  <nav class="navigator">
+  <nav
+    :aria-labelledby="INDEX_ROOT_KEY"
+    class="navigator"
+  >
     <NavigatorCard
       v-if="!isFetching"
       :technology="technology.title"
@@ -66,6 +69,11 @@ export default {
     NavigatorCard,
     NavigatorCardInner,
     SpinnerIcon,
+  },
+  data() {
+    return {
+      INDEX_ROOT_KEY,
+    };
   },
   props: {
     parentTopicIdentifiers: {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -32,7 +32,7 @@
         v-on="sidebarListeners"
       >
         <template #aside="{ scrollLockID, breakpoint }">
-          <aside class="doc-topic-aside">
+          <div class="doc-topic-aside">
             <NavigatorDataProvider
               :interface-language="topicProps.interfaceLanguage"
               :technology="technology"
@@ -55,7 +55,7 @@
                 </transition>
               </template>
             </NavigatorDataProvider>
-          </aside>
+          </div>
         </template>
         <Topic
           v-bind="topicProps"

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -116,8 +116,10 @@ describe('Navigator', () => {
 
   it('renders the Navigator', () => {
     const wrapper = createWrapper();
+    const navigator = wrapper.find('.navigator');
     // assert navigator is a `nav`
-    expect(wrapper.find('.navigator').is('nav')).toBe(true);
+    expect(navigator.is('nav')).toBe(true);
+    expect(navigator.attributes()).toHaveProperty('aria-labelledby', INDEX_ROOT_KEY);
     // assert Navigator card is rendered
     expect(wrapper.find(NavigatorCard).props()).toEqual({
       activePath: [references.first.url, references.second.url, mocks.$route.path],


### PR DESCRIPTION
- Rationale: Navigator doesn't need a aside element but it needs an aria-label for better VO interpretation
- Risk: Low
- Risk Detail: VO readability
- Reward: Low
- Reward Details: It improves VO readability on the navigator
- Original PR: https://github.com/apple/swift-docc-render/pull/340/
- Issue: rdar://94043661
- Code Reviewed By: @dobromir-hristov 
- Testing Details: Added automation tests and tested manually in the browser