### PR TITLE
Make sure "Hide Deprecated" is not shown, when API changes are enabled

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -266,6 +266,10 @@ export default {
 
       const tagLabelsSet = new Set(tagLabels);
       const generalTags = new Set([HIDE_DEPRECATED_TAG]);
+      // when API changes are available, remove the `HIDE_DEPRECATED_TAG` option
+      if (apiChangesTypesSet.size) {
+        generalTags.delete(HIDE_DEPRECATED_TAG);
+      }
       const availableTags = {
         type: [],
         changes: [],

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1592,9 +1592,6 @@ describe('NavigatorCard', () => {
     };
     const apiChanges = {
       [updatedChild.path]: ChangeTypes.added,
-      [root0Updated.path]: ChangeTypes.modified,
-      [root0Child1GrandChild0.path]: ChangeTypes.modified,
-      [root1.path]: ChangeTypes.deprecated,
     };
     const wrapper = createWrapper({
       propsData: {
@@ -1608,9 +1605,7 @@ describe('NavigatorCard', () => {
     await flushPromises();
     const filter = wrapper.find(FilterInput);
     // assert there is no 'Hide Deprecated' tag
-    expect(filter.props('tags')).toEqual([
-      'Articles', 'Tutorials', ChangeNames.modified, ChangeNames.added, ChangeNames.deprecated,
-    ]);
+    expect(filter.props('tags')).not.toContain(HIDE_DEPRECATED_TAG);
   });
 
   describe('navigating', () => {

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import NavigatorCard from '@/components/Navigator/NavigatorCard.vue';
 import { shallowMount } from '@vue/test-utils';

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import NavigatorCard from '@/components/Navigator/NavigatorCard.vue';
 import { shallowMount } from '@vue/test-utils';
@@ -1570,6 +1570,47 @@ describe('NavigatorCard', () => {
     expect(allItems.at(0).props('item')).toEqual(root0Updated);
     expect(allItems.at(1).props('item')).toEqual(root0Child1);
     expect(allItems.at(2).props('item')).toEqual(root0Child1GrandChild0);
+  });
+
+  it('Does not show "Hide Deprecated" tag, if API changes are ON', async () => {
+    const updatedChild = {
+      ...root0Child0,
+      deprecated: true,
+    };
+    const groupMarker = {
+      type: TopicTypes.groupMarker,
+      title: 'First Child Group Marker',
+      uid: 22,
+      parent: root0.uid,
+      depth: 1,
+      index: 4,
+      childUIDs: [],
+    };
+    const root0Updated = {
+      ...root0,
+      childUIDs: root0.childUIDs.concat(groupMarker.uid),
+    };
+    const apiChanges = {
+      [updatedChild.path]: ChangeTypes.added,
+      [root0Updated.path]: ChangeTypes.modified,
+      [root0Child1GrandChild0.path]: ChangeTypes.modified,
+      [root1.path]: ChangeTypes.deprecated,
+    };
+    const wrapper = createWrapper({
+      propsData: {
+        children: [
+          root0Updated, updatedChild, groupMarker, root0Child1, root0Child1GrandChild0, root1,
+        ],
+        activePath: [root0.path],
+        apiChanges,
+      },
+    });
+    await flushPromises();
+    const filter = wrapper.find(FilterInput);
+    // assert there is no 'Hide Deprecated' tag
+    expect(filter.props('tags')).toEqual([
+      'Articles', 'Tutorials', ChangeNames.modified, ChangeNames.added, ChangeNames.deprecated,
+    ]);
   });
 
   describe('navigating', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 94295219

## Summary

Removes the "Hide Deprecated", when API changes are Enabled.

## Dependencies

NA

## Testing

NA

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
