### PR TITLE
[5.7] Make sure "Hide Deprecated" is not shown, when API changes are enabled

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -266,6 +266,10 @@ export default {
 
       const tagLabelsSet = new Set(tagLabels);
       const generalTags = new Set([HIDE_DEPRECATED_TAG]);
+      // when API changes are available, remove the `HIDE_DEPRECATED_TAG` option
+      if (apiChangesTypesSet.size) {
+        generalTags.delete(HIDE_DEPRECATED_TAG);
+      }
       const availableTags = {
         type: [],
         changes: [],

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1572,6 +1572,42 @@ describe('NavigatorCard', () => {
     expect(allItems.at(2).props('item')).toEqual(root0Child1GrandChild0);
   });
 
+  it('Does not show "Hide Deprecated" tag, if API changes are ON', async () => {
+    const updatedChild = {
+      ...root0Child0,
+      deprecated: true,
+    };
+    const groupMarker = {
+      type: TopicTypes.groupMarker,
+      title: 'First Child Group Marker',
+      uid: 22,
+      parent: root0.uid,
+      depth: 1,
+      index: 4,
+      childUIDs: [],
+    };
+    const root0Updated = {
+      ...root0,
+      childUIDs: root0.childUIDs.concat(groupMarker.uid),
+    };
+    const apiChanges = {
+      [updatedChild.path]: ChangeTypes.added,
+    };
+    const wrapper = createWrapper({
+      propsData: {
+        children: [
+          root0Updated, updatedChild, groupMarker, root0Child1, root0Child1GrandChild0, root1,
+        ],
+        activePath: [root0.path],
+        apiChanges,
+      },
+    });
+    await flushPromises();
+    const filter = wrapper.find(FilterInput);
+    // assert there is no 'Hide Deprecated' tag
+    expect(filter.props('tags')).not.toContain(HIDE_DEPRECATED_TAG);
+  });
+
   describe('navigating', () => {
     it('changes the open item, when navigating across pages, keeping the previously open items', async () => {
       // simulate navigating to the bottom most item.


### PR DESCRIPTION
- **Rationale:** Modifies the Navigator tags to now show "Hide Deprecated" tag, if API changes are available.
- **Risk:** Medium
- **Risk Detail:** Changes the logic that shows tags
- **Reward:** Medium
- **Reward Details:** Users no longer will see Deprecated items, even though they clicked Hide Deprecated.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/375
- **Issue:** rdar://94295219
- **Code Reviewed By:** @mportiz08  
- **Testing Details:** Tested manually in the browser and added unit tests.