### PR TITLE
Plist links in topics section should not be in code voice

### DIFF
--- a/src/components/DocumentationTopic/TopicsLinkBlock.vue
+++ b/src/components/DocumentationTopic/TopicsLinkBlock.vue
@@ -180,8 +180,8 @@ export default {
       if (topic.titleStyle === TitleStyles.title) {
         return topic.ideTitle ? 'span' : 'code';
       }
-      // Framework name links should not be code voice
-      if (topic.role && topic.role === TopicRole.collection) return 'span';
+      // Framework name and property list links and should not be code voice
+      if (topic.role && (topic.role === TopicRole.collection || topic.role === TopicRole.dictionarySymbol)) return 'span';
 
       switch (topic.kind) {
       case TopicKind.symbol:

--- a/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
@@ -155,7 +155,21 @@ describe('TopicsLinkBlock', () => {
     expect(wordBreak.text()).toBe(propsData.topic.title);
   });
 
-  it('renders a `WordBreak` using <code> tag for Framework name links in Topic that do NOT have role collection', () => {
+  it('renders a `WordBreak` using <span> tag for property list links in Topic, which have role dictionarySymbol', () => {
+    wrapper.setProps({
+      topic: {
+        ...propsData.topic,
+        role: TopicRole.dictionarySymbol,
+        kind: TopicKind.symbol,
+      },
+    });
+    const wordBreak = wrapper.find('.link').find(WordBreak);
+    expect(wordBreak.exists()).toBe(true);
+    expect(wordBreak.attributes('tag')).toBe('span');
+    expect(wordBreak.text()).toBe(propsData.topic.title);
+  });
+
+  it('renders a `WordBreak` using <code> tag for Framework name links in Topic that do NOT have role collection or dictionarySymbol', () => {
     wrapper.setProps({ topic: { ...propsData.topic, kind: TopicKind.symbol } });
     const wordBreak = wrapper.find('.link').find(WordBreak);
     expect(wordBreak.exists()).toBe(true);

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -188,7 +188,6 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.emitted()).toEqual({ 'toggle-full': [[defaultProps.item]] });
   });
 
-
   it('emits a `toggle-full` event, when @keydown.right + alt/option the tree-toggle button', () => {
     const wrapper = createWrapper();
     wrapper.find('.tree-toggle').trigger('keydown.right', {


### PR DESCRIPTION
Bug/issue #, if applicable: 62751444

## Summary
Plist links in the Topics section should not be in code voice

## Testing
Manually verify in browser 
Steps:
1. Navigate to a documentation with links to property list pages in the topics section
2. Verify that the link is rendered in plain text instead of code voice

## Checklist
- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
