### PR TITLE
Add support for the `@Image` directive

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -185,19 +185,20 @@ function renderNode(createElement, references) {
 
   const renderFigure = ({
     metadata: {
-      abstract,
+      abstract = [],
       anchor,
       title,
     },
     ...node
-  }) => createElement(Figure, { props: { anchor } }, [
-    ...(title && abstract && abstract.length ? [
-      createElement(FigureCaption, { props: { title } }, (
-        renderChildren(abstract)
-      )),
-    ] : []),
-    renderChildren([node]),
-  ]);
+  }) => {
+    const figureContent = [renderChildren([node])];
+    if ((title && abstract.length) || abstract.length) {
+      // if there is a `title`, it should be above, otherwise below
+      figureContent.splice(title ? 0 : 1, 0,
+        createElement(FigureCaption, { props: { title } }, renderChildren(abstract)));
+    }
+    return createElement(Figure, { props: { anchor } }, figureContent);
+  };
 
   return function render(node) {
     switch (node.type) {
@@ -284,7 +285,7 @@ function renderNode(createElement, references) {
         renderChildren(node.inlineContent)
       ));
     case InlineType.image: {
-      if (node.metadata && node.metadata.anchor) {
+      if (node.metadata && (node.metadata.anchor || node.metadata.abstract)) {
         return renderFigure(node);
       }
 

--- a/src/components/ContentNode/Figure.vue
+++ b/src/components/ContentNode/Figure.vue
@@ -18,7 +18,7 @@ export default {
   props: {
     anchor: {
       type: String,
-      required: true,
+      required: false,
     },
   },
 };

--- a/src/components/ContentNode/FigureCaption.vue
+++ b/src/components/ContentNode/FigureCaption.vue
@@ -10,7 +10,7 @@
 
 <template>
   <figcaption class="caption">
-    <strong>{{ title }}</strong>&nbsp;<slot />
+    <strong v-if="title">{{ title }}</strong>&nbsp;<slot />
   </figcaption>
 </template>
 
@@ -20,7 +20,7 @@ export default {
   props: {
     title: {
       type: String,
-      required: true,
+      required: false,
     },
   },
 };

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -431,6 +431,83 @@ describe('ContentNode', () => {
       expect(caption.props('title')).toBe(metadata.title);
       expect(caption.text()).toContain('blah');
     });
+
+    it('renders a `Figure`/`FigureCaption` without an anchor, with text under the image', () => {
+      const metadata = {
+        abstract: [{
+          type: 'paragraph',
+          inlineContent: [{ type: 'text', text: 'blah' }],
+        }],
+      };
+      const wrapper = mountWithItem({
+        type: 'image',
+        identifier: 'figure1.png',
+        metadata,
+      }, references);
+
+      const figure = wrapper.find(Figure);
+      expect(figure.exists()).toBe(true);
+      expect(figure.props('anchor')).toBeFalsy();
+      expect(figure.contains(InlineImage)).toBe(true);
+
+      const caption = wrapper.find(FigureCaption);
+      expect(caption.exists()).toBe(true);
+      expect(caption.contains('p')).toBe(true);
+      expect(caption.props('title')).toBeFalsy();
+      expect(caption.text()).toContain('blah');
+      // assert figurerecaption is below the image
+      expect(figure.html()).toMatchInlineSnapshot(`
+        <figure-stub>
+          <inlineimage-stub alt="" variants="[object Object],[object Object]"></inlineimage-stub>
+          <figurecaption-stub>
+            <p>blah</p>
+          </figurecaption-stub>
+        </figure-stub>
+      `);
+    });
+
+    it('renders a `FigureCaption` before the image, if it has a title', () => {
+      const metadata = {
+        title: 'foo',
+        abstract: [{
+          type: 'paragraph',
+          inlineContent: [{ type: 'text', text: 'blah' }],
+        }],
+      };
+      const wrapper = mountWithItem({
+        type: 'image',
+        identifier: 'figure1.png',
+        metadata,
+      }, references);
+      expect(wrapper.find(Figure).html()).toMatchInlineSnapshot(`
+        <figure-stub>
+          <figurecaption-stub title="foo">
+            <p>blah</p>
+          </figurecaption-stub>
+          <inlineimage-stub alt="" variants="[object Object],[object Object]"></inlineimage-stub>
+        </figure-stub>
+      `);
+    });
+
+    it('renders no `FigureCaption`, if there is a `title`, but no `abstract`', () => {
+      const metadata = {
+        postTitle: true,
+        title: 'Foo',
+        anchor: 'foo-figure',
+      };
+      const wrapper = mountWithItem({
+        type: 'image',
+        identifier: 'figure1.png',
+        metadata,
+      }, references);
+
+      const figure = wrapper.find(Figure);
+      expect(figure.exists()).toBe(true);
+      expect(figure.props('anchor')).toBe('foo-figure');
+      expect(figure.contains(InlineImage)).toBe(true);
+
+      expect(wrapper.find(FigureCaption).exists()).toBe(false);
+    });
   });
 
   describe('with type="link"', () => {

--- a/tests/unit/components/ContentNode/Figure.spec.js
+++ b/tests/unit/components/ContentNode/Figure.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import { shallowMount } from '@vue/test-utils';
 import Figure from 'docc-render/components/ContentNode/Figure.vue';
@@ -20,6 +20,17 @@ describe('Figure', () => {
 
     expect(wrapper.is('figure')).toBe(true);
     expect(wrapper.attributes('id')).toBe(propsData.anchor);
+
+    const p = wrapper.find('p');
+    expect(p.exists()).toBe(true);
+    expect(p.text()).toBe('blah');
+  });
+
+  it('renders a <figure> without an id, just slot content', () => {
+    const wrapper = shallowMount(Figure, { slots });
+
+    expect(wrapper.is('figure')).toBe(true);
+    expect(wrapper.attributes('id')).toBeFalsy();
 
     const p = wrapper.find('p');
     expect(p.exists()).toBe(true);

--- a/tests/unit/components/ContentNode/Figure.spec.js
+++ b/tests/unit/components/ContentNode/Figure.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import { shallowMount } from '@vue/test-utils';
 import Figure from 'docc-render/components/ContentNode/Figure.vue';

--- a/tests/unit/components/ContentNode/FigureCaption.spec.js
+++ b/tests/unit/components/ContentNode/FigureCaption.spec.js
@@ -20,4 +20,11 @@ describe('FigureCaption', () => {
     expect(wrapper.is('figcaption')).toBe(true);
     expect(wrapper.text()).toMatch(/Figure 1\sBlah/);
   });
+  it('renders a <figcaption> with slot content only', () => {
+    const slots = { default: '<p>Blah</p>' };
+    const wrapper = shallowMount(FigureCaption, { slots });
+
+    expect(wrapper.is('figcaption')).toBe(true);
+    expect(wrapper.text()).toBe('Blah');
+  });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 97715120

## Summary

Extends support for the `@Image` directive, by allowing users to add captions to images. 

![image](https://user-images.githubusercontent.com/9863944/183633550-010200d0-52a5-4ee6-a6e1-fb1c59b887ca.png)

It uses the already available `InlineImage` component, and just extends the `Figure` logic to wrap, if either an `anchor` or `abstract` is present.

## Dependencies

DocC PR - 

## Testing

You can add this RenderJSON piece to the `content` array of your render json `primaryContentSections`:

```json
                {
                  "type": "image",
                  "identifier": "reference-for-image",
                  "metadata": {
                    "abstract": [
                      {
                        "type": "text",
                        "text": "Image Caption"
                      }
                    ]
                  }
                }
```

Or use the attached JSON:

[example_image.json.zip](https://github.com/apple/swift-docc-render/files/9289833/example_image.json.zip)

Steps:
1. Assert the caption is rendered below the image

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
