### PR TITLE
[5.7] Fix preview box getting cut off for Tutorial pages

### DIFF
--- a/src/components/Tutorial/CodePreview.vue
+++ b/src/components/Tutorial/CodePreview.vue
@@ -18,26 +18,28 @@
       :class="runtimePreviewClasses"
       :style="previewStyles"
     >
-      <button
-        class="header"
-        :disabled="!hasRuntimePreview"
-        :title="runtimePreviewTitle"
-        @click="togglePreview"
-      >
+      <div class="runtimve-preview__container">
+        <button
+          class="header"
+          :disabled="!hasRuntimePreview"
+          :title="runtimePreviewTitle"
+          @click="togglePreview"
+        >
         <span
           class="runtime-preview-label"
           :aria-label="textAriaLabel"
         >{{ togglePreviewText }}</span>
-        <DiagonalArrowIcon
-          :class="[ shouldDisplayHideLabel ? 'preview-hide': 'preview-show' ]"
-          class="icon-inline preview-icon"
-        />
-      </button>
-      <transition @leave="handleLeave">
-        <div class="runtime-preview-asset" v-show="shouldDisplayHideLabel">
-          <slot />
-        </div>
-      </transition>
+          <DiagonalArrowIcon
+            :class="[ shouldDisplayHideLabel ? 'preview-hide': 'preview-show' ]"
+            class="icon-inline preview-icon"
+          />
+        </button>
+        <transition @leave="handleLeave">
+          <div class="runtime-preview-asset" v-show="shouldDisplayHideLabel">
+            <slot />
+          </div>
+        </transition>
+      </div>
     </div>
   </div>
 </template>
@@ -111,7 +113,7 @@ export default {
          * videos are not provided with size attributes.
          * The width result ends up being 300px
          * because all sizes bigger than 400 get scaled down by 3 on the `scaledSize` function.
-        */
+         */
         width: 900,
       };
 
@@ -127,11 +129,9 @@ export default {
     previewSize() {
       const collapsedPreviewSize = {
         width: 102,
-        height: 32,
       };
       return (this.shouldDisplayHideLabel && this.previewAssetSize) ? ({
         width: this.previewAssetSize.width,
-        height: this.previewAssetSize.height + collapsedPreviewSize.height,
       }) : (
         collapsedPreviewSize
       );
@@ -139,11 +139,9 @@ export default {
     previewStyles() {
       const {
         width,
-        height,
       } = this.previewSize;
       return {
         width: `${width}px`,
-        height: `${height}px`,
       };
     },
     codeProps() {
@@ -261,28 +259,19 @@ $duration: 0.2s;
   margin-left: 0;
   // For animation
   // Width and height must have a pixel value in order to be transitioned
-  transition: width $duration $runtime-preview-transition-curve,
-  height $duration $runtime-preview-transition-curve;
+  transition: width $duration $runtime-preview-transition-curve;
   // fallback to correctly stretch the toggle button for older browsers
   @supports not (width: stretch) {
     display: flex;
     flex-direction: column;
   }
 
-  &::before {
-    box-shadow: 0px 0px 3px 0px var(--color-runtime-preview-shadow);
+  .runtimve-preview__container {
     border-radius: $border-radius;
-    content: "";
-    position: absolute;
-    top: 0;
-    right: 0;
-    left: 0;
-    bottom: 0;
-
-    @include prefers-dark {
-      mix-blend-mode: difference;
-    }
+    overflow: hidden;
   }
+
+  box-shadow: 0px 0px 3px 0px var(--color-runtime-preview-shadow);
 }
 
 .runtime-preview-ide {
@@ -303,7 +292,6 @@ $duration: 0.2s;
   // Potentially a JS method that can create the proper dimensions
   // based on text.
   width: 102px;
-  height: 28px;
 
   .header {
     border-radius: $border-radius;

--- a/tests/unit/components/Tutorial/CodePreview.spec.js
+++ b/tests/unit/components/Tutorial/CodePreview.spec.js
@@ -96,11 +96,11 @@ describe('CodePreview', () => {
       it('renders the media preview at 1/3 scale', () => {
         TopicStore.updateBreakpoint('large');
         let runtimePreview = wrapper.find('.runtime-preview');
-        expect(runtimePreview.attributes('style')).toBe('width: 200px; height: 432px;');
+        expect(runtimePreview.attributes('style')).toBe('width: 200px;');
 
         TopicStore.updateBreakpoint('small');
         runtimePreview = wrapper.find('.runtime-preview');
-        expect(runtimePreview.attributes('style')).toBe('width: 200px; height: 432px;');
+        expect(runtimePreview.attributes('style')).toBe('width: 200px;');
       });
     });
 
@@ -108,7 +108,7 @@ describe('CodePreview', () => {
       it('renders the preview at 80% of 1/3 scale', () => {
         TopicStore.updateBreakpoint('medium');
         const runtimePreview = wrapper.find('.runtime-preview');
-        expect(runtimePreview.attributes('style')).toBe('width: 160px; height: 352px;');
+        expect(runtimePreview.attributes('style')).toBe('width: 160px;');
       });
     });
   });
@@ -196,8 +196,8 @@ describe('CodePreview', () => {
     wrapper = mountWithVariant(variantWithOnlyHeight);
 
     const runtimePreview = wrapper.find('.runtime-preview');
-    // 32px are added from the collapsedPreviewSize's height
-    expect(runtimePreview.attributes('style')).toBe('height: 432px;');
+    // no height is defined at all
+    expect(runtimePreview.attributes('style')).toBeFalsy();
   });
 
   describe('collapsed', () => {
@@ -243,7 +243,7 @@ describe('CodePreview', () => {
     it('renders the collapsed preview button at proper dimensions', () => {
       wrapper = mountWithPreviewVisible(false);
       const runtimePreview = wrapper.find('.runtime-preview');
-      expect(runtimePreview.attributes('style')).toBe('width: 102px; height: 32px;');
+      expect(runtimePreview.attributes('style')).toBe('width: 102px;');
     });
   });
 
@@ -265,11 +265,11 @@ describe('CodePreview', () => {
       it('renders the preview at 1/1.75 scale', () => {
         TopicStore.updateBreakpoint('large');
         let runtimePreview = wrapper.find('.runtime-preview');
-        expect(runtimePreview.attributes('style')).toBe('width: 200px; height: 432px;');
+        expect(runtimePreview.attributes('style')).toBe('width: 200px;');
 
         TopicStore.updateBreakpoint('small');
         runtimePreview = wrapper.find('.runtime-preview');
-        expect(runtimePreview.attributes('style')).toBe('width: 200px; height: 432px;');
+        expect(runtimePreview.attributes('style')).toBe('width: 200px;');
       });
     });
 
@@ -277,7 +277,7 @@ describe('CodePreview', () => {
       it('renders the preview at 80% of 1/1.75 scale', () => {
         TopicStore.updateBreakpoint('medium');
         const runtimePreview = wrapper.find('.runtime-preview');
-        expect(runtimePreview.attributes('style')).toBe('width: 160px; height: 352px;');
+        expect(runtimePreview.attributes('style')).toBe('width: 160px;');
       });
     });
   });
@@ -307,7 +307,7 @@ describe('CodePreview', () => {
     it('renders the preview with a disabled state', () => {
       const preview = wrapper.find('.runtime-preview');
       expect(preview.classes('disabled')).toBe(true);
-      expect(preview.attributes('style')).toBe('width: 102px; height: 32px;');
+      expect(preview.attributes('style')).toBe('width: 102px;');
 
       const button = preview.find('button');
       expect(button.attributes('disabled')).toBe('disabled');


### PR DESCRIPTION
- **Rationale:** Fixes an issue where tutorial previews display incorrectly after second click
- **Risk:** Low
- **Risk Detail:** minor refactor
- **Reward:** High
- **Reward Details:** Users will no longer see obvious UI issue when previewing a tutorial 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/338
- **Issue:** rdar://93843834
- **Code Reviewed By:** @marinaaisa @dobromir-hristov   
- **Testing Details:** Tested manually in the browser