### PR TITLE
LanguageToggle dropdown should have a cursor-pointer

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
+++ b/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
@@ -240,6 +240,7 @@ $nav-menu-toggle-label-margin: 6px;
     padding: 0 $dropdown-icon-padding 0 4px;
     margin-left: -4px;
     @include font-styles(nav-toggles);
+    cursor: pointer;
 
     // remove the default focus styles, and re-add them on keyboard navigation, only.
     &:focus {

--- a/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
+++ b/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
@@ -241,6 +241,8 @@ $nav-menu-toggle-label-margin: 6px;
     margin-left: -4px;
     @include font-styles(nav-toggles);
     cursor: pointer;
+    position: relative;
+    z-index: 1;
 
     // remove the default focus styles, and re-add them on keyboard navigation, only.
     &:focus {

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -291,6 +291,10 @@ $nesting-spacing: $card-horizontal-spacing + $card-horizontal-spacing-small;
     .leaf-link {
       color: var(--color-figure-gray-secondary);
       font-weight: $font-weight-semibold;
+      // groups dont need the overlay
+      &:after {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 89923444

## Summary

Language toggle should have a pointer cursor icon.

## Dependencies

NA

## Testing

Open an archive that has language versions

Steps:
1. Assert that hovering over the language toggle shows a pointer cursor

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
