### PR TITLE
[5.7] Plist links in topics section should not be in code voice

### DIFF
--- a/src/components/DocumentationTopic/TopicsLinkBlock.vue
+++ b/src/components/DocumentationTopic/TopicsLinkBlock.vue
@@ -179,6 +179,8 @@ export default {
       if (topic.titleStyle === TitleStyles.title) {
         return topic.ideTitle ? 'span' : 'code';
       }
+      // Framework name and property list links and should not be code voice
+      if (topic.role && (topic.role === TopicRole.collection || topic.role === TopicRole.dictionarySymbol)) return 'span';
 
       switch (topic.kind) {
       case TopicKind.symbol:

--- a/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
@@ -140,6 +140,42 @@ describe('TopicsLinkBlock', () => {
     expect(wordBreak.text()).toBe(propsData.topic.title);
   });
 
+  it('renders a `WordBreak` using <span> tag for Framework name links in Topic that have role collection', () => {
+    wrapper.setProps({
+      topic: {
+        ...propsData.topic,
+        role: TopicRole.collection,
+        kind: TopicKind.symbol,
+      },
+    });
+    const wordBreak = wrapper.find('.link').find(WordBreak);
+    expect(wordBreak.exists()).toBe(true);
+    expect(wordBreak.attributes('tag')).toBe('span');
+    expect(wordBreak.text()).toBe(propsData.topic.title);
+  });
+
+  it('renders a `WordBreak` using <span> tag for property list links in Topic, which have role dictionarySymbol', () => {
+    wrapper.setProps({
+      topic: {
+        ...propsData.topic,
+        role: TopicRole.dictionarySymbol,
+        kind: TopicKind.symbol,
+      },
+    });
+    const wordBreak = wrapper.find('.link').find(WordBreak);
+    expect(wordBreak.exists()).toBe(true);
+    expect(wordBreak.attributes('tag')).toBe('span');
+    expect(wordBreak.text()).toBe(propsData.topic.title);
+  });
+
+  it('renders a `WordBreak` using <code> tag for Framework name links in Topic that do NOT have role collection or dictionarySymbol', () => {
+    wrapper.setProps({ topic: { ...propsData.topic, kind: TopicKind.symbol } });
+    const wordBreak = wrapper.find('.link').find(WordBreak);
+    expect(wordBreak.exists()).toBe(true);
+    expect(wordBreak.attributes('tag')).toBe('code');
+    expect(wordBreak.text()).toBe(propsData.topic.title);
+  });
+
   it('renders a `WordBreak` using <code> tag for links with a titleStyle == title and no ideTitle', () => {
     wrapper.setProps({ topic: { ...propsData.topic, titleStyle: 'title' } });
     const wordBreak = wrapper.find('.link').find(WordBreak);

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -188,7 +188,6 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.emitted()).toEqual({ 'toggle-full': [[defaultProps.item]] });
   });
 
-
   it('emits a `toggle-full` event, when @keydown.right + alt/option the tree-toggle button', () => {
     const wrapper = createWrapper();
     wrapper.find('.tree-toggle').trigger('keydown.right', {


### PR DESCRIPTION
- Rationale: Plist links are being displayed in code voice in the topics section, which is misleading and inconsistent with how the same links are displayed on other sections of the page
- Risk: Low
- Risk Detail: Only affects plist links in the topic section; does not affect other types of pages.
- Reward: High
- Reward Details: Plist items will no longer be incorrectly displayed in code voice in the Topics section
- Original PR: https://github.com/apple/swift-docc-render/pull/390
- Issue: rdar://62751444
- Code Reviewed By: @mportiz08 
- Testing Details: Tested manually in the browser and added relevant unit tests

Note: dependency: https://github.com/apple/swift-docc-render/pull/388