### PR TITLE
Allow tabbing through tutorial steps

### DIFF
--- a/src/components/Tutorial/SectionSteps.vue
+++ b/src/components/Tutorial/SectionSteps.vue
@@ -19,6 +19,7 @@
         :key="index"
         :currentIndex="activeStep"
         ref="contentNodes"
+        @focus="onFocus"
       />
     </div>
     <!-- the asset-container is only for medium and large breakpoints -->

--- a/src/components/Tutorial/Step.vue
+++ b/src/components/Tutorial/Step.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <div :class="['step-container', `step-${stepNumber}`]">
+  <div :class="['step-container', `step-${stepNumber}`]" tabindex="0" @focus="onFocus">
     <div
       ref="step"
       class="step"
@@ -116,6 +116,21 @@ export default {
       return this.tutorialState.breakpoint === BreakpointName.small;
     },
     isActive: ({ index, currentIndex }) => index === currentIndex,
+  },
+  methods: {
+    onFocus() {
+      if (this.isClientMobile) return;
+      const bodyRect = document.body.getBoundingClientRect().top;
+      const elementRect = this.$el.getBoundingClientRect().top;
+      const elementPosition = elementRect - bodyRect;
+      // make sure the element is at the top 25% of the screen
+      const offsetPosition = elementPosition - (window.innerHeight * 0.25);
+
+      // scroll to the element
+      window.scrollTo({ top: offsetPosition, behavior: 'smooth' });
+      // notify the parent it must be in focus, if for some reason it is not.
+      this.$emit('focus', this.index);
+    },
   },
 };
 </script>


### PR DESCRIPTION
Bug/issue #, if applicable: 50959680

## Summary

Allows tabbing through the tutorial sections.

## Dependencies

NA

## Testing

Steps:
1. Open a tutorial page, like http://localhost:8080/tutorials/slothcreator/creating-custom-sloths
2. Assert you can start tabbing and it will tab through each tutorial item

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
