### PR TITLE
[5.7] Stop using word break logic in titles for "enhanced" pages

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -28,7 +28,7 @@
           :swiftPath="swiftPath"
         />
         <Title :eyebrow="roleHeading">
-          <WordBreak>{{ title }}</WordBreak>
+          <component :is="titleBreakComponent">{{ title }}</component>
           <small
             v-if="isSymbolDeprecated || isSymbolBeta"
             slot="after"
@@ -328,6 +328,11 @@ export default {
         ? technologyList
         : [];
     },
+    // there shouldn't be a pressing need to use the `WordBreak` component in
+    // the main title for for non-symbol pages with the "enhanced" background
+    titleBreakComponent: ({ enhanceBackground }) => (enhanceBackground
+      ? 'span'
+      : WordBreak),
     showContainer: ({
       isRequirement,
       deprecationSummary,

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -272,6 +272,18 @@ describe('DocumentationTopic', () => {
     const title = hero.find(Title);
     expect(title.exists()).toBe(true);
     expect(title.props('eyebrow')).toBe(propsData.roleHeading);
+    expect(title.text()).toBe(propsData.title);
+    expect(title.find(WordBreak).exists()).toBe(false);
+  });
+
+  it('uses `WordBreak` in the title for symbol pages', () => {
+    wrapper.setProps({
+      role: 'symbol',
+      symbolKind: 'protocol',
+    });
+
+    const title = wrapper.find(Title);
+    expect(title.exists()).toBe(true);
 
     const wb = title.find(WordBreak);
     expect(wb.exists()).toBe(true);


### PR DESCRIPTION
- **Rationale:** Fixes issue where article titles may have suboptimal word breaking behavior
- **Risk:** Low
- **Risk Detail:** Impacts whitespace formatting in page title headings
- **Reward:** High
- **Reward Details:** Improves formatting of page title headings
- **Original PR:** https://github.com/apple/swift-docc-render/pull/365
- **Issue:** rdar://54931063
- **Code Reviewed By:** @dobromir-hristov
- **Testing Details:** Added unit tests, manually tested problematic scenario with example documentation.