### PR TITLE
[5.7] Toggle entire tree when clicking while pressing alt key on title symbol at Navigator

### DIFF
--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -76,7 +76,8 @@
           :aria-describedby="`${ariaDescribedBy} ${usageLabel}`"
           class="leaf-link"
           ref="reference"
-          @click.native="handleClick"
+          @click.exact.native="handleClick"
+          @click.alt.native.prevent="toggleEntireTree"
         >
           <HighlightMatches
             :text="item.title"

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -287,6 +287,14 @@ describe('NavigatorCardItem', () => {
     expect(wrapper.emitted('navigate')).toEqual([[defaultProps.item.uid]]);
   });
 
+  it('emits a `toggle-full` event, when alt + clicking on the leaf-link', () => {
+    const wrapper = createWrapper();
+    wrapper.find('.leaf-link').trigger('click', {
+      altKey: true,
+    });
+    expect(wrapper.emitted('toggle-full')).toEqual([[defaultProps.item]]);
+  });
+
   describe('keyboard navigation', () => {
     it('clicks the reference link on `@keydown.enter`', () => {
       const wrapper = createWrapper();


### PR DESCRIPTION
- Rationale: Toggle entire tree when clicking while pressing alt key on title symbol at Navigator
- Risk: Low
- Risk Detail: Only affects a small interaction in the navigator
- Reward: Low
- Reward Details: Users will be able to toggle the entire tree in a new interaction, similar to the macOS experience
- Original PR: https://github.com/apple/swift-docc-render/pull/389
- Issue: rdar://94150776
- Code Reviewed By: @hqhhuang @dobromir-hristov 
- Testing Details: Tested manually in the browser and added relevant unit tests