### PR TITLE
Fix multiline detection in DeclarationSource for ObjC

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -168,12 +168,11 @@ export default {
     },
   },
   async mounted() {
-    if (hasMultipleLines(this.$refs.declarationGroup)) this.hasMultipleLines = true;
-
     if (this.language === Language.objectiveC.key.api) {
       await this.$nextTick();
       indentDeclaration(this.$refs.code, this.language);
     }
+    if (hasMultipleLines(this.$refs.declarationGroup)) this.hasMultipleLines = true;
   },
 };
 </script>


### PR DESCRIPTION
Bug/issue #, if applicable: 97024618

## Summary

Moves the multiline code detection after we indent ObjC code, so we can properly detect newly created new lines.

## Dependencies

NA

## Testing

This bug is seen in Safari only, so use that to test.

Steps:
1. Go to a page that has a multiline declaration in ObjC language
2. Assert with the inspector, that there is a `.has-multiple-lines` class on the `.source` class.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
