### PR TITLE
[5.7] LanguageToggle dropdown should have a cursor-pointer

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
+++ b/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
@@ -240,6 +240,9 @@ $nav-menu-toggle-label-margin: 6px;
     padding: 0 $dropdown-icon-padding 0 4px;
     margin-left: -4px;
     @include font-styles(nav-toggles);
+    cursor: pointer;
+    position: relative;
+    z-index: 1;
 
     // remove the default focus styles, and re-add them on keyboard navigation, only.
     &:focus {


### PR DESCRIPTION
- **Rationale:** Fixes a visual issue with hovering the Language picker
- **Risk:** Low
- **Risk Detail:** Scoped CSS only change
- **Reward:** Low
- **Reward Details:** Users will now see a pointer hand, when hovering over the dropdown.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/363
- **Issue:** rdar://89923444
- **Code Reviewed By:** @mportiz08 
- **Testing Details:** Tested manually in the browser