### PR TITLE
close mobile navigator, when clicking on any navigation item

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -932,6 +932,8 @@ export default {
      * that points to another technology.
      */
     handleNavigationChange(uid) {
+      // force-close the navigator on mobile
+      this.$emit('close');
       // if the path is outside of this technology tree, dont store the uid
       if (this.childrenMap[uid].path.startsWith(this.technologyPath)) {
         this.setActiveUID(uid);

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1698,6 +1698,8 @@ describe('NavigatorCard', () => {
       expect(getChildPositionInScroller).toHaveBeenCalledTimes(2);
       expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenCalledTimes(1);
       expect(RecycleScrollerStub.methods.scrollToItem).toHaveBeenLastCalledWith(2); // 3-rd item
+      // assert close event was emitted
+      expect(wrapper.emitted('close')).toHaveLength(1);
       // now simulate the router change
       wrapper.setProps({ activePath: [root0.path, root0Child1.path] });
       await flushPromises();


### PR DESCRIPTION
Bug/issue #, if applicable: 90839759

## Summary

Closes the mobile navigator, if clicked on the already highlighted current page, even though no page navigation is performed.

## Dependencies

NA

## Testing

Steps:
1. Go to a page in the navigator 
2. While in mobile screen size open the navigator again and click on the current (bolded) page link again
3. Assert the navigator is hidden but nothing else happens.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
