### PR TITLE
Fix bug where mobile navigator does not open

### DIFF
--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -214,12 +214,15 @@ export default {
       this.isTransitioning = true;
     },
     closeNav() {
+      const oldValue = this.isOpen;
+      // close the nav
       this.isOpen = false;
-      return this.resolveOnceTransitionsEnd();
+      // return a promise, that resolves when transitions end
+      return this.resolveOnceTransitionsEnd(oldValue);
     },
-    resolveOnceTransitionsEnd() {
-      // if outside the breakpoint, resolve as there is no tray animation
-      if (!this.inBreakpoint) return Promise.resolve();
+    resolveOnceTransitionsEnd(oldIsOpen) {
+      // if outside the breakpoint, or was already closed, resolve as there is no tray animation
+      if (!oldIsOpen || !this.inBreakpoint) return Promise.resolve();
       // enable the transitioning up tracking
       this.isTransitioning = true;
       // resolve a promise, when we stop transitioning

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -574,5 +574,13 @@ describe('NavBase', () => {
       await wrapper.vm.$nextTick();
       expect(resolved).toBe(true);
     });
+
+    it('resolves closeNav immediately, if already closed and in breakpoint', async () => {
+      wrapper = await createWrapper({
+        data: () => ({ inBreakpoint: true, isOpen: false }),
+      });
+      expect(wrapper.classes()).not.toContain(NavStateClasses.isOpen);
+      await expect(wrapper.vm.closeNav()).resolves.toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 94461604

## Summary

Fixes a regression from #367 , where on mobile it would not open the navigator

## Dependencies

NA

## Testing

Steps:
1. On mobile viewport try to open the navigator from the Nav toggle
2. Assert it opens the navigator

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
