### PR TITLE
Toggle entire tree when clicking while pressing alt key on title symbol at Navigator

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -76,7 +76,8 @@
           :aria-describedby="`${ariaDescribedBy} ${usageLabel}`"
           class="leaf-link"
           ref="reference"
-          @click.native="handleClick"
+          @click.exact.native="handleClick"
+          @click.alt.native.prevent="toggleEntireTree"
         >
           <HighlightMatches
             :text="item.title"

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -287,6 +287,14 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.emitted('navigate')).toEqual([[defaultProps.item.uid]]);
   });
 
+  it('emits a `toggle-full` event, when alt + clicking on the leaf-link', () => {
+    const wrapper = createWrapper();
+    wrapper.find('.leaf-link').trigger('click', {
+      altKey: true,
+    });
+    expect(wrapper.emitted('toggle-full')).toEqual([[defaultProps.item]]);
+  });
+
   describe('keyboard navigation', () => {
     it('clicks the reference link on `@keydown.enter`', () => {
       const wrapper = createWrapper();


### PR DESCRIPTION
Bug/issue #94150776, if applicable: 

## Summary

Toggle entire tree when clicking while pressing alt key on title symbol at Navigator

## Dependencies

NA

## Testing

Steps:
1. Run doccarchive with navigation
2. Click on a title symbol while holding the option/alt key and assert that toggle the entire tree

## Checklist

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
