### PR TITLE
[5.7] Fix footer gutters on small sizes

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -37,5 +37,10 @@ export default {
   display: flex;
   flex-direction: row-reverse;
   padding: 20px 0;
+  @include breakpoint(small) {
+    width: 100%;
+    padding: 20px $nav-padding-small;
+    box-sizing: border-box;
+  }
 }
 </style>


### PR DESCRIPTION
- **Rationale:** Fixes the footer gutters on small screen sizes to match those of the navigator.
- **Risk:** Small
- **Risk Detail:** CSS Only changes to the footer
- **Reward:** Small
- **Reward Details:** Gutter sizes are now the same as the header.
- **Original PR:** https://github.com/apple/swift-docc-render/pull/362
- **Issue:** rdar://91829676
- **Code Reviewed By:** @marinaaisa   
- **Testing Details:** Tested manually in the browser