### PR TITLE
[5.7] Fix double click to re-play tutorials issue on Safari

### DIFF
--- a/src/components/ReplayableVideoAsset.vue
+++ b/src/components/ReplayableVideoAsset.vue
@@ -62,10 +62,8 @@ export default {
     async replay() {
       const videoPlayer = this.$refs.asset.$el;
       if (videoPlayer) {
-        this.showsReplayButton = false;
-        // Start video playback from the beginning.
-        videoPlayer.currentTime = 0;
         await videoPlayer.play();
+        this.showsReplayButton = false;
       }
     },
     onVideoEnd() {

--- a/tests/unit/components/ReplayableVideoAsset.spec.js
+++ b/tests/unit/components/ReplayableVideoAsset.spec.js
@@ -50,7 +50,7 @@ describe('ReplayableVideoAsset', () => {
     expect(video.props('autoplays')).toBe(true);
   });
 
-  it('displays the replay button when the video has ended', () => {
+  it('displays the replay button when the video has ended', async () => {
     const wrapper = mountWithProps();
 
     const replayButton = wrapper.find('.replay-button');
@@ -67,6 +67,7 @@ describe('ReplayableVideoAsset', () => {
 
     // When the video is playing, the replay button should be hidden.
     replayButton.trigger('click');
+    await flushPromises();
     expect(replayButton.classes('visible')).toBe(false);
   });
 


### PR DESCRIPTION
- **Rationale:** Fixes an issue where Safari would sometimes require two clicks to replay a Tutorial video
- **Risk:** Low
- **Risk Detail:** Reduces the replay functionality complexity
- **Reward:** Medium
- **Reward Details:** Users will no longer get a buggy experience, when clicking replay on a tutorial video
- **Original PR:** https://github.com/apple/swift-docc-render/pull/347
- **Issue:** rdar://94304930
- **Code Reviewed By:** @mportiz08  
- **Testing Details:** Tested manually in the browser