### PR TITLE
[5.7] Open Navigator Recursively with Option-Right Arrow

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -16,8 +16,9 @@
     :id="`container-${item.uid}`"
     :aria-hidden="isRendered ? null : 'true'"
     @keydown.left.prevent="handleLeftKeydown"
-    @keydown.right.prevent="handleRightKeydown"
+    @keydown.right.exact.prevent="handleRightKeydown"
     @keydown.enter.prevent="clickReference"
+    @keydown.alt.right.prevent="toggleEntireTree"
   >
     <div class="head-wrapper" :class="{ active: isActive, 'is-group': isGroupMarker }">
       <span

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -188,6 +188,15 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.emitted()).toEqual({ 'toggle-full': [[defaultProps.item]] });
   });
 
+
+  it('emits a `toggle-full` event, when @keydown.right + alt/option the tree-toggle button', () => {
+    const wrapper = createWrapper();
+    wrapper.find('.tree-toggle').trigger('keydown.right', {
+      altKey: true,
+    });
+    expect(wrapper.emitted()).toEqual({ 'toggle-full': [[defaultProps.item]] });
+  });
+
   it('emits a `toggle-siblings` event, when cmd + clicking the tree-toggle button', () => {
     const wrapper = createWrapper();
     wrapper.find('.tree-toggle').trigger('click', {
@@ -213,7 +222,24 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.find('.icon-inline').classes()).not.toContain('animating');
   });
 
-  it('adds a temporary `animating` class, on `@toggle-full`', async () => {
+  it('adds a temporary `animating` class, on `@toggle-full` when @keydown.right + alt/option the tree-toggle button', async () => {
+    const wrapper = createWrapper();
+    wrapper.find('.tree-toggle').trigger('keydown.right', { altKey: true });
+    expect(wrapper.emitted('toggle-full')).toEqual([[defaultProps.item]]);
+    // assert it adds the animating class
+    expect(wrapper.find('.icon-inline').classes()).toContain('animating');
+    wrapper.setProps({
+      expanded: true,
+    });
+    expect(wrapper.find('.icon-inline').classes()).toContain('animating');
+    await flushPromises();
+    // assert we have waited a few frames
+    expect(waitFrames).toHaveBeenCalledTimes(1);
+    expect(waitFrames).toHaveBeenCalledWith(9);
+    expect(wrapper.find('.icon-inline').classes()).not.toContain('animating');
+  });
+
+  it('adds a temporary `animating` class, on `@toggle-full` with alt + rightkey', async () => {
     const wrapper = createWrapper();
     wrapper.find('.tree-toggle').trigger('click', { altKey: true });
     expect(wrapper.emitted('toggle-full')).toEqual([[defaultProps.item]]);


### PR DESCRIPTION
- **Rationale:**  Adds support for recursively expanding all of the children underneath a given navigator item by using Option-Click or Option-Right Arrow.
- **Risk:** Low
- **Risk Detail:** Small, additional keyboard shortcut introduced
- **Reward:** Low
- **Reward Details:** Allows for additional shortcut of option-right-arrow to expand navigator
- **Original PR:** https://github.com/apple/swift-docc-render/pull/383
- **Issue:** rdar://92738111
- **Code Reviewed By:** @marinaaisa   
- **Testing Details:** Updated unit tests