### PR TITLE
[5.7] Wait for the nav collapse animation to end before changing the language on mobile

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -45,7 +45,7 @@
         <span v-else class="nav-title-link inactive">Documentation</span>
       </slot>
     </template>
-    <template slot="tray">
+    <template #tray="{ closeNav }">
       <Hierarchy
         :currentTopicTitle="title"
         :isSymbolDeprecated="isSymbolDeprecated"
@@ -63,6 +63,7 @@
           :interfaceLanguage="interfaceLanguage"
           :objcPath="objcPath"
           :swiftPath="swiftPath"
+          :closeNav="closeNav"
         />
         <slot name="menu-items" />
       </NavMenuItems>

--- a/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
+++ b/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
@@ -66,13 +66,14 @@
           >
             {{ language.name }}
           </span>
-          <router-link
+          <a
             v-else
+            href="#"
             class="nav-menu-link"
-            :to="getRoute(language.route)"
+            @click.prevent="pushRoute(language.route)"
           >
             {{ language.name }}
-          </router-link>
+          </a>
         </li>
       </ul>
     </div>
@@ -110,6 +111,10 @@ export default {
     swiftPath: {
       type: String,
       required: false,
+    },
+    closeNav: {
+      type: Function,
+      default: () => {},
     },
   },
   data() {
@@ -160,7 +165,8 @@ export default {
         path: this.isCurrentPath(route.path) ? null : this.normalizePath(route.path),
       };
     },
-    pushRoute(route) {
+    async pushRoute(route) {
+      await this.closeNav();
       // Persist the selected language as a preference in the store (backed by
       // the browser's local storage so that it can be retrieved later for
       // subsequent navigation without the query parameter present)

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -45,7 +45,7 @@
             @transitionend.self="onTransitionEnd"
             @click="handleTrayClick"
           >
-            <slot name="tray">
+            <slot name="tray" :closeNav="closeNav">
               <NavMenuItems>
                 <slot name="menu-items" />
               </NavMenuItems>
@@ -91,7 +91,7 @@ const NavStateClasses = {
   isDark: 'theme-dark',
   isOpen: 'nav--is-open',
   inBreakpoint: 'nav--in-breakpoint-range',
-  isTransitioning: 'nav--is-opening',
+  isTransitioning: 'nav--is-transitioning',
   isSticking: 'nav--is-sticking',
   hasSolidBackground: 'nav--solid-background',
   hasNoBorder: 'nav--noborder',
@@ -215,6 +215,20 @@ export default {
     },
     closeNav() {
       this.isOpen = false;
+      return this.resolveOnceTransitionsEnd();
+    },
+    resolveOnceTransitionsEnd() {
+      // if outside the breakpoint, resolve as there is no tray animation
+      if (!this.inBreakpoint) return Promise.resolve();
+      // enable the transitioning up tracking
+      this.isTransitioning = true;
+      // resolve a promise, when we stop transitioning
+      return new Promise((resolve) => {
+        const unwatch = this.$watch('isTransitioning', () => {
+          resolve();
+          unwatch();
+        });
+      });
     },
     /**
      * When the closing animation ends,
@@ -620,7 +634,7 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
       visibility: visible;
       transition-delay: 0.2s, 0s;
 
-      @include unify-selector('.nav--is-opening', $nested: true) {
+      @include unify-selector('.nav--is-transitioning', $nested: true) {
         overflow-y: hidden;
       }
 

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -214,12 +214,15 @@ export default {
       this.isTransitioning = true;
     },
     closeNav() {
+      const oldValue = this.isOpen;
+      // close the nav
       this.isOpen = false;
-      return this.resolveOnceTransitionsEnd();
+      // return a promise, that resolves when transitions end
+      return this.resolveOnceTransitionsEnd(oldValue);
     },
-    resolveOnceTransitionsEnd() {
-      // if outside the breakpoint, resolve as there is no tray animation
-      if (!this.inBreakpoint) return Promise.resolve();
+    resolveOnceTransitionsEnd(oldIsOpen) {
+      // if outside the breakpoint, or was already closed, resolve as there is no tray animation
+      if (!oldIsOpen || !this.inBreakpoint) return Promise.resolve();
       // enable the transitioning up tracking
       this.isTransitioning = true;
       // resolve a promise, when we stop transitioning

--- a/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
@@ -210,6 +210,7 @@ describe('DocumentationNav', () => {
       interfaceLanguage: propsData.interfaceLanguage,
       swiftPath: propsData.swiftPath,
       objcPath: propsData.objcPath,
+      closeNav: expect.any(Function),
     });
   });
 

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -574,5 +574,13 @@ describe('NavBase', () => {
       await wrapper.vm.$nextTick();
       expect(resolved).toBe(true);
     });
+
+    it('resolves closeNav immediately, if already closed and in breakpoint', async () => {
+      wrapper = await createWrapper({
+        data: () => ({ inBreakpoint: true, isOpen: false }),
+      });
+      expect(wrapper.classes()).not.toContain(NavStateClasses.isOpen);
+      await expect(wrapper.vm.closeNav()).resolves.toBeUndefined();
+    });
   });
 });

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -204,14 +204,21 @@ describe('NavBase', () => {
   });
 
   it('renders the `tray` slot', async () => {
+    let slotProps = null;
     wrapper = await createWrapper({
-      slots: {
-        tray: '<div class="tray-slot">Tray slot content</div>',
+      scopedSlots: {
+        tray(props) {
+          slotProps = props;
+          return this.$createElement('div', { class: 'tray-slot' }, 'Tray slot content');
+        },
       },
     });
     const tray = wrapper.find({ ref: 'tray' });
     expect(tray.find('.tray-slot').text()).toBe('Tray slot content');
     expect(wrapper.find(NavMenuItems).exists()).toBe(false);
+    expect(slotProps).toEqual({
+      closeNav: expect.any(Function),
+    });
   });
 
   it('renders the `menu-items` slot', async () => {
@@ -550,6 +557,22 @@ describe('NavBase', () => {
 
       wrapper.find(BreakpointEmitter).vm.$emit('change', BreakpointName.large);
       expect(wrapper.classes()).not.toContain(NavStateClasses.isOpen);
+    });
+
+    it('resolves closeNav on transitionEnd, only when inside Breakpoint', async () => {
+      wrapper = await createWrapper({
+        data: () => ({ inBreakpoint: true, isOpen: true }),
+      });
+      expect(wrapper.classes()).toContain(NavStateClasses.isOpen);
+      let resolved = false;
+      wrapper.vm.closeNav().then(() => {
+        resolved = true;
+      });
+      await wrapper.vm.$nextTick();
+      expect(resolved).toBe(false);
+      emitEndOfTrayTransition(wrapper);
+      await wrapper.vm.$nextTick();
+      expect(resolved).toBe(true);
     });
   });
 });


### PR DESCRIPTION
- **Rationale:** The language switcher will now wait for the nav to collapse itself, before changing the language. This will prevent glitchy collapse animation from changing breadcrumbs.
- **Risk:** Low
- **Risk Detail:** Adds logic to wait for the animation to finish, before changing the language
- **Reward:** Medium
- **Reward Details:** Users no longer get a glitchy language switching exp on mobile
- **Original PR:** https://github.com/apple/swift-docc-render/pull/367
- **Issue:** rdar://94461604
- **Code Reviewed By:** @hqhhuang     
- **Testing Details:** Tested manually in the browser and added unit tests