### PR TITLE
[5.7] Remove overlay from navigator group labels

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -291,6 +291,10 @@ $nesting-spacing: $card-horizontal-spacing + $card-horizontal-spacing-small;
     .leaf-link {
       color: var(--color-figure-gray-secondary);
       font-weight: $font-weight-semibold;
+      // groups dont need the overlay
+      &:after {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
- **Rationale:** Fixes an issue with selecting group labels in Navigator
- **Risk:** Low
- **Risk Detail:** Changes isolated css styling
- **Reward:** Medium
- **Reward Details:** Users will now be able to select the names of groups with their mouse
- **Original PR:** https://github.com/apple/swift-docc-render/pull/350
- **Issue:** rdar://94615183
- **Code Reviewed By:** @mportiz08  
- **Testing Details:** Tested manually in the browser