### PR TITLE
Refactor Video assets to allow sound, poster support to replayable videos, text fixes.

### DIFF
--- a/src/components/Asset.vue
+++ b/src/components/Asset.vue
@@ -51,6 +51,10 @@ export default {
       type: Boolean,
       default: () => true,
     },
+    videoMuted: {
+      type: Boolean,
+      default: true,
+    },
   },
   computed: {
     rawAsset() {
@@ -96,6 +100,7 @@ export default {
       return {
         variants: this.asset.variants,
         showsControls: this.showsVideoControls,
+        muted: this.videoMuted,
         autoplays: this.prefersReducedMotion ? false : this.videoAutoplays,
         posterVariants: this.videoPoster ? this.videoPoster.variants : [],
       };

--- a/src/components/ReplayableVideoAsset.vue
+++ b/src/components/ReplayableVideoAsset.vue
@@ -13,9 +13,13 @@
     <VideoAsset
       ref="asset"
       :variants="variants"
-      @ended="onVideoEnd"
-      :showsControls="showsControls"
       :autoplays="autoplays"
+      :showsControls="showsControls"
+      :muted="muted"
+      :posterVariants="posterVariants"
+      @pause="onPause"
+      @playing="onVideoPlaying"
+      @ended="onVideoEnd"
     />
     <a
       class="replay-button"
@@ -23,7 +27,7 @@
       :class="{ visible: this.showsReplayButton }"
       @click.prevent="replay"
     >
-      Replay
+      {{ text }}
       <InlineReplayIcon class="replay-icon icon-inline" />
     </a>
   </div>
@@ -52,10 +56,22 @@ export default {
       type: Boolean,
       default: () => true,
     },
+    muted: {
+      type: Boolean,
+      default: true,
+    },
+    posterVariants: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  computed: {
+    text: ({ played }) => (played ? 'Replay' : 'Play'),
   },
   data() {
     return {
-      showsReplayButton: false,
+      showsReplayButton: !(this.autoplays && this.muted),
+      played: false,
     };
   },
   methods: {
@@ -68,6 +84,16 @@ export default {
     },
     onVideoEnd() {
       this.showsReplayButton = true;
+      this.played = true;
+    },
+    onVideoPlaying() {
+      this.showsReplayButton = false;
+    },
+    onPause() {
+      // if the video pauses, and we are hiding the controls, show the replay button
+      if (!this.showsControls && !this.showsReplayButton) {
+        this.showsReplayButton = true;
+      }
     },
   },
 };

--- a/src/components/VideoAsset.vue
+++ b/src/components/VideoAsset.vue
@@ -13,9 +13,10 @@
     :controls="showsControls"
     :autoplay="autoplays"
     :poster="normalizeAssetUrl(defaultPosterAttributes.url)"
-    muted
+    :muted="muted"
     playsinline
     @playing="$emit('playing')"
+    @pause="$emit('pause')"
     @ended="$emit('ended')"
   >
     <!--
@@ -52,6 +53,10 @@ export default {
       type: Array,
       required: false,
       default: () => [],
+    },
+    muted: {
+      type: Boolean,
+      default: true,
     },
   },
   data: () => ({ appState: AppStore.state }),

--- a/tests/unit/components/Asset.spec.js
+++ b/tests/unit/components/Asset.spec.js
@@ -14,6 +14,21 @@ import ImageAsset from 'docc-render/components/ImageAsset.vue';
 import VideoAsset from 'docc-render/components/VideoAsset.vue';
 import ReplayableVideoAsset from 'docc-render/components/ReplayableVideoAsset.vue';
 
+const video = {
+  type: 'video',
+  poster: 'image',
+  variants: [
+    {
+      url: 'foo.mp4',
+      traits: ['2x'],
+      size: {
+        width: 42,
+        height: 42,
+      },
+    },
+  ],
+};
+
 describe('Asset', () => {
   beforeAll(() => {
     Object.defineProperty(window, 'matchMedia', {
@@ -60,20 +75,6 @@ describe('Asset', () => {
   });
 
   it('renders a `VideoAsset` for video', () => {
-    const foo = {
-      type: 'video',
-      poster: 'image',
-      variants: [
-        {
-          url: 'foo.mp4',
-          traits: ['2x'],
-          size: {
-            width: 42,
-            height: 42,
-          },
-        },
-      ],
-    };
     const image = {
       type: 'image',
       variants: [
@@ -83,10 +84,10 @@ describe('Asset', () => {
         },
       ],
     };
-    const wrapper = mountAsset('foo', { foo, image });
+    const wrapper = mountAsset('video', { video, image });
 
     const videoAsset = wrapper.find(VideoAsset);
-    expect(videoAsset.props('variants')).toBe(foo.variants);
+    expect(videoAsset.props('variants')).toBe(video.variants);
     expect(videoAsset.props('posterVariants')).toBe(image.variants);
     expect(videoAsset.props('showsControls')).toBe(true);
     expect(videoAsset.props('autoplays')).toBe(true);
@@ -97,68 +98,63 @@ describe('Asset', () => {
   });
 
   it('renders a `VideoAsset` without poster variants', () => {
-    const foo = {
-      type: 'video',
-      poster: 'image',
-      variants: [
-        {
-          url: 'foo.mp4',
-          traits: ['2x'],
-          size: {
-            width: 42,
-            height: 42,
-          },
-        },
-      ],
-    };
-    const videoAsset = mountAsset('foo', { foo }).find(VideoAsset);
-    expect(videoAsset.props('variants')).toBe(foo.variants);
+    const videoAsset = mountAsset('video', { video }).find(VideoAsset);
+    expect(videoAsset.props('variants')).toBe(video.variants);
     expect(videoAsset.props('posterVariants')).toEqual([]);
   });
 
   it('renders a `ReplayableVideoAsset` for video with `showsReplayButton=true`', () => {
-    const foo = {
-      type: 'video',
-      variants: [
-        {
-          url: 'foo.mp4',
-          traits: ['2x'],
-          size: {
-            width: 42,
-            height: 42,
-          },
-        },
-      ],
-    };
     const wrapper = shallowMount(Asset, {
       propsData: {
-        identifier: 'foo',
+        identifier: 'video',
         showsReplayButton: true,
         showsVideoControls: true,
       },
-      provide: { references: { foo } },
+      provide: { references: { video } },
     });
 
     const videoAsset = wrapper.find(ReplayableVideoAsset);
-    expect(videoAsset.props('variants')).toBe(foo.variants);
+    expect(videoAsset.props('variants')).toBe(video.variants);
     expect(videoAsset.props('showsControls')).toBe(true);
+    expect(videoAsset.props('muted')).toBe(true);
+  });
+
+  it('renders a `VideoAsset`, without muting it', () => {
+    const wrapper = shallowMount(Asset, {
+      propsData: {
+        identifier: 'video',
+        showsVideoControls: true,
+        videoAutoplays: true,
+        videoMuted: false,
+      },
+      provide: { references: { video } },
+    });
+
+    expect(wrapper.find(ReplayableVideoAsset).exists()).toBe(false);
+    const videoAsset = wrapper.find(VideoAsset);
+    expect(videoAsset.props('variants')).toBe(video.variants);
+    expect(videoAsset.props('showsControls')).toBe(true);
+    expect(videoAsset.props('muted')).toBe(false);
+    expect(videoAsset.props('autoplays')).toBe(true);
+  });
+
+  it('renders a `ReplayableVideoAsset` without it being muted', () => {
+    const wrapper = shallowMount(Asset, {
+      propsData: {
+        identifier: 'video',
+        showsReplayButton: true,
+        showsVideoControls: true,
+        videoMuted: false,
+      },
+      provide: { references: { video } },
+    });
+
+    const videoAsset = wrapper.find(ReplayableVideoAsset);
+    expect(videoAsset.props('showsControls')).toBe(true);
+    expect(videoAsset.props('muted')).toBe(false);
   });
 
   describe('ReduceMotion aware', () => {
-    const video = {
-      type: 'video',
-      poster: 'image',
-      variants: [
-        {
-          url: 'foo.mp4',
-          traits: ['2x'],
-          size: {
-            width: 42,
-            height: 42,
-          },
-        },
-      ],
-    };
     const image = {
       type: 'image',
       alt: 'blah',

--- a/tests/unit/components/Tutorial/SectionIntro.spec.js
+++ b/tests/unit/components/Tutorial/SectionIntro.spec.js
@@ -108,6 +108,7 @@ describe('SectionIntro', () => {
       showsReplayButton: true,
       showsVideoControls: false,
       videoAutoplays: true,
+      videoMuted: true,
     });
   });
 

--- a/tests/unit/components/VideoAsset.spec.js
+++ b/tests/unit/components/VideoAsset.spec.js
@@ -40,6 +40,7 @@ describe('VideoAsset', () => {
 
   it('renders a video', () => {
     expect(wrapper.is('video')).toBe(true);
+    expect(wrapper.element.muted).toBe(true);
   });
 
   it('adds a poster to the `video`, using light by default', () => {
@@ -86,11 +87,14 @@ describe('VideoAsset', () => {
     expect(source.attributes('controls')).toBe(undefined);
   });
 
-  it('forwards `playing` and `ended` events', () => {
+  it('forwards `playing`, `pause` and `ended` events', () => {
     const video = wrapper.find('video');
 
     video.trigger('playing');
     expect(wrapper.emitted().playing.length).toBe(1);
+
+    video.trigger('pause');
+    expect(wrapper.emitted().pause.length).toBe(1);
 
     video.trigger('ended');
     expect(wrapper.emitted().ended.length).toBe(1);
@@ -142,5 +146,12 @@ describe('VideoAsset', () => {
     source = wrapper.find('source');
     expect(source.exists()).toBe(true);
     expect(source.attributes('src')).toBe(propsData.variants[1].url);
+  });
+
+  it('renders a video as none-muted', () => {
+    wrapper.setProps({
+      muted: false,
+    });
+    expect(wrapper.element.muted).toBeFalsy();
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 97715398

## Summary

1. Refactors the Video component to allow rendering videos with sound.
2. Properly pass `posterVariants` to `VideoAsset.vue` from `ReplayableVideoAsset.vue`. This was a bug left from before.
3. Make sure `ReplayableVideoAsset.vue` shows the proper text in it's "Play" butotn, if its not autoplayed yet.

## Dependencies

NA

## Testing

This PR can be best tested with 

Steps:
1. Assert Videos can be rendered with sound ON.
2. Assert that videos with Sound and Autoplay, show a "Play" button.
3. Assert that the "Play" button changes to "Replay", upon video completion. 
4. Assert that in Safari, it shows a "Play" button, even if autoplay is ON with sound.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
