### PR TITLE
[5.7] Optically center the navigator toggle icon in Nav

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -270,10 +270,11 @@ $sidenav-icon-size: 19px;
   margin-right: -$space;
   padding-left: $space;
   padding-right: $space;
-}
 
-.sidenav-icon {
-  width: $sidenav-icon-size;
-  height: $sidenav-icon-size;
+  .sidenav-icon {
+    display: flex;
+    width: $sidenav-icon-size;
+    height: $sidenav-icon-size;
+  }
 }
 </style>

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1080,6 +1080,7 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
     border-bottom: 1px solid var(--color-grid);
     display: flex;
     align-items: baseline;
+    box-sizing: border-box;
 
     &.router-link-exact-active {
       background: $navigator-head-background-active;
@@ -1096,10 +1097,12 @@ $navigator-head-background-active: var(--color-fill-tertiary) !default;
 
     @include breakpoint(medium, nav) {
       justify-content: center;
+      height: $nav-height;
       padding: 14px $card-horizontal-spacing-large;
     }
 
     @include breakpoint(small, nav) {
+      height: $nav-height-small;
       padding: 12px $card-horizontal-spacing-large;
     }
 


### PR DESCRIPTION
- **Rationale:** Centers the icon that toggles the navigator on mobile devices vertically, as it was a couple of pixels off.
- **Risk:** Low
- **Risk Detail:** Changes isolated css styling
- **Reward:** Medium
- **Reward Details:** Users will get vertically aligned items in the navbar.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/248
- **Issue:** rdar://92095402
- **Code Reviewed By:** @marinaaisa 
- **Testing Details:** Tested manually in the browser