### PR TITLE
Fix footer gutters on small sizes

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -37,5 +37,10 @@ export default {
   display: flex;
   flex-direction: row-reverse;
   padding: 20px 0;
+  @include breakpoint(small) {
+    width: 100%;
+    padding: 20px $nav-padding-small;
+    box-sizing: border-box;
+  }
 }
 </style>


### PR DESCRIPTION
Bug/issue #, if applicable: 91829676

## Summary

Fixes the footer gutters on small screen sizes to match those of the navigator.

![image](https://user-images.githubusercontent.com/9863944/174743998-59c61844-ee25-47d0-9038-8cb11f48aad9.png)


## Dependencies

NA

## Testing

Steps:
1. Assert the footer gutters match the top navigator's

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~ - no need, CSS only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
