### PR TITLE
[5.7] Framework name links in Topics to be rendered in body text styling instead of code voice

### DIFF
--- a/src/components/DocumentationTopic/TopicsLinkBlock.vue
+++ b/src/components/DocumentationTopic/TopicsLinkBlock.vue
@@ -59,6 +59,7 @@
 </template>
 
 <script>
+import { TopicRole } from 'docc-render/constants/roles';
 import { buildUrl } from 'docc-render/utils/url-helper';
 import Badge from 'docc-render/components/Badge.vue';
 import WordBreak from 'docc-render/components/WordBreak.vue';
@@ -179,6 +180,8 @@ export default {
       if (topic.titleStyle === TitleStyles.title) {
         return topic.ideTitle ? 'span' : 'code';
       }
+      // Framework name links should not be code voice
+      if (topic.role && topic.role === TopicRole.collection) return 'span';
 
       switch (topic.kind) {
       case TopicKind.symbol:

--- a/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
@@ -12,6 +12,7 @@ import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import TopicsLinkBlock from 'docc-render/components/DocumentationTopic/TopicsLinkBlock.vue';
 import { ChangeNames } from 'docc-render/constants/Changes';
 import { multipleLinesClass } from 'docc-render/constants/multipleLines';
+import { TopicRole } from 'docc-render/constants/roles';
 
 const {
   ReferenceType,
@@ -133,6 +134,28 @@ describe('TopicsLinkBlock', () => {
   });
 
   it('renders a `WordBreak` using <code> tag for link text to symbols', () => {
+    wrapper.setProps({ topic: { ...propsData.topic, kind: TopicKind.symbol } });
+    const wordBreak = wrapper.find('.link').find(WordBreak);
+    expect(wordBreak.exists()).toBe(true);
+    expect(wordBreak.attributes('tag')).toBe('code');
+    expect(wordBreak.text()).toBe(propsData.topic.title);
+  });
+
+  it('renders a `WordBreak` using <span> tag for Framework name links in Topic that have role collection', () => {
+    wrapper.setProps({
+      topic: {
+        ...propsData.topic,
+        role: TopicRole.collection,
+        kind: TopicKind.symbol,
+      },
+    });
+    const wordBreak = wrapper.find('.link').find(WordBreak);
+    expect(wordBreak.exists()).toBe(true);
+    expect(wordBreak.attributes('tag')).toBe('span');
+    expect(wordBreak.text()).toBe(propsData.topic.title);
+  });
+
+  it('renders a `WordBreak` using <code> tag for Framework name links in Topic that do NOT have role collection', () => {
     wrapper.setProps({ topic: { ...propsData.topic, kind: TopicKind.symbol } });
     const wordBreak = wrapper.find('.link').find(WordBreak);
     expect(wordBreak.exists()).toBe(true);


### PR DESCRIPTION
- **Rationale:**   Framework name links in Topics to be rendered in body text styling instead of code voice
- **Risk:** Low
- **Risk Detail:**  Small conditional logic changes for TopicsLinksBlock
- **Reward:** Low
- **Reward Details:** Proper rendering of framework name links 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/371
- **Issue:** rdar://94293647
- **Code Reviewed By:** @mportiz08 @hqhhuang @marinaaisa @dobromir-hristov 
- **Testing Details:** Updated unit tests, tested manually on rendernodes