### PR TITLE
[AX] Color scheme toggle keyboard navigation should follow radio buttons standards

### DIFF
--- a/src/components/ColorSchemeToggle.vue
+++ b/src/components/ColorSchemeToggle.vue
@@ -13,7 +13,6 @@
     aria-label="Select a color scheme preference"
     class="color-scheme-toggle"
     role="radiogroup"
-    tabindex="0"
   >
     <label
       v-for="option in options"
@@ -83,6 +82,12 @@ export default {
 input {
   @include visuallyhidden;
   appearance: none;
+}
+
+label {
+  @include on-keyboard-focus-within() {
+    @include focus-outline();
+  }
 }
 
 .text {

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -487,11 +487,9 @@ $input-height: rem(28px);
       border-bottom-left-radius: $small-border-radius - 1;
       border-bottom-right-radius: $small-border-radius - 1;
 
-      .fromkeyboard & {
-        &:focus {
-          outline: none;
-          box-shadow: 0 0 0 5px var(--color-focus-color);
-        }
+      @include on-keyboard-focus() {
+        outline: none;
+        box-shadow: 0 0 0 5px var(--color-focus-color);
       }
     }
 

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -250,15 +250,13 @@ $nesting-spacing: $card-horizontal-spacing + $card-horizontal-spacing-small;
   display: flex;
   align-items: center;
 
-  .fromkeyboard & {
-    &:focus-within {
-      margin: $card-horizontal-spacing-small;
-      height: $item-height - 10px;
-      @include focus-outline();
+  @include on-keyboard-focus-within() {
+    margin: $card-horizontal-spacing-small;
+    height: $item-height - 10px;
+    @include focus-outline();
 
-      .depth-spacer {
-        margin-left: -$card-horizontal-spacing-small;
-      }
+    .depth-spacer {
+      margin-left: -$card-horizontal-spacing-small;
     }
   }
 }

--- a/src/styles/core/_helpers.scss
+++ b/src/styles/core/_helpers.scss
@@ -67,7 +67,7 @@
     line-height: $line-height;
     clip-path: unset;
   }
-}
+};
 
 ////
 /// Apply styling only when focused via the keyboard.
@@ -78,7 +78,18 @@
       @content
     }
   }
-}
+};
+
+////
+/// Apply styling only when focused via the keyboard in a element inside.
+////
+@mixin on-keyboard-focus-within() {
+  .fromkeyboard & {
+    &:focus-within {
+      @content
+    }
+  }
+};
 
 ////
 /// Replaces the outline effect when an element is in focus, with a box shadow effect.

--- a/src/styles/core/_helpers.scss
+++ b/src/styles/core/_helpers.scss
@@ -81,7 +81,7 @@
 };
 
 ////
-/// Apply styling only when focused via the keyboard in a element inside.
+/// Apply styling only when focused via the keyboard in an element inside.
 ////
 @mixin on-keyboard-focus-within() {
   .fromkeyboard & {


### PR DESCRIPTION
Bug/issue #94221573, if applicable: 

## Summary

Color scheme toggle keyboard navigation should follow radio buttons standards: https://www.w3.org/WAI/ARIA/apg/example-index/radio/radio.html

https://user-images.githubusercontent.com/8567677/182437276-458b790e-e91d-4d8a-b1c9-ee6f49f761df.mov

## Dependencies

NA

## Testing

Steps:
1. Run any doccarchive
2. Go to footer
3. Tab and assert that you focus the radio buttons for the Color scheme toggle
4. Assert that by pressing the arrow keys you can select different color schemes

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
