### PR TITLE
Stop using word break logic in titles for "enhanced" pages

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -28,7 +28,7 @@
           :swiftPath="swiftPath"
         />
         <Title :eyebrow="roleHeading">
-          <WordBreak>{{ title }}</WordBreak>
+          <component :is="titleBreakComponent">{{ title }}</component>
           <small
             v-if="isSymbolDeprecated || isSymbolBeta"
             slot="after"
@@ -328,6 +328,11 @@ export default {
         ? technologyList
         : [];
     },
+    // there shouldn't be a pressing need to use the `WordBreak` component in
+    // the main title for for non-symbol pages with the "enhanced" background
+    titleBreakComponent: ({ enhanceBackground }) => (enhanceBackground
+      ? 'span'
+      : WordBreak),
     showContainer: ({
       isRequirement,
       deprecationSummary,

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -272,6 +272,18 @@ describe('DocumentationTopic', () => {
     const title = hero.find(Title);
     expect(title.exists()).toBe(true);
     expect(title.props('eyebrow')).toBe(propsData.roleHeading);
+    expect(title.text()).toBe(propsData.title);
+    expect(title.find(WordBreak).exists()).toBe(false);
+  });
+
+  it('uses `WordBreak` in the title for symbol pages', () => {
+    wrapper.setProps({
+      role: 'symbol',
+      symbolKind: 'protocol',
+    });
+
+    const title = wrapper.find(Title);
+    expect(title.exists()).toBe(true);
 
     const wb = title.find(WordBreak);
     expect(wb.exists()).toBe(true);


### PR DESCRIPTION
Bug/issue #, if applicable: 54931063

## Summary

Since the logic in the `WordBreak` component was mainly needed and designed for symbol pages (those without the enhanced hero background), it should only be used there and not for every kind of generic page title (like articles, etc).

## Testing

Steps:
1. Run `env VUE_APP_DEV_SERVER_PROXY=https://ethan-kusters.github.io/swift-argument-parser npm run serve` to start the dev server using data from an example project
2. Open http://localhost:8080/documentation/argumentparser/gettingstarted and verify that the word "ArgumentParser" in the page title heading **no longer contains** a `<wbr>` HTML element between the text "Argument" and "Parser"
3. Open http://localhost:8080/documentation/argumentparser/optiongroup and verify that the word "OptionGroup" in the page title heading **still contains** a `<wbr>` HTML element between the text "Option" and "Group"

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
