### PR TITLE
[5.7] Fix fetch redirects

### DIFF
--- a/src/errors/FetchError.js
+++ b/src/errors/FetchError.js
@@ -1,0 +1,16 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+export default class FetchError extends Error {
+  constructor(route) {
+    super('Unable to fetch data');
+    this.route = route;
+  }
+}

--- a/src/errors/RedirectError.js
+++ b/src/errors/RedirectError.js
@@ -1,0 +1,17 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+export default class RedirectError extends Error {
+  constructor({ location, response }) {
+    super('Request redirected');
+    this.location = location;
+    this.response = response;
+  }
+}

--- a/tests/unit/setup-utils/SwiftDocCRenderRouter.spec.js
+++ b/tests/unit/setup-utils/SwiftDocCRenderRouter.spec.js
@@ -11,7 +11,7 @@
 import { restoreScrollOnReload, saveScrollOnReload, scrollBehavior } from 'docc-render/utils/router-utils';
 import Router from 'vue-router';
 import SwiftDocCRenderRouter from 'docc-render/setup-utils/SwiftDocCRenderRouter';
-import { FetchError } from 'docc-render/utils/data';
+import FetchError from 'docc-render/errors/FetchError';
 
 jest.mock('docc-render/utils/theme-settings', () => ({
   baseUrl: '/',

--- a/tests/unit/utils/data.spec.js
+++ b/tests/unit/utils/data.spec.js
@@ -9,7 +9,6 @@
 */
 
 import {
-  FetchError,
   fetchData,
   fetchDataForRouteEnter,
   shouldFetchDataForRouteUpdate,
@@ -17,6 +16,8 @@ import {
   fetchIndexPathsData,
 } from 'docc-render/utils/data';
 import emitWarningForSchemaVersionMismatch from 'docc-render/utils/schema-version-check';
+import FetchError from 'docc-render/errors/FetchError';
+import RedirectError from 'docc-render/errors/RedirectError';
 
 jest.mock('docc-render/utils/schema-version-check', () => jest.fn());
 
@@ -37,6 +38,11 @@ const goodFetchResponse = {
 const notFoundFetchResposne = {
   ok: false,
   status: 404,
+};
+const redirectResponse = {
+  redirected: true,
+  ok: true,
+  url: 'https://localhost:8080/data/documentation/foo/framework.json?language=objc',
 };
 
 const badIDEFetchResponse = {
@@ -87,6 +93,17 @@ describe('fetchData', () => {
     expect(emitWarningForSchemaVersionMismatch).toHaveBeenCalledTimes(1);
 
     expect(emitWarningForSchemaVersionMismatch).toHaveBeenCalledWith(schemaVersion);
+  });
+
+  it('throws a RedirectError, when a redirect response is present', async () => {
+    window.fetch = jest.fn().mockImplementation(() => redirectResponse);
+    try {
+      await fetchData('/data/tutorials/augmented-responses/tutorials.json');
+    } catch (err) {
+      expect(err).toBeInstanceOf(RedirectError);
+      expect(err.response).toEqual(redirectResponse);
+      expect(err.location).toEqual(redirectResponse.url);
+    }
   });
 
   describe('with an IDE target', () => {
@@ -202,6 +219,16 @@ describe('fetchDataForRouteEnter', () => {
 
     window.fetch.mockRestore();
     process.env.VUE_APP_TARGET = '';
+  });
+
+  it('throws with a new path, when `fetch` has been redirected', async () => {
+    window.fetch = jest.fn().mockResolvedValue(redirectResponse);
+
+    await expect(fetchDataForRouteEnter(to, from, next))
+      .rejects
+      .toBe('/documentation/foo/framework?language=objc');
+    expect(next).toHaveBeenCalledTimes(0);
+    window.fetch.mockRestore();
   });
 
   it('calls the `next` fn with a `FetchError`', async () => {


### PR DESCRIPTION
- **Rationale:** Fixes an issue with following redirect rules.
- **Risk:** Medium
- **Risk Detail:** Changes the logic that handles 301 and 302 redirects
- **Reward:** Medium
- **Reward Details:** Users will now be properly redirected to the new path.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/352
- **Issue:** rdar://74717074
- **Code Reviewed By:** @mportiz08  
- **Testing Details:** Tested manually in the browser