### PR TITLE
[5.7] Remove `min-width` from web content container

### DIFF
--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -342,7 +342,6 @@ $breakpoint-attributes: (
 @mixin breakpoint-dynamic-sidebar-content {
   @include inTargetWeb {
     max-width: 920px;
-    min-width: map-deep-get($breakpoint-attributes, (default, small, min-width));
     margin-left: auto;
     margin-right: auto;
     padding-left: 80px;


### PR DESCRIPTION
- **Rationale:** Fixes a regression introduced by recent style changes for padding in the small viewport.
- **Risk:** Small
- **Risk Detail:** Minimal CSS changes
- **Reward:** High
- **Reward Details:** Fixes a regression introduced by recent style changes.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/369
- **Issue:** rdar://95981164
- **Code Reviewed By:** @dobromir-hristov @SamLanier 
- **Testing Details:** Tested manually in the browser.