### PR TITLE
[5.7] Use references to build secondary navigation urls in NavigationBar

### DIFF
--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -16,6 +16,7 @@
       :technology="metadata.category"
       :topic="heroTitle || ''"
       :rootReference="hierarchy.reference"
+      :identifierUrl="identifierUrl"
     />
     <main id="main" role="main" tabindex="0">
       <slot name="above-hero" />
@@ -82,6 +83,10 @@ export default {
       validator: sections => sections.every(({ kind }) => (
         Object.prototype.hasOwnProperty.call(SectionKind, kind)
       )),
+    },
+    identifierUrl: {
+      type: String,
+      required: true,
     },
   },
   computed: {

--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -16,6 +16,7 @@
       :chapters="hierarchy.modules"
       :topic="tutorialTitle || ''"
       :rootReference="hierarchy.reference"
+      :identifierUrl="identifierUrl"
     />
     <main id="main" role="main" tabindex="0">
       <Section
@@ -118,6 +119,10 @@ export default {
     },
     metadata: {
       type: Object,
+      required: true,
+    },
+    identifierUrl: {
+      type: String,
       required: true,
     },
   },

--- a/src/views/Topic.vue
+++ b/src/views/Topic.vue
@@ -112,6 +112,7 @@ export default {
         metadata,
         references,
         sections,
+        identifier,
       } = topic;
       return {
         [TopicKind.article]: {
@@ -119,12 +120,14 @@ export default {
           metadata,
           references,
           sections,
+          identifierUrl: identifier.url,
         },
         [TopicKind.tutorial]: {
           hierarchy,
           metadata,
           references,
           sections,
+          identifierUrl: identifier.url,
         },
       }[kind];
     },

--- a/tests/unit/components/Article.spec.js
+++ b/tests/unit/components/Article.spec.js
@@ -99,6 +99,7 @@ const propsData = {
     assessmentsSection,
     ctaSection,
   ],
+  identifierUrl: 'foo',
 };
 
 describe('Article', () => {
@@ -136,6 +137,7 @@ describe('Article', () => {
       technology: propsData.metadata.category,
       topic: heroSection.title,
       rootReference: hierarchy.reference,
+      identifierUrl: propsData.identifierUrl,
     });
   });
 

--- a/tests/unit/components/Tutorial.spec.js
+++ b/tests/unit/components/Tutorial.spec.js
@@ -171,6 +171,7 @@ describe('Tutorial', () => {
     sections,
     hierarchy,
     metadata: { category: 'Blah' },
+    identifierUrl: 'foo',
   };
 
   beforeEach(() => {
@@ -201,6 +202,7 @@ describe('Tutorial', () => {
       chapters: propsData.hierarchy.modules,
       topic: propsData.sections[0].title,
       rootReference: hierarchy.reference,
+      identifierUrl: propsData.identifierUrl,
     });
   });
 
@@ -253,6 +255,7 @@ describe('Tutorial without hero section', () => {
         hierarchy,
         metadata: { category: 'Blah' },
         technologyNavigation: ['overview', 'tutorials', 'resources'],
+        identifierUrl: 'foo',
       },
       mocks,
       provide: {

--- a/tests/unit/components/Tutorial/NavigationBar.spec.js
+++ b/tests/unit/components/Tutorial/NavigationBar.spec.js
@@ -38,34 +38,19 @@ describe('NavigationBar', () => {
 
   const chapters = [
     {
-      title: 'Building Interactive AR Experiences',
-      identifier: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences',
+      reference: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences',
       projects: [
         {
-          title: 'Basic Augmented Reality App',
-          identifier: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App',
-          path: '/tutorials/augmented-reality/basic-augmented-reality-app',
-          sections: [],
-        },
-        {
-          title: 'Lists and Data Flow',
-          identifier: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App',
-          path: '/tutorials/augmented-reality/lists-and-data-flow',
+          reference: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App',
           sections: [
             {
-              title: 'Create a new AR project',
-              identifier: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Create-a-new-AR-project',
-              path: '/tutorials/augmented-reality/basic-augmented-reality-app#create-a-new-ar-project',
+              reference: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Create-a-new-AR-project',
             },
             {
-              title: 'Initiate ARKit plane detection',
-              identifier: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Initiate-ARKit-plane-detection',
-              path: '/tutorials/augmented-reality/basic-augmented-reality-app#initiate-arkit-plane-detection',
+              reference: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Initiate-ARKit-plane-detection',
             },
             {
-              title: 'Check your understanding',
-              identifier: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Assessment',
-              path: '/tutorials/augmented-reality/basic-augmented-reality-app#check-your-understanding',
+              reference: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Assessment',
             },
           ],
         },
@@ -73,11 +58,29 @@ describe('NavigationBar', () => {
     },
   ];
 
-  const topic = chapters[0].projects[0].title;
-
   const references = {
     foo: { url: 'foo.com' },
+    'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App': {
+      title: 'Basic Augmented Reality App',
+    },
+    'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Create-a-new-AR-project': {
+      title: 'Create a new AR project',
+      reference: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Create-a-new-AR-project',
+      url: '/tutorials/augmented-reality/basic-augmented-reality-app#create-a-new-ar-project',
+    },
+    'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Initiate-ARKit-plane-detection': {
+      title: 'Initiate ARKit plane detection',
+      reference: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Initiate-ARKit-plane-detection',
+      url: '/tutorials/augmented-reality/basic-augmented-reality-app#initiate-arkit-plane-detection',
+    },
+    'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Assessment': {
+      title: 'Check your understanding',
+      reference: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App.Assessment',
+      url: '/tutorials/augmented-reality/basic-augmented-reality-app#check-your-understanding',
+    },
   };
+
+  const topic = references[chapters[0].projects[0].reference].title;
 
   const rootReference = 'foo';
 
@@ -96,6 +99,7 @@ describe('NavigationBar', () => {
       topic,
       technologyNavigation: ['overview', 'tutorials', 'resources'],
       rootReference,
+      identifierUrl: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App',
     },
     provide: {
       store: TopicStore,
@@ -145,18 +149,22 @@ describe('NavigationBar', () => {
       TopicStore.addLinkableSection({
         anchor: 'introduction',
         title: 'Introduction',
+        depth: 0,
       });
       TopicStore.addLinkableSection({
         anchor: 'create-a-new-ar-project',
         title: 'Create a new AR project',
+        depth: 0,
       });
       TopicStore.addLinkableSection({
         anchor: 'initiate-arkit-plane-detection',
         title: 'Initiate ARKit plane detection',
+        depth: 0,
       });
       TopicStore.addLinkableSection({
         anchor: 'check-your-understanding',
         title: 'Check your understanding',
+        depth: 0,
       });
 
       wrapper = shallowMount(NavigationBar, mountOptions);
@@ -206,20 +214,24 @@ describe('NavigationBar', () => {
         currentOption: 'Introduction',
         sections: [
           {
-            path: '/tutorials/augmented-reality/basic-augmented-reality-app#introduction',
+            path: '#introduction',
             title: 'Introduction',
+            depth: 0,
           },
           {
             path: '/tutorials/augmented-reality/basic-augmented-reality-app#create-a-new-ar-project',
             title: 'Create a new AR project',
+            depth: 0,
           },
           {
             path: '/tutorials/augmented-reality/basic-augmented-reality-app#initiate-arkit-plane-detection',
             title: 'Initiate ARKit plane detection',
+            depth: 0,
           },
           {
             path: '/tutorials/augmented-reality/basic-augmented-reality-app#check-your-understanding',
             title: 'Check your understanding',
+            depth: 0,
           },
         ],
       });
@@ -276,20 +288,24 @@ describe('NavigationBar', () => {
       expect(secondaryDropdown.is(SecondaryDropdown)).toBe(true);
       expect(secondaryDropdown.props('options')).toEqual([
         {
-          path: '/tutorials/augmented-reality/basic-augmented-reality-app#introduction',
+          path: '#introduction',
           title: 'Introduction',
+          depth: 0,
         },
         {
           path: '/tutorials/augmented-reality/basic-augmented-reality-app#create-a-new-ar-project',
           title: 'Create a new AR project',
+          depth: 0,
         },
         {
           path: '/tutorials/augmented-reality/basic-augmented-reality-app#initiate-arkit-plane-detection',
           title: 'Initiate ARKit plane detection',
+          depth: 0,
         },
         {
           path: '/tutorials/augmented-reality/basic-augmented-reality-app#check-your-understanding',
           title: 'Check your understanding',
+          depth: 0,
         },
       ]);
       expect(secondaryDropdown.props('currentOption'))

--- a/tests/unit/views/Topic.spec.js
+++ b/tests/unit/views/Topic.spec.js
@@ -160,6 +160,7 @@ describe('Topic', () => {
       expect(article.exists()).toBe(true);
       expect(article.props()).toEqual({
         ...props,
+        identifierUrl: 'foo',
         hierarchy: {
           technologyNavigation: ['overview', 'tutorials', 'resources'],
         },
@@ -224,6 +225,7 @@ describe('Topic', () => {
       expect(tutorial.exists()).toBe(true);
       expect(tutorial.props()).toEqual({
         ...props,
+        identifierUrl: 'foo',
         hierarchy: {
           technologyNavigation: ['overview', 'tutorials', 'resources'],
         },


### PR DESCRIPTION
- **Rationale:** Modifies the NavigationBar to use paths from the references to build the URLs for SecondaryDropdown and MobileDropdown elements.
- **Risk:** Medium
- **Risk Detail:** Changes the logic that builds the nav dropdowns in Tutorials
- **Reward:** Low
- **Reward Details:** The app will use the proper data to build the Tutorials, which currently is not user facing
- **Original PR:** https://github.com/apple/swift-docc-render/pull/337
- **Issue:** rdar://63628221
- **Code Reviewed By:** @mportiz08  
- **Testing Details:** Tested manually in the browser and added unit tests.