### PR TITLE
Framework Name Links In Body Styling

### DIFF
--- a/src/components/DocumentationTopic/TopicsLinkBlock.vue
+++ b/src/components/DocumentationTopic/TopicsLinkBlock.vue
@@ -179,6 +179,7 @@ export default {
       if (topic.titleStyle === TitleStyles.title) {
         return topic.ideTitle ? 'span' : 'code';
       }
+      if (topic.role === 'collection') return 'span';
 
       switch (topic.kind) {
       case TopicKind.symbol:

--- a/src/components/DocumentationTopic/TopicsLinkBlock.vue
+++ b/src/components/DocumentationTopic/TopicsLinkBlock.vue
@@ -59,6 +59,7 @@
 </template>
 
 <script>
+import { TopicRole } from 'docc-render/constants/roles';
 import { buildUrl } from 'docc-render/utils/url-helper';
 import Badge from 'docc-render/components/Badge.vue';
 import WordBreak from 'docc-render/components/WordBreak.vue';
@@ -179,7 +180,7 @@ export default {
       if (topic.titleStyle === TitleStyles.title) {
         return topic.ideTitle ? 'span' : 'code';
       }
-      if (topic.role === 'collection') return 'span';
+      if (topic.role && topic.role === TopicRole.collection) return 'span';
 
       switch (topic.kind) {
       case TopicKind.symbol:

--- a/src/components/DocumentationTopic/TopicsLinkBlock.vue
+++ b/src/components/DocumentationTopic/TopicsLinkBlock.vue
@@ -180,6 +180,7 @@ export default {
       if (topic.titleStyle === TitleStyles.title) {
         return topic.ideTitle ? 'span' : 'code';
       }
+      // Framework name links should not be code voice
       if (topic.role && topic.role === TopicRole.collection) return 'span';
 
       switch (topic.kind) {

--- a/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
@@ -12,6 +12,7 @@ import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import TopicsLinkBlock from 'docc-render/components/DocumentationTopic/TopicsLinkBlock.vue';
 import { ChangeNames } from 'docc-render/constants/Changes';
 import { multipleLinesClass } from 'docc-render/constants/multipleLines';
+import { TopicRole } from 'docc-render/constants/roles';
 
 const {
   ReferenceType,
@@ -133,6 +134,33 @@ describe('TopicsLinkBlock', () => {
   });
 
   it('renders a `WordBreak` using <code> tag for link text to symbols', () => {
+    wrapper.setProps({ topic: { ...propsData.topic, kind: TopicKind.symbol } });
+    const wordBreak = wrapper.find('.link').find(WordBreak);
+    expect(wordBreak.exists()).toBe(true);
+    expect(wordBreak.attributes('tag')).toBe('code');
+    expect(wordBreak.text()).toBe(propsData.topic.title);
+  });
+
+  it('renders a `WordBreak` using <span> tag for Framework name links in Topic that have role collection', () => {
+    // eslint-disable-next-line max-len
+    wrapper.setProps({ topic: { ...propsData.topic, role: TopicRole.collection, kind: TopicKind.symbol } });
+    const wordBreak = wrapper.find('.link').find(WordBreak);
+    expect(wordBreak.exists()).toBe(true);
+    expect(wordBreak.attributes('tag')).toBe('span');
+    expect(wordBreak.text()).toBe(propsData.topic.title);
+  });
+
+  it('renders a `WordBreak` using <code> tag for Framework name links in Topic that have role: article ', () => {
+    // eslint-disable-next-line max-len
+    wrapper.setProps({ topic: { ...propsData.topic, role: TopicRole.article, kind: TopicKind.symbol } });
+    const wordBreak = wrapper.find('.link').find(WordBreak);
+    expect(wordBreak.exists()).toBe(true);
+    expect(wordBreak.attributes('tag')).toBe('code');
+    expect(wordBreak.text()).toBe(propsData.topic.title);
+  });
+
+  it('renders a `WordBreak` using <code> tag for Framework name links in Topic that do NOT have role collection', () => {
+    // eslint-disable-next-line max-len
     wrapper.setProps({ topic: { ...propsData.topic, kind: TopicKind.symbol } });
     const wordBreak = wrapper.find('.link').find(WordBreak);
     expect(wordBreak.exists()).toBe(true);

--- a/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
@@ -143,8 +143,7 @@ describe('TopicsLinkBlock', () => {
 
   it('renders a `WordBreak` using <span> tag for Framework name links in Topic that have role collection', () => {
     wrapper.setProps({
-      topic:
-      {
+      topic: {
         ...propsData.topic,
         role: TopicRole.collection,
         kind: TopicKind.symbol,
@@ -153,21 +152,6 @@ describe('TopicsLinkBlock', () => {
     const wordBreak = wrapper.find('.link').find(WordBreak);
     expect(wordBreak.exists()).toBe(true);
     expect(wordBreak.attributes('tag')).toBe('span');
-    expect(wordBreak.text()).toBe(propsData.topic.title);
-  });
-
-  it('renders a `WordBreak` using <code> tag for Framework name links in Topic that have role: article ', () => {
-    wrapper.setProps({
-      topic:
-      {
-        ...propsData.topic,
-        role: TopicRole.article,
-        kind: TopicKind.symbol,
-      },
-    });
-    const wordBreak = wrapper.find('.link').find(WordBreak);
-    expect(wordBreak.exists()).toBe(true);
-    expect(wordBreak.attributes('tag')).toBe('code');
     expect(wordBreak.text()).toBe(propsData.topic.title);
   });
 

--- a/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
@@ -142,8 +142,14 @@ describe('TopicsLinkBlock', () => {
   });
 
   it('renders a `WordBreak` using <span> tag for Framework name links in Topic that have role collection', () => {
-    // eslint-disable-next-line max-len
-    wrapper.setProps({ topic: { ...propsData.topic, role: TopicRole.collection, kind: TopicKind.symbol } });
+    wrapper.setProps({
+      topic:
+      {
+        ...propsData.topic,
+        role: TopicRole.collection,
+        kind: TopicKind.symbol,
+      },
+    });
     const wordBreak = wrapper.find('.link').find(WordBreak);
     expect(wordBreak.exists()).toBe(true);
     expect(wordBreak.attributes('tag')).toBe('span');
@@ -151,8 +157,14 @@ describe('TopicsLinkBlock', () => {
   });
 
   it('renders a `WordBreak` using <code> tag for Framework name links in Topic that have role: article ', () => {
-    // eslint-disable-next-line max-len
-    wrapper.setProps({ topic: { ...propsData.topic, role: TopicRole.article, kind: TopicKind.symbol } });
+    wrapper.setProps({
+      topic:
+      {
+        ...propsData.topic,
+        role: TopicRole.article,
+        kind: TopicKind.symbol,
+      },
+    });
     const wordBreak = wrapper.find('.link').find(WordBreak);
     expect(wordBreak.exists()).toBe(true);
     expect(wordBreak.attributes('tag')).toBe('code');
@@ -160,7 +172,6 @@ describe('TopicsLinkBlock', () => {
   });
 
   it('renders a `WordBreak` using <code> tag for Framework name links in Topic that do NOT have role collection', () => {
-    // eslint-disable-next-line max-len
     wrapper.setProps({ topic: { ...propsData.topic, kind: TopicKind.symbol } });
     const wordBreak = wrapper.find('.link').find(WordBreak);
     expect(wordBreak.exists()).toBe(true);


### PR DESCRIPTION
Bug/issue #94293647: 

## Summary
Framework name links in Topics are now rendered in body text styling not code voice

## Dependencies

NA

## Testing

1. Use a docc archive with a rendernode with body text styling in code, (where a topic role is also a collection)
2. Run local environment
3. Assert that Framework name links in topics are now rendered in body text styling instead of code voice

## Checklist
- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
