### PR TITLE
Remove `min-width` from web content container

### DIFF
--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -342,7 +342,6 @@ $breakpoint-attributes: (
 @mixin breakpoint-dynamic-sidebar-content {
   @include inTargetWeb {
     max-width: 920px;
-    min-width: map-deep-get($breakpoint-attributes, (default, small, min-width));
     margin-left: auto;
     margin-right: auto;
     padding-left: 80px;


### PR DESCRIPTION
Bug/issue #, if applicable: 95981164

## Summary
Remove `min-width` property from `breakpoint-dynamic-sidebar-content`; this change only affects the web. 

## Testing
Steps:
1. Inspect the body content `container` class in ContentTable, DocumentationTopic, and BetaLegalText; and `__content` class in DocumentationHero. Assert that no `min-width` property are applied.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
