### PR TITLE
Add anchor for section titles for quick sharing of sections

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -11,7 +11,7 @@
 <script>
 import Aside from './ContentNode/Aside.vue';
 import CodeListing from './ContentNode/CodeListing.vue';
-import SectionTitle from './ContentNode/SectionTitle.vue';
+import LinkableHeading from './ContentNode/LinkableHeading.vue';
 import CodeVoice from './ContentNode/CodeVoice.vue';
 import DictionaryExample from './ContentNode/DictionaryExample.vue';
 import EndpointExample from './ContentNode/EndpointExample.vue';
@@ -25,7 +25,6 @@ import StrikeThrough from './ContentNode/StrikeThrough.vue';
 const BlockType = {
   aside: 'aside',
   codeListing: 'codeListing',
-  sectionTitle: 'sectionTitle',
   endpointExample: 'endpointExample',
   heading: 'heading',
   orderedList: 'orderedList',
@@ -232,9 +231,9 @@ function renderNode(createElement, references) {
     case BlockType.heading: {
       const props = {
         anchor: node.anchor,
-        tag: `h${node.level}`,
+        level: Number(node.level),
       };
-      return createElement(SectionTitle, { props }, node.text);
+      return createElement(LinkableHeading, { props }, node.text);
     }
     case BlockType.orderedList:
       return createElement('ol', {

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -11,6 +11,7 @@
 <script>
 import Aside from './ContentNode/Aside.vue';
 import CodeListing from './ContentNode/CodeListing.vue';
+import SectionTitle from './ContentNode/SectionTitle.vue';
 import CodeVoice from './ContentNode/CodeVoice.vue';
 import DictionaryExample from './ContentNode/DictionaryExample.vue';
 import EndpointExample from './ContentNode/EndpointExample.vue';
@@ -24,6 +25,7 @@ import StrikeThrough from './ContentNode/StrikeThrough.vue';
 const BlockType = {
   aside: 'aside',
   codeListing: 'codeListing',
+  sectionTitle: 'sectionTitle',
   endpointExample: 'endpointExample',
   heading: 'heading',
   orderedList: 'orderedList',
@@ -227,24 +229,13 @@ function renderNode(createElement, references) {
       };
       return createElement(EndpointExample, { props }, renderChildren(node.summary || []));
     }
-    case BlockType.heading:
-      return createElement(`h${node.level}`, {
-        attrs: {
-          id: node.anchor,
-        },
-      }, [
-        createElement('a', {
-          attrs: {
-            id: node.anchor,
-            class: 'header-anchor',
-            href: `#${node.anchor}`,
-            'aria-hidden': 'true',
-          },
-        }, (
-          '#'
-        )),
-        node.text,
-      ]);
+    case BlockType.heading: {
+      const props = {
+        anchor: node.anchor,
+        tag: `h${node.level}`,
+      };
+      return createElement(SectionTitle, { props }, node.text);
+    }
     case BlockType.orderedList:
       return createElement('ol', {
         attrs: {

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -231,7 +231,7 @@ function renderNode(createElement, references) {
     case BlockType.heading: {
       const props = {
         anchor: node.anchor,
-        level: Number(node.level),
+        level: node.level,
       };
       return createElement(LinkableHeading, { props }, node.text);
     }

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -232,9 +232,19 @@ function renderNode(createElement, references) {
         attrs: {
           id: node.anchor,
         },
-      }, (
-        node.text
-      ));
+      }, [
+        createElement('a', {
+          attrs: {
+            id: node.anchor,
+            class: 'header-anchor',
+            href: `#${node.anchor}`,
+            'aria-hidden': 'true',
+          },
+        }, (
+          '#'
+        )),
+        node.text,
+      ]);
     case BlockType.orderedList:
       return createElement('ol', {
         attrs: {

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -10,8 +10,8 @@
 
 <template>
   <component
-   :id="!isTargetIDE ? id : null"
-   :is="tag"
+   :id="id"
+   :is="`h${level}`"
    class="section-title"
   >
     <a
@@ -28,8 +28,10 @@
 <script>
 import scrollToElement from 'docc-render/mixins/scrollToElement';
 
+const HeadingLevels = [1, 2, 3, 4, 5, 6];
+
 export default {
-  name: 'SectionTitle',
+  name: 'LinkableHeading',
   mixins: [scrollToElement],
   data() {
     return {
@@ -41,9 +43,10 @@ export default {
       type: String,
       required: false,
     },
-    tag: {
-      type: String,
-      default: () => 'h2',
+    level: {
+      type: Number,
+      default: () => 2,
+      validator: v => v in HeadingLevels,
     },
   },
   inject: {

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -20,6 +20,7 @@
       @click="handleFocusAndScroll(anchor)"
     >
       <slot />
+      <LinkIcon class="icon" aria-hidden="true"/>
     </router-link>
     <template v-else>
       <slot />
@@ -29,10 +30,14 @@
 
 <script>
 import scrollToElement from 'docc-render/mixins/scrollToElement';
+import LinkIcon from 'theme/components/Icons/LinkIcon.vue';
 
 export default {
   name: 'LinkableHeading',
   mixins: [scrollToElement],
+  components: {
+    LinkIcon,
+  },
   props: {
     anchor: {
       type: String,
@@ -58,22 +63,28 @@ export default {
 .header-anchor {
   color: var(--colors-text, var(--color-text));
   text-decoration: none;
-  position: relative;
 
-  &:after {
-    content: "";
-    display: block;
-    position: absolute;
-    width: 0px;
-    bottom: -3px;
-    height: 1px;
-    background-color: var(--colors-text, var(--color-text));
-    // transition: width 0.2s cubic-bezier(0.82, 0.085, 0.395, 0.895) 0s;
-    // transition-delay: .5s;
+  // &:after {
+  //   content: "";
+  //   display: block;
+  //   position: absolute;
+  //   width: 0px;
+  //   bottom: -3px;
+  //   height: 1px;
+  //   background-color: var(--colors-text, var(--color-text));
+  //   // transition: width 0.2s cubic-bezier(0.82, 0.085, 0.395, 0.895) 0s;
+  //   // transition-delay: .5s;
+  // }
+
+  .icon {
+    display: none;
+    height: .6em;
+    margin-left: .3em;
+    fill: currentColor;
   }
 
-  &:hover::after {
-    width: 100%;
+  &:hover .icon {
+    display: inline;
   }
 }
 </style>

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -28,8 +28,6 @@
 <script>
 import scrollToElement from 'docc-render/mixins/scrollToElement';
 
-const HeadingLevels = [1, 2, 3, 4, 5, 6];
-
 export default {
   name: 'LinkableHeading',
   mixins: [scrollToElement],
@@ -46,7 +44,7 @@ export default {
     level: {
       type: Number,
       default: () => 2,
-      validator: v => v in HeadingLevels,
+      validator: v => v >= 1 && v <= 6,
     },
   },
   inject: {

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -17,6 +17,7 @@
       v-if="anchor && !isTargetIDE"
       :to="{ hash: `#${anchor}` }"
       class="header-anchor"
+      aria-label="Scroll to section"
       @click="handleFocusAndScroll(anchor)"
     >
       <slot />

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -10,7 +10,7 @@
 
 <template>
   <component
-   :id="id"
+   :id="anchor"
    :is="`h${level}`"
    class="section-title"
   >
@@ -31,11 +31,6 @@ import scrollToElement from 'docc-render/mixins/scrollToElement';
 export default {
   name: 'LinkableHeading',
   mixins: [scrollToElement],
-  data() {
-    return {
-      id: null,
-    };
-  },
   props: {
     anchor: {
       type: String,
@@ -51,15 +46,6 @@ export default {
     isTargetIDE: {
       default: () => false,
     },
-  },
-  mounted() {
-    if (!this.anchor) return;
-    const element = document.getElementById(`${this.anchor}`);
-    // if there is no element in the document that has an id,
-    // add it to this component
-    if (!element) {
-      this.id = this.anchor;
-    }
   },
 };
 </script>

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -63,17 +63,17 @@ export default {
 $icon-margin: 7px;
 
 .header-anchor {
-  color: var(--colors-text, var(--color-text));
+  color: inherit;
   text-decoration: none;
   position: relative;
-  padding-right: $icon-size + $icon-margin;
+  padding-right: $icon-size-default + $icon-margin;
   display: inline-block;
 
   .icon {
     position: absolute;
     bottom: .2em;
     display: none;
-    height: $icon-size;
+    height: $icon-size-default;
     margin-left: $icon-margin;
   }
 

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -60,21 +60,21 @@ export default {
 
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
+$icon-margin: 7px;
 
 .header-anchor {
   color: var(--colors-text, var(--color-text));
   text-decoration: none;
   position: relative;
-  padding-right: 1em;
+  padding-right: $icon-size + $icon-margin;
   display: inline-block;
 
   .icon {
     position: absolute;
     bottom: .2em;
     display: none;
-    height: .6em;
-    margin-left: .3em;
-    fill: currentColor;
+    height: $icon-size;
+    margin-left: $icon-margin;
   }
 
   &:hover .icon {

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -63,20 +63,11 @@ export default {
 .header-anchor {
   color: var(--colors-text, var(--color-text));
   text-decoration: none;
-
-  // &:after {
-  //   content: "";
-  //   display: block;
-  //   position: absolute;
-  //   width: 0px;
-  //   bottom: -3px;
-  //   height: 1px;
-  //   background-color: var(--colors-text, var(--color-text));
-  //   // transition: width 0.2s cubic-bezier(0.82, 0.085, 0.395, 0.895) 0s;
-  //   // transition-delay: .5s;
-  // }
+  position: relative;
 
   .icon {
+    position: absolute;
+    bottom: .2em;
     display: none;
     height: .6em;
     margin-left: .3em;

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -12,16 +12,18 @@
   <component
    :id="anchor"
    :is="`h${level}`"
-   class="section-title"
   >
     <router-link
       v-if="anchor && !isTargetIDE"
       :to="{ hash: `#${anchor}` }"
       class="header-anchor"
-      aria-label="hidden"
       @click="handleFocusAndScroll(anchor)"
-    >#</router-link>
-    <slot />
+    >
+      <slot />
+    </router-link>
+    <template v-else>
+      <slot />
+    </template>
   </component>
 </template>
 
@@ -53,21 +55,25 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-.section-title:hover {
-  .header-anchor {
-    opacity: 1;
-  }
-}
-
 .header-anchor {
-  margin-left: -0.73em;
-  padding-right: 0.23em;
-  transition: opacity .25s;
-  opacity: 0;
+  color: var(--colors-text, var(--color-text));
   text-decoration: none;
+  position: relative;
 
-  &:hover, &:focus {
-    opacity: 1;
+  &:after {
+    content: "";
+    display: block;
+    position: absolute;
+    width: 0px;
+    bottom: -3px;
+    height: 1px;
+    background-color: var(--colors-text, var(--color-text));
+    // transition: width 0.2s cubic-bezier(0.82, 0.085, 0.395, 0.895) 0s;
+    // transition-delay: .5s;
+  }
+
+  &:hover::after {
+    width: 100%;
   }
 }
 </style>

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -14,13 +14,13 @@
    :is="`h${level}`"
    class="section-title"
   >
-    <a
+    <router-link
       v-if="anchor && !isTargetIDE"
-      :href="`#${anchor}`"
+      :to="{ hash: `#${anchor}` }"
       class="header-anchor"
       aria-label="hidden"
       @click="handleFocusAndScroll(anchor)"
-    >#</a>
+    >#</router-link>
     <slot />
   </component>
 </template>

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -64,6 +64,8 @@ export default {
   color: var(--colors-text, var(--color-text));
   text-decoration: none;
   position: relative;
+  padding-right: 1em;
+  display: inline-block;
 
   .icon {
     position: absolute;

--- a/src/components/ContentNode/SectionTitle.vue
+++ b/src/components/ContentNode/SectionTitle.vue
@@ -1,0 +1,72 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2022 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <component
+   :id="anchor"
+   :is="tag"
+  >
+    <a
+      :href="`#${anchor}`"
+      class="header-anchor"
+      aria-label="hidden"
+    >#</a>
+    <slot />
+  </component>
+</template>
+
+<script>
+export default {
+  name: 'SectionTitle',
+  props: {
+    anchor: {
+      type: String,
+      required: true,
+    },
+    tag: {
+      type: String,
+      default: () => 'h2',
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@import 'docc-render/styles/_core.scss';
+
+h2 {
+  scroll-margin-top: $nav-height + 1rem;
+
+  @include breakpoint(small, $scope: nav) {
+    scroll-margin-top: $nav-height-small + 1rem;
+  }
+}
+
+h2:hover {
+  .header-anchor {
+    opacity: 1;
+  }
+}
+
+.header-anchor {
+  margin-left: -30px;
+  transition: opacity .25s;
+  opacity: 0;
+  text-decoration: none;
+
+  @include breakpoint(small, $scope: nav) {
+    margin-left: -20px;
+  }
+
+  &:hover {
+    opacity: 1;
+  }
+}
+</style>

--- a/src/components/ContentNode/SectionTitle.vue
+++ b/src/components/ContentNode/SectionTitle.vue
@@ -12,6 +12,7 @@
   <component
    :id="anchor"
    :is="tag"
+   class="section-title"
   >
     <a
       :href="`#${anchor}`"
@@ -41,7 +42,7 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-h2 {
+.section-title {
   scroll-margin-top: $nav-height + 1rem;
 
   @include breakpoint(small, $scope: nav) {
@@ -49,21 +50,18 @@ h2 {
   }
 }
 
-h2:hover {
+.section-title:hover {
   .header-anchor {
     opacity: 1;
   }
 }
 
 .header-anchor {
-  margin-left: -30px;
+  margin-left: -0.73em;
+  padding-right: 0.23em;
   transition: opacity .25s;
   opacity: 0;
   text-decoration: none;
-
-  @include breakpoint(small, $scope: nav) {
-    margin-left: -20px;
-  }
 
   &:hover {
     opacity: 1;

--- a/src/components/ContentNode/SectionTitle.vue
+++ b/src/components/ContentNode/SectionTitle.vue
@@ -10,12 +10,12 @@
 
 <template>
   <component
-   :id="id"
+   :id="!isTargetIDE ? id : null"
    :is="tag"
    class="section-title"
   >
     <a
-      v-if="anchor"
+      v-if="anchor && !isTargetIDE"
       :href="`#${anchor}`"
       class="header-anchor"
       aria-label="hidden"
@@ -44,6 +44,11 @@ export default {
     tag: {
       type: String,
       default: () => 'h2',
+    },
+  },
+  inject: {
+    isTargetIDE: {
+      default: () => false,
     },
   },
   mounted() {

--- a/src/components/ContentNode/SectionTitle.vue
+++ b/src/components/ContentNode/SectionTitle.vue
@@ -10,12 +10,13 @@
 
 <template>
   <component
-   :id="anchor"
+   :id="anchor ? anchor : null"
    :is="tag"
    class="section-title"
   >
     <a
-      :href="`#${anchor}`"
+      v-if="anchor || href"
+      :href="`#${anchor || href}`"
       class="header-anchor"
       aria-label="hidden"
     >#</a>
@@ -29,7 +30,11 @@ export default {
   props: {
     anchor: {
       type: String,
-      required: true,
+      required: false,
+    },
+    href: {
+      type: String,
+      required: false,
     },
     tag: {
       type: String,

--- a/src/components/ContentNode/SectionTitle.vue
+++ b/src/components/ContentNode/SectionTitle.vue
@@ -10,29 +10,34 @@
 
 <template>
   <component
-   :id="anchor ? anchor : null"
+   :id="id"
    :is="tag"
    class="section-title"
   >
     <a
-      v-if="anchor || href"
-      :href="`#${anchor || href}`"
+      v-if="anchor"
+      :href="`#${anchor}`"
       class="header-anchor"
       aria-label="hidden"
+      @click="handleFocusAndScroll(anchor)"
     >#</a>
     <slot />
   </component>
 </template>
 
 <script>
+import scrollToElement from 'docc-render/mixins/scrollToElement';
+
 export default {
   name: 'SectionTitle',
+  mixins: [scrollToElement],
+  data() {
+    return {
+      id: null,
+    };
+  },
   props: {
     anchor: {
-      type: String,
-      required: false,
-    },
-    href: {
       type: String,
       required: false,
     },
@@ -41,19 +46,20 @@ export default {
       default: () => 'h2',
     },
   },
+  mounted() {
+    if (!this.anchor) return;
+    const element = document.getElementById(`${this.anchor}`);
+    // if there is no element in the document that has an id,
+    // add it to this component
+    if (!element) {
+      this.id = this.anchor;
+    }
+  },
 };
 </script>
 
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
-
-.section-title {
-  scroll-margin-top: $nav-height + 1rem;
-
-  @include breakpoint(small, $scope: nav) {
-    scroll-margin-top: $nav-height-small + 1rem;
-  }
-}
 
 .section-title:hover {
   .header-anchor {
@@ -68,7 +74,7 @@ export default {
   opacity: 0;
   text-decoration: none;
 
-  &:hover {
+  &:hover, &:focus {
     opacity: 1;
   }
 }

--- a/src/components/DocumentationTopic/ContentTable.vue
+++ b/src/components/DocumentationTopic/ContentTable.vue
@@ -15,7 +15,7 @@
     :title="title"
   >
     <div class="container">
-      <SectionTitle class="title" :href="anchor">{{ title }}</SectionTitle>
+      <SectionTitle class="title" :anchor="anchor">{{ title }}</SectionTitle>
       <slot />
     </div>
   </OnThisPageSection>

--- a/src/components/DocumentationTopic/ContentTable.vue
+++ b/src/components/DocumentationTopic/ContentTable.vue
@@ -15,7 +15,7 @@
     :title="title"
   >
     <div class="container">
-      <SectionTitle class="title" :anchor="anchor">{{ title }}</SectionTitle>
+      <SectionTitle class="title" :href="anchor">{{ title }}</SectionTitle>
       <slot />
     </div>
   </OnThisPageSection>

--- a/src/components/DocumentationTopic/ContentTable.vue
+++ b/src/components/DocumentationTopic/ContentTable.vue
@@ -15,18 +15,21 @@
     :title="title"
   >
     <div class="container">
-      <h2 class="title">{{title}}</h2>
+      <SectionTitle class="title" :anchor="anchor">
+        {{ title }}
+      </SectionTitle>
       <slot />
     </div>
   </OnThisPageSection>
 </template>
 
 <script>
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
 import OnThisPageSection from './OnThisPageSection.vue';
 
 export default {
   name: 'ContentTable',
-  components: { OnThisPageSection },
+  components: { OnThisPageSection, SectionTitle },
   props: {
     anchor: {
       type: String,

--- a/src/components/DocumentationTopic/ContentTable.vue
+++ b/src/components/DocumentationTopic/ContentTable.vue
@@ -15,19 +15,19 @@
     :title="title"
   >
     <div class="container">
-      <SectionTitle class="title" :anchor="anchor">{{ title }}</SectionTitle>
+      <LinkableHeading class="title" :anchor="anchor">{{ title }}</LinkableHeading>
       <slot />
     </div>
   </OnThisPageSection>
 </template>
 
 <script>
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 import OnThisPageSection from './OnThisPageSection.vue';
 
 export default {
   name: 'ContentTable',
-  components: { OnThisPageSection, SectionTitle },
+  components: { OnThisPageSection, LinkableHeading },
   props: {
     anchor: {
       type: String,

--- a/src/components/DocumentationTopic/ContentTable.vue
+++ b/src/components/DocumentationTopic/ContentTable.vue
@@ -15,9 +15,7 @@
     :title="title"
   >
     <div class="container">
-      <SectionTitle class="title" :anchor="anchor">
-        {{ title }}
-      </SectionTitle>
+      <SectionTitle class="title" :anchor="anchor">{{ title }}</SectionTitle>
       <slot />
     </div>
   </OnThisPageSection>

--- a/src/components/DocumentationTopic/ContentTableSection.vue
+++ b/src/components/DocumentationTopic/ContentTableSection.vue
@@ -12,7 +12,11 @@
   <div class="contenttable-section">
     <div class="section-title">
       <slot name="title">
-        <SectionTitle tag="h3" class="title" :anchor="anchor">{{ title }}</SectionTitle>
+        <LinkableHeading
+          :level="3"
+          class="title"
+          :anchor="anchorComputed"
+        >{{ title }}</LinkableHeading>
       </slot>
     </div>
     <div class="section-content">
@@ -24,20 +28,24 @@
 </template>
 
 <script>
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 import { anchorize } from 'docc-render/utils/strings';
 
 export default {
   name: 'ContentTableSection',
-  components: { SectionTitle },
+  components: { LinkableHeading },
   props: {
     title: {
       type: String,
       required: true,
     },
+    anchor: {
+      type: String,
+      default: null,
+    },
   },
   computed: {
-    anchor: ({ title }) => anchorize(title),
+    anchorComputed: ({ title, anchor }) => anchor || anchorize(title),
   },
 };
 </script>

--- a/src/components/DocumentationTopic/ContentTableSection.vue
+++ b/src/components/DocumentationTopic/ContentTableSection.vue
@@ -25,6 +25,7 @@
 
 <script>
 import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import { anchorize } from 'docc-render/utils/strings';
 
 export default {
   name: 'ContentTableSection',
@@ -36,7 +37,7 @@ export default {
     },
   },
   computed: {
-    anchor: ({ title }) => title.replaceAll(' ', '-'),
+    anchor: ({ title }) => anchorize(title),
   },
 };
 </script>

--- a/src/components/DocumentationTopic/ContentTableSection.vue
+++ b/src/components/DocumentationTopic/ContentTableSection.vue
@@ -12,7 +12,7 @@
   <div class="contenttable-section">
     <div class="section-title">
       <slot name="title">
-        <h3 class="title">{{ title }}</h3>
+        <SectionTitle tag="h3" class="title" :anchor="anchor">{{ title }}</SectionTitle>
       </slot>
     </div>
     <div class="section-content">
@@ -24,13 +24,19 @@
 </template>
 
 <script>
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+
 export default {
   name: 'ContentTableSection',
+  components: { SectionTitle },
   props: {
     title: {
       type: String,
       required: true,
     },
+  },
+  computed: {
+    anchor: ({ title }) => title.replaceAll(' ', '-'),
   },
 };
 </script>

--- a/src/components/DocumentationTopic/OnThisPageSection.vue
+++ b/src/components/DocumentationTopic/OnThisPageSection.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <section :id="anchor"><slot /></section>
+  <section><slot /></section>
 </template>
 
 <script>
@@ -25,10 +25,6 @@ export default {
     },
   },
   props: {
-    anchor: {
-      type: String,
-      required: true,
-    },
     title: {
       type: String,
       required: true,

--- a/src/components/DocumentationTopic/OnThisPageSection.vue
+++ b/src/components/DocumentationTopic/OnThisPageSection.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <section :id="anchor"><slot /></section>
+  <section><slot /></section>
 </template>
 
 <script>

--- a/src/components/DocumentationTopic/OnThisPageSection.vue
+++ b/src/components/DocumentationTopic/OnThisPageSection.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <section><slot /></section>
+  <section :id="anchor"><slot /></section>
 </template>
 
 <script>
@@ -25,6 +25,10 @@ export default {
     },
   },
   props: {
+    anchor: {
+      type: String,
+      required: true,
+    },
     title: {
       type: String,
       required: true,

--- a/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
@@ -14,7 +14,7 @@
     class="declaration"
     title="Declaration"
   >
-    <SectionTitle href="declaration">Declaration</SectionTitle>
+    <SectionTitle anchor="declaration">Declaration</SectionTitle>
     <template v-if="hasModifiedChanges">
       <DeclarationDiff
         :class="[changeClasses, multipleLinesClass]"

--- a/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
@@ -14,7 +14,7 @@
     class="declaration"
     title="Declaration"
   >
-    <SectionTitle anchor="declaration">Declaration</SectionTitle>
+    <SectionTitle href="declaration">Declaration</SectionTitle>
     <template v-if="hasModifiedChanges">
       <DeclarationDiff
         :class="[changeClasses, multipleLinesClass]"

--- a/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
@@ -14,7 +14,7 @@
     class="declaration"
     title="Declaration"
   >
-    <SectionTitle anchor="declaration">Declaration</SectionTitle>
+    <LinkableHeading anchor="declaration">Declaration</LinkableHeading>
     <template v-if="hasModifiedChanges">
       <DeclarationDiff
         :class="[changeClasses, multipleLinesClass]"
@@ -48,7 +48,7 @@
 <script>
 import ConditionalConstraints from 'docc-render/components/DocumentationTopic/ConditionalConstraints.vue';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 
 import DeclarationGroup from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationGroup.vue';
 import DeclarationDiff
@@ -66,7 +66,7 @@ export default {
     DeclarationSourceLink,
     ConditionalConstraints,
     OnThisPageSection,
-    SectionTitle,
+    LinkableHeading,
   },
   constants: { ChangeTypes, multipleLinesClass },
   inject: ['identifier', 'store'],

--- a/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
@@ -14,7 +14,7 @@
     class="declaration"
     title="Declaration"
   >
-    <h2>Declaration</h2>
+    <SectionTitle anchor="declaration">Declaration</SectionTitle>
     <template v-if="hasModifiedChanges">
       <DeclarationDiff
         :class="[changeClasses, multipleLinesClass]"
@@ -48,6 +48,7 @@
 <script>
 import ConditionalConstraints from 'docc-render/components/DocumentationTopic/ConditionalConstraints.vue';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
 
 import DeclarationGroup from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationGroup.vue';
 import DeclarationDiff
@@ -65,6 +66,7 @@ export default {
     DeclarationSourceLink,
     ConditionalConstraints,
     OnThisPageSection,
+    SectionTitle,
   },
   constants: { ChangeTypes, multipleLinesClass },
   inject: ['identifier', 'store'],

--- a/src/components/DocumentationTopic/PrimaryContent/Parameters.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/Parameters.vue
@@ -14,7 +14,7 @@
     class="parameters"
     title="Parameters"
   >
-    <SectionTitle href="parameters">Parameters</SectionTitle>
+    <SectionTitle anchor="parameters">Parameters</SectionTitle>
     <dl>
       <template v-for="param in parameters">
         <dt class="param-name" :key="`${param.name}:name`">

--- a/src/components/DocumentationTopic/PrimaryContent/Parameters.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/Parameters.vue
@@ -14,7 +14,7 @@
     class="parameters"
     title="Parameters"
   >
-    <SectionTitle anchor="parameters">Parameters</SectionTitle>
+    <LinkableHeading anchor="parameters">Parameters</LinkableHeading>
     <dl>
       <template v-for="param in parameters">
         <dt class="param-name" :key="`${param.name}:name`">
@@ -31,14 +31,14 @@
 <script>
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 
 export default {
   name: 'Parameters',
   components: {
     ContentNode,
     OnThisPageSection,
-    SectionTitle,
+    LinkableHeading,
   },
   props: {
     parameters: {

--- a/src/components/DocumentationTopic/PrimaryContent/Parameters.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/Parameters.vue
@@ -14,7 +14,7 @@
     class="parameters"
     title="Parameters"
   >
-    <h2>Parameters</h2>
+    <SectionTitle anchor="parameters">Parameters</SectionTitle>
     <dl>
       <template v-for="param in parameters">
         <dt class="param-name" :key="`${param.name}:name`">
@@ -31,12 +31,14 @@
 <script>
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
 
 export default {
   name: 'Parameters',
   components: {
     ContentNode,
     OnThisPageSection,
+    SectionTitle,
   },
   props: {
     parameters: {

--- a/src/components/DocumentationTopic/PrimaryContent/Parameters.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/Parameters.vue
@@ -14,7 +14,7 @@
     class="parameters"
     title="Parameters"
   >
-    <SectionTitle anchor="parameters">Parameters</SectionTitle>
+    <SectionTitle href="parameters">Parameters</SectionTitle>
     <dl>
       <template v-for="param in parameters">
         <dt class="param-name" :key="`${param.name}:name`">

--- a/src/components/DocumentationTopic/PrimaryContent/PossibleValues.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/PossibleValues.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection anchor="possibleValues" title="PossibleValues">
-    <h2>Possible Values</h2>
+     <LinkableHeading anchor="possibleValues">Possible Values</LinkableHeading>
     <dl class="datalist">
       <template v-for="value in values">
         <dt class="param-name" :key="`${value.name}:name`">
@@ -28,10 +28,16 @@
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
 import ContentNode from 'docc-render/components/ContentNode.vue';
 import WordBreak from 'docc-render/components/WordBreak.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 
 export default {
   name: 'PossibleValues',
-  components: { ContentNode, OnThisPageSection, WordBreak },
+  components: {
+    ContentNode,
+    OnThisPageSection,
+    LinkableHeading,
+    WordBreak,
+  },
   props: {
     values: {
       type: Array,

--- a/src/components/DocumentationTopic/PrimaryContent/PropertyListKeyDetails.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/PropertyListKeyDetails.vue
@@ -14,7 +14,7 @@
     class="details"
     title="Details"
   >
-    <h2>Details</h2>
+    <LinkableHeading anchor="details">Details</LinkableHeading>
     <dl>
       <template v-if="isSymbol">
         <dt class="detail-type" :key="`${details.name}:name`">
@@ -45,12 +45,14 @@
 <script>
 import PropertyListKeyType from 'docc-render/components/DocumentationTopic/PrimaryContent/PropertyListKeyType.vue';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 
 export default {
   name: 'PropertyListKeyDetails',
   components: {
     PropertyListKeyType,
     OnThisPageSection,
+    LinkableHeading,
   },
   props: {
     details: {

--- a/src/components/DocumentationTopic/PrimaryContent/PropertyTable.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/PropertyTable.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <SectionTitle :anchor="anchor">{{ title }}</SectionTitle>
+    <LinkableHeading :anchor="anchor">{{ title }}</LinkableHeading>
     <ParametersTable :parameters="properties" :changes="propertyChanges" class="property-table">
       <template slot="symbol" slot-scope="{ name, type, content, changes, deprecated }">
         <div class="property-name" :class="{ deprecated: deprecated }">
@@ -60,7 +60,7 @@
 
 <script>
 import { anchorize } from 'docc-render/utils/strings';
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 import WordBreak from 'docc-render/components/WordBreak.vue';
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 
@@ -84,7 +84,7 @@ export default {
     ContentNode,
     OnThisPageSection,
     ParametersTable,
-    SectionTitle,
+    LinkableHeading,
   },
   props: {
     title: {

--- a/src/components/DocumentationTopic/PrimaryContent/PropertyTable.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/PropertyTable.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <SectionTitle :href="anchor">{{ title }}</SectionTitle>
+    <SectionTitle :anchor="anchor">{{ title }}</SectionTitle>
     <ParametersTable :parameters="properties" :changes="propertyChanges" class="property-table">
       <template slot="symbol" slot-scope="{ name, type, content, changes, deprecated }">
         <div class="property-name" :class="{ deprecated: deprecated }">

--- a/src/components/DocumentationTopic/PrimaryContent/PropertyTable.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/PropertyTable.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <h2>{{ title }}</h2>
+    <SectionTitle :href="anchor">{{ title }}</SectionTitle>
     <ParametersTable :parameters="properties" :changes="propertyChanges" class="property-table">
       <template slot="symbol" slot-scope="{ name, type, content, changes, deprecated }">
         <div class="property-name" :class="{ deprecated: deprecated }">
@@ -60,6 +60,7 @@
 
 <script>
 import { anchorize } from 'docc-render/utils/strings';
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
 import WordBreak from 'docc-render/components/WordBreak.vue';
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 
@@ -83,6 +84,7 @@ export default {
     ContentNode,
     OnThisPageSection,
     ParametersTable,
+    SectionTitle,
   },
   props: {
     title: {

--- a/src/components/DocumentationTopic/PrimaryContent/RestBody.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestBody.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <SectionTitle :href="anchor">{{ title }}</SectionTitle>
+    <SectionTitle :anchor="anchor">{{ title }}</SectionTitle>
     <ParametersTable :parameters="[bodyParam]" :changes="bodyChanges" keyBy="key">
       <template slot="symbol" slot-scope="{ type, content, changes, name }">
         <PossiblyChangedType

--- a/src/components/DocumentationTopic/PrimaryContent/RestBody.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestBody.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <h2>{{ title }}</h2>
+    <SectionTitle :href="anchor">{{ title }}</SectionTitle>
     <ParametersTable :parameters="[bodyParam]" :changes="bodyChanges" keyBy="key">
       <template slot="symbol" slot-scope="{ type, content, changes, name }">
         <PossiblyChangedType
@@ -84,6 +84,7 @@
 import { anchorize } from 'docc-render/utils/strings';
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
 
 import WordBreak from 'docc-render/components/WordBreak.vue';
 import apiChangesProvider from 'docc-render/mixins/apiChangesProvider';
@@ -107,6 +108,7 @@ export default {
     ContentNode,
     OnThisPageSection,
     ParametersTable,
+    SectionTitle,
   },
   constants: { ChangesKey },
   props: {

--- a/src/components/DocumentationTopic/PrimaryContent/RestBody.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestBody.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <SectionTitle :anchor="anchor">{{ title }}</SectionTitle>
+    <LinkableHeading :anchor="anchor">{{ title }}</LinkableHeading>
     <ParametersTable :parameters="[bodyParam]" :changes="bodyChanges" keyBy="key">
       <template slot="symbol" slot-scope="{ type, content, changes, name }">
         <PossiblyChangedType
@@ -84,7 +84,7 @@
 import { anchorize } from 'docc-render/utils/strings';
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 
 import WordBreak from 'docc-render/components/WordBreak.vue';
 import apiChangesProvider from 'docc-render/mixins/apiChangesProvider';
@@ -108,7 +108,7 @@ export default {
     ContentNode,
     OnThisPageSection,
     ParametersTable,
-    SectionTitle,
+    LinkableHeading,
   },
   constants: { ChangesKey },
   props: {

--- a/src/components/DocumentationTopic/PrimaryContent/RestEndpoint.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestEndpoint.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <SectionTitle :href="anchor">{{ title }}</SectionTitle>
+    <SectionTitle :anchor="anchor">{{ title }}</SectionTitle>
     <DeclarationSource :tokens="tokens" />
   </OnThisPageSection>
 </template>

--- a/src/components/DocumentationTopic/PrimaryContent/RestEndpoint.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestEndpoint.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <SectionTitle :anchor="anchor">{{ title }}</SectionTitle>
+    <LinkableHeading :anchor="anchor">{{ title }}</LinkableHeading>
     <DeclarationSource :tokens="tokens" />
   </OnThisPageSection>
 </template>
@@ -18,7 +18,7 @@
 <script>
 import { anchorize } from 'docc-render/utils/strings';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 import DeclarationSource
   from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue';
 
@@ -30,7 +30,7 @@ export default {
   components: {
     DeclarationSource,
     OnThisPageSection,
-    SectionTitle,
+    LinkableHeading,
   },
   props: {
     title: {

--- a/src/components/DocumentationTopic/PrimaryContent/RestEndpoint.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestEndpoint.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <h2>{{ title }}</h2>
+    <SectionTitle :href="anchor">{{ title }}</SectionTitle>
     <DeclarationSource :tokens="tokens" />
   </OnThisPageSection>
 </template>
@@ -18,6 +18,7 @@
 <script>
 import { anchorize } from 'docc-render/utils/strings';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
 import DeclarationSource
   from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue';
 
@@ -29,6 +30,7 @@ export default {
   components: {
     DeclarationSource,
     OnThisPageSection,
+    SectionTitle,
   },
   props: {
     title: {

--- a/src/components/DocumentationTopic/PrimaryContent/RestParameters.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestParameters.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <h2>{{ title }}</h2>
+    <SectionTitle :href="anchor">{{ title }}</SectionTitle>
     <ParametersTable :parameters="parameters" :changes="parameterChanges">
       <template slot="symbol" slot-scope="{ name, type, content, changes, deprecated }">
         <div class="param-name" :class="{ deprecated: deprecated }">
@@ -55,6 +55,7 @@
 import { anchorize } from 'docc-render/utils/strings';
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
 
 import WordBreak from 'docc-render/components/WordBreak.vue';
 import apiChangesProvider from 'docc-render/mixins/apiChangesProvider';
@@ -76,6 +77,7 @@ export default {
     ContentNode,
     OnThisPageSection,
     ParametersTable,
+    SectionTitle,
   },
   props: {
     title: {

--- a/src/components/DocumentationTopic/PrimaryContent/RestParameters.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestParameters.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <SectionTitle :href="anchor">{{ title }}</SectionTitle>
+    <SectionTitle :anchor="anchor">{{ title }}</SectionTitle>
     <ParametersTable :parameters="parameters" :changes="parameterChanges">
       <template slot="symbol" slot-scope="{ name, type, content, changes, deprecated }">
         <div class="param-name" :class="{ deprecated: deprecated }">

--- a/src/components/DocumentationTopic/PrimaryContent/RestParameters.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestParameters.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <SectionTitle :anchor="anchor">{{ title }}</SectionTitle>
+    <LinkableHeading :anchor="anchor">{{ title }}</LinkableHeading>
     <ParametersTable :parameters="parameters" :changes="parameterChanges">
       <template slot="symbol" slot-scope="{ name, type, content, changes, deprecated }">
         <div class="param-name" :class="{ deprecated: deprecated }">
@@ -55,7 +55,7 @@
 import { anchorize } from 'docc-render/utils/strings';
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 
 import WordBreak from 'docc-render/components/WordBreak.vue';
 import apiChangesProvider from 'docc-render/mixins/apiChangesProvider';
@@ -77,7 +77,7 @@ export default {
     ContentNode,
     OnThisPageSection,
     ParametersTable,
-    SectionTitle,
+    LinkableHeading,
   },
   props: {
     title: {

--- a/src/components/DocumentationTopic/PrimaryContent/RestResponses.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestResponses.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <h2>{{ title }}</h2>
+    <SectionTitle :href="anchor">{{ title }}</SectionTitle>
     <ParametersTable :parameters="responses" :changes="propertyChanges" key-by="status">
       <template slot="symbol" slot-scope="{ status, type, reason, content, changes }">
         <div class="response-name">
@@ -51,6 +51,7 @@
 
 <script>
 import { anchorize } from 'docc-render/utils/strings';
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
 
@@ -68,6 +69,7 @@ export default {
     ContentNode,
     OnThisPageSection,
     ParametersTable,
+    SectionTitle,
   },
   props: {
     title: {

--- a/src/components/DocumentationTopic/PrimaryContent/RestResponses.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestResponses.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <SectionTitle :anchor="anchor">{{ title }}</SectionTitle>
+    <LinkableHeading :anchor="anchor">{{ title }}</LinkableHeading>
     <ParametersTable :parameters="responses" :changes="propertyChanges" key-by="status">
       <template slot="symbol" slot-scope="{ status, type, reason, content, changes }">
         <div class="response-name">
@@ -51,7 +51,7 @@
 
 <script>
 import { anchorize } from 'docc-render/utils/strings';
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import OnThisPageSection from 'docc-render/components/DocumentationTopic/OnThisPageSection.vue';
 
@@ -69,7 +69,7 @@ export default {
     ContentNode,
     OnThisPageSection,
     ParametersTable,
-    SectionTitle,
+    LinkableHeading,
   },
   props: {
     title: {

--- a/src/components/DocumentationTopic/PrimaryContent/RestResponses.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestResponses.vue
@@ -10,7 +10,7 @@
 
 <template>
   <OnThisPageSection :anchor="anchor" :title="title">
-    <SectionTitle :href="anchor">{{ title }}</SectionTitle>
+    <SectionTitle :anchor="anchor">{{ title }}</SectionTitle>
     <ParametersTable :parameters="responses" :changes="propertyChanges" key-by="status">
       <template slot="symbol" slot-scope="{ status, type, reason, content, changes }">
         <div class="response-name">

--- a/src/components/DocumentationTopic/Relationships.vue
+++ b/src/components/DocumentationTopic/Relationships.vue
@@ -17,6 +17,7 @@
       v-for="section in sectionsWithSymbols"
       :key="section.type"
       :title="section.title"
+      :anchor="section.anchor"
     >
       <List :symbols="section.symbols" :type="section.type" />
     </Section>

--- a/src/components/DocumentationTopic/Summary/Availability.vue
+++ b/src/components/DocumentationTopic/Summary/Availability.vue
@@ -142,15 +142,14 @@ export default {
 
 .changed {
   $-coin-spacer: 5px;
-  $-coin-size: 16px;
-  padding-left: $-coin-size + ($-coin-spacer * 2);
+  padding-left: $icon-size + ($-coin-spacer * 2);
 
   &::after {
     content: none;
   }
 
   &::before {
-    @include coin($modified-svg, $-coin-size);
+    @include coin($modified-svg, $icon-size);
     left: $-coin-spacer;
 
     @include prefers-dark {

--- a/src/components/DocumentationTopic/Summary/Availability.vue
+++ b/src/components/DocumentationTopic/Summary/Availability.vue
@@ -142,14 +142,14 @@ export default {
 
 .changed {
   $-coin-spacer: 5px;
-  padding-left: $icon-size + ($-coin-spacer * 2);
+  padding-left: $icon-size-default + ($-coin-spacer * 2);
 
   &::after {
     content: none;
   }
 
   &::before {
-    @include coin($modified-svg, $icon-size);
+    @include coin($modified-svg, $icon-size-default);
     left: $-coin-spacer;
 
     @include prefers-dark {

--- a/src/components/DocumentationTopic/TopicsTable.vue
+++ b/src/components/DocumentationTopic/TopicsTable.vue
@@ -17,7 +17,7 @@
       :anchor="section.anchor"
     >
       <template v-if="wrapTitle" slot="title">
-        <LinkableHeading :level="3" :anchor="anchor" class="title">
+        <LinkableHeading :level="3" :anchor="section.anchor" class="title">
           <WordBreak>{{ section.title }}</WordBreak>
         </LinkableHeading>
       </template>

--- a/src/components/DocumentationTopic/TopicsTable.vue
+++ b/src/components/DocumentationTopic/TopicsTable.vue
@@ -14,11 +14,12 @@
       v-for="section in sectionsWithTopics"
       :key="section.title"
       :title="section.title"
+      :anchor="section.anchor"
     >
       <template v-if="wrapTitle" slot="title">
-        <SectionTitle tag="h3" :anchor="anchor" class="title">
+        <LinkableHeading :level="3" :anchor="anchor" class="title">
           <WordBreak>{{ section.title }}</WordBreak>
-        </SectionTitle>
+        </LinkableHeading>
       </template>
       <template v-if="section.abstract" slot="abstract">
         <ContentNode :content="section.abstract" />
@@ -41,7 +42,7 @@
 <script>
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import WordBreak from 'docc-render/components/WordBreak.vue';
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 import ContentTable from './ContentTable.vue';
 import ContentTableSection from './ContentTableSection.vue';
 import TopicsLinkBlock from './TopicsLinkBlock.vue';
@@ -61,7 +62,7 @@ export default {
     TopicsLinkBlock,
     ContentNode,
     ContentTableSection,
-    SectionTitle,
+    LinkableHeading,
   },
   props: {
     isSymbolDeprecated: Boolean,

--- a/src/components/DocumentationTopic/TopicsTable.vue
+++ b/src/components/DocumentationTopic/TopicsTable.vue
@@ -16,9 +16,11 @@
       :title="section.title"
     >
       <template v-if="wrapTitle" slot="title">
-        <WordBreak tag="h3" class="title">
+        <SectionTitle :href="anchor" class="title">
+          <WordBreak tag="h3" class="title">
           {{ section.title }}
-        </WordBreak>
+          </WordBreak>
+        </SectionTitle>
       </template>
       <template v-if="section.abstract" slot="abstract">
         <ContentNode :content="section.abstract" />

--- a/src/components/DocumentationTopic/TopicsTable.vue
+++ b/src/components/DocumentationTopic/TopicsTable.vue
@@ -16,7 +16,7 @@
       :title="section.title"
     >
       <template v-if="wrapTitle" slot="title">
-        <SectionTitle tag="h3" :href="anchor" class="title">
+        <SectionTitle tag="h3" :anchor="anchor" class="title">
           <WordBreak>{{ section.title }}</WordBreak>
         </SectionTitle>
       </template>

--- a/src/components/DocumentationTopic/TopicsTable.vue
+++ b/src/components/DocumentationTopic/TopicsTable.vue
@@ -16,10 +16,8 @@
       :title="section.title"
     >
       <template v-if="wrapTitle" slot="title">
-        <SectionTitle :href="anchor" class="title">
-          <WordBreak tag="h3" class="title">
-          {{ section.title }}
-          </WordBreak>
+        <SectionTitle tag="h3" :href="anchor" class="title">
+          <WordBreak>{{ section.title }}</WordBreak>
         </SectionTitle>
       </template>
       <template v-if="section.abstract" slot="abstract">
@@ -43,6 +41,7 @@
 <script>
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import WordBreak from 'docc-render/components/WordBreak.vue';
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
 import ContentTable from './ContentTable.vue';
 import ContentTableSection from './ContentTableSection.vue';
 import TopicsLinkBlock from './TopicsLinkBlock.vue';
@@ -62,6 +61,7 @@ export default {
     TopicsLinkBlock,
     ContentNode,
     ContentTableSection,
+    SectionTitle,
   },
   props: {
     isSymbolDeprecated: Boolean,

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -531,8 +531,8 @@ $input-height: rem(28px);
     border-radius: 100%;
 
     .clear-rounded-icon {
-      height: $icon-size;
-      width: $icon-size;
+      height: $icon-size-default;
+      width: $icon-size-default;
       fill: var(--input-text);
       display: block;
     }

--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -531,8 +531,8 @@ $input-height: rem(28px);
     border-radius: 100%;
 
     .clear-rounded-icon {
-      height: rem(16px);
-      width: rem(16px);
+      height: $icon-size;
+      width: $icon-size;
       fill: var(--input-text);
       display: block;
     }

--- a/src/components/Icons/LinkIcon.vue
+++ b/src/components/Icons/LinkIcon.vue
@@ -1,0 +1,27 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2022 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <SVGIcon
+    class="link-icon"
+    viewBox="0 0 20 20"
+  >
+    <path d="m12.6 7.4c-.3-.3-.6-.5-1-.7s-.9-.4-1.5-.5l-1.2 1.2c.6 0 1.1.2 1.5.3.4.2.8.4 1.1.7.5.5.9 1.1 1.1 1.8s.2 1.3 0 2-.5 1.2-1.1 1.8l-3 3c-.5.5-1.1.9-1.8 1.1-.6.2-1.3.2-2 0-.6-.1-1.2-.5-1.7-1s-.9-1.1-1.1-1.8-.2-1.3 0-2c.2-.6.5-1.2 1.1-1.8l1.8-1.8c-.1-.3-.2-.6-.3-.9 0-.3 0-.6 0-1l-2.7 2.7c-.7.7-1.2 1.6-1.5 2.5-.3.9-.3 1.8 0 2.7.2.9.7 1.7 1.5 2.5s1.6 1.3 2.5 1.5 1.8.2 2.7 0c.9-.3 1.7-.7 2.4-1.5l3.2-3.2c.7-.7 1.2-1.6 1.5-2.5s.3-1.8 0-2.7c-.2-.8-.7-1.7-1.5-2.4z"/><path d="m19.7 4.3c-.2-.9-.7-1.7-1.5-2.5s-1.6-1.3-2.5-1.5-1.8-.2-2.7 0c-.9.3-1.7.7-2.5 1.5l-3.1 3.2c-.8.7-1.3 1.6-1.5 2.4-.3.9-.3 1.8 0 2.7.2.9.7 1.7 1.5 2.5.3.3.6.5 1 .7s.9.4 1.5.5l1.2-1.3c-.6 0-1.1-.2-1.5-.3-.4-.2-.8-.4-1.1-.7-.6-.5-.9-1.1-1.1-1.8s-.2-1.3 0-2c.2-.6.5-1.2 1.1-1.7l3-3c.5-.5 1.1-.9 1.8-1.1.6-.2 1.3-.2 1.9 0s1.2.5 1.8 1.1c.5.5.9 1.1 1.1 1.8s.2 1.3 0 2c-.2.6-.5 1.2-1.1 1.8l-1.8 1.8c.1.3.2.6.2.9v.9l2.7-2.7c.7-.7 1.2-1.6 1.5-2.5s.3-1.8.1-2.7z"/>
+  </SVGIcon>
+</template>
+
+<script>
+import SVGIcon from 'docc-render/components/SVGIcon.vue';
+
+export default {
+  name: 'LinkIcon',
+  components: { SVGIcon },
+};
+</script>

--- a/src/components/Tutorial/NavigationBar.vue
+++ b/src/components/Tutorial/NavigationBar.vue
@@ -174,8 +174,8 @@ export default {
   methods: {
     onSelectSection(path) {
       // Manually scroll to the section to work around a vue-router bug: https://github.com/vuejs/vue-router/issues/1668
-      const hash = `#${path.split('#')[1]}`;
-      this.scrollToElement(hash);
+      const hash = path.split('#')[1];
+      this.handleFocusAndScroll(hash);
     },
   },
 };

--- a/src/components/TutorialsOverview/Hero.vue
+++ b/src/components/TutorialsOverview/Hero.vue
@@ -107,8 +107,8 @@ export default {
 
   .timer-icon {
     margin-right: rem(6px);
-    height: rem(16px);
-    width: rem(16px);
+    height: $icon-size;
+    width: $icon-size;
     fill: var(--color-tutorials-overview-icon);
     @include breakpoint(small) {
       margin-right: rem(5px);

--- a/src/components/TutorialsOverview/Hero.vue
+++ b/src/components/TutorialsOverview/Hero.vue
@@ -107,8 +107,8 @@ export default {
 
   .timer-icon {
     margin-right: rem(6px);
-    height: $icon-size;
-    width: $icon-size;
+    height: $icon-size-default;
+    width: $icon-size-default;
     fill: var(--color-tutorials-overview-icon);
     @include breakpoint(small) {
       margin-right: rem(5px);

--- a/src/components/TutorialsOverview/ResourcesTile.vue
+++ b/src/components/TutorialsOverview/ResourcesTile.vue
@@ -109,12 +109,12 @@ a, .content /deep/ a {
 }
 
 .icon {
-  $icon-size: rem(25px);
+  $icon-size-default: rem(25px);
   display: block;
-  height: $icon-size;
-  line-height: $icon-size;
+  height: $icon-size-default;
+  line-height: $icon-size-default;
   margin-bottom: rem(10px);
-  width: $icon-size;
+  width: $icon-size-default;
 
   /deep/ svg.svg-icon {
     width: 100%;

--- a/src/components/TutorialsOverview/TutorialsNavigationLink.vue
+++ b/src/components/TutorialsOverview/TutorialsNavigationLink.vue
@@ -13,7 +13,7 @@
     class="tutorials-navigation-link"
     :class="{ active }"
     :to="fragment"
-    @click.native="handleFocus"
+    @click.native="handleFocusAndScroll(fragment.hash)"
   >
     <slot />
   </router-link>
@@ -41,23 +41,6 @@ export default {
     }) => text === activeTutorialLink,
     fragment: ({ text, $route }) => ({ hash: anchorize(text), query: $route.query }),
     text: ({ $slots: { default: [{ text: slotText }] } }) => slotText.trim(),
-  },
-  methods: {
-    /**
-     * Always scroll to the element and focus it.
-     * This ensures that the next tab target is inside
-     * and that it is in view, even if the hash is in the url
-     * @returns {Promise<void>}
-     */
-    async handleFocus() {
-      const { hash } = this.fragment;
-      const element = document.getElementById(hash);
-      if (!element) return;
-      // Focus scrolls to the element
-      element.focus();
-      // but we need to compensate for the navigation height
-      await this.scrollToElement(`#${hash}`);
-    },
   },
 };
 </script>

--- a/src/mixins/scrollToElement.js
+++ b/src/mixins/scrollToElement.js
@@ -27,5 +27,19 @@ export default {
       window.scrollBy(-offset.x, -offset.y);
       return element;
     },
+    /**
+     * Always scroll to the element and focus it.
+     * This ensures that the next tab target is inside
+     * and that it is in view, even if the hash is in the url
+     * @returns {Promise<void>}
+    */
+    async handleFocusAndScroll(hash) {
+      const element = document.getElementById(hash);
+      if (!element) return;
+      // Focus scrolls to the element
+      element.focus();
+      // but we need to compensate for the navigation height
+      await this.scrollToElement(`#${hash}`);
+    },
   },
 };

--- a/src/mixins/scrollToElement.js
+++ b/src/mixins/scrollToElement.js
@@ -31,7 +31,7 @@ export default {
      * Always scroll to the element and focus it.
      * This ensures that the next tab target is inside
      * and that it is in view, even if the hash is in the url
-     * @returns {Promise<void>}
+     * @returns {Promise<Element>}
     */
     async handleFocusAndScroll(hash) {
       const element = document.getElementById(hash);

--- a/src/mixins/scrollToElement.js
+++ b/src/mixins/scrollToElement.js
@@ -35,6 +35,7 @@ export default {
     */
     async handleFocusAndScroll(hash) {
       const element = document.getElementById(hash);
+      // if no element to focus or scroll, exit
       if (!element) return;
       // Focus scrolls to the element
       element.focus();

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -35,7 +35,7 @@ $topic-link-icon-width: 1.294rem;
 $topic-link-icon-spacing: 1rem;
 
 // Icons
-$icon-size: 16px;
+$icon-size-default: 16px;
 
 // Code Block Style Elements
 $code-block-style-elements-padding: 8px 14px !default;

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -34,6 +34,9 @@ $article-stacked-margin-small: 20px;
 $topic-link-icon-width: 1.294rem;
 $topic-link-icon-spacing: 1rem;
 
+// Icons
+$icon-size: 16px;
+
 // Code Block Style Elements
 $code-block-style-elements-padding: 8px 14px !default;
 $code-listing-with-numbers-padding: 14px 0;

--- a/tests/unit/components/Asset.spec.js
+++ b/tests/unit/components/Asset.spec.js
@@ -185,7 +185,7 @@ describe('Asset', () => {
       expect(asset.exists()).toBe(true);
       expect(asset.props()).toEqual({
         alt: image.alt,
-        loading: "lazy",
+        loading: 'lazy',
         variants: image.variants,
       });
     });
@@ -195,7 +195,7 @@ describe('Asset', () => {
       const asset = wrapper.find(ImageAsset);
       expect(asset.props()).toEqual({
         alt: image.alt,
-        loading: "lazy",
+        loading: 'lazy',
         variants: image.variants,
       });
     });

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -153,7 +153,7 @@ describe('ContentNode', () => {
 
   describe('with type="heading"', () => {
     it('renders a <h*>', () => {
-      for (let level = 1; level < 6; level += 1) {
+      for (let level = 1; level <= 6; level += 1) {
         const wrapper = mountWithItem({
           type: 'heading',
           anchor: 'heading',

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -22,7 +22,7 @@ import Reference from 'docc-render/components/ContentNode/Reference.vue';
 import Table from 'docc-render/components/ContentNode/Table.vue';
 import StrikeThrough from 'docc-render/components/ContentNode/StrikeThrough.vue';
 
-const { TableHeaderStyle } = ContentNode.constants;
+const { TableHeaderStyle, SectionTitle } = ContentNode.constants;
 
 const mountWithContent = (content = [], provide = { references: {} }) => (
   shallowMount(ContentNode, {
@@ -160,11 +160,12 @@ describe('ContentNode', () => {
           text: 'heading',
         });
 
-        const heading = wrapper.find('.content').find(`h${level}`);
-        expect(heading.exists()).toBe(true);
-        expect(heading.attributes('id')).toBe('heading');
-        expect(heading.isEmpty()).toBe(false);
-        expect(heading.text()).toBe('heading');
+        const sectionTitle = wrapper.find('.content').find(SectionTitle);
+        expect(sectionTitle.exists()).toBe(true);
+        expect(sectionTitle.attributes('tag')).toBe(`h${level}`);
+        expect(sectionTitle.attributes('anchor')).toBe('heading');
+        expect(sectionTitle.isEmpty()).toBe(false);
+        expect(sectionTitle.text()).toContain('heading');
       }
     });
   });

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -20,7 +20,7 @@ import FigureCaption from 'docc-render/components/ContentNode/FigureCaption.vue'
 import InlineImage from 'docc-render/components/ContentNode/InlineImage.vue';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
 import Table from 'docc-render/components/ContentNode/Table.vue';
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 import StrikeThrough from 'docc-render/components/ContentNode/StrikeThrough.vue';
 
 const { TableHeaderStyle } = ContentNode.constants;
@@ -153,7 +153,7 @@ describe('ContentNode', () => {
 
   describe('with type="heading"', () => {
     it('renders a <h*>', () => {
-      for (let level = 1; level <= 6; level += 1) {
+      for (let level = 1; level < 6; level += 1) {
         const wrapper = mountWithItem({
           type: 'heading',
           anchor: 'heading',
@@ -161,9 +161,9 @@ describe('ContentNode', () => {
           text: 'heading',
         });
 
-        const sectionTitle = wrapper.find('.content').find(SectionTitle);
+        const sectionTitle = wrapper.find('.content').find(LinkableHeading);
         expect(sectionTitle.exists()).toBe(true);
-        expect(sectionTitle.attributes('tag')).toBe(`h${level}`);
+        expect(sectionTitle.props('level')).toBe(level);
         expect(sectionTitle.attributes('anchor')).toBe('heading');
         expect(sectionTitle.isEmpty()).toBe(false);
         expect(sectionTitle.text()).toContain('heading');

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -20,9 +20,10 @@ import FigureCaption from 'docc-render/components/ContentNode/FigureCaption.vue'
 import InlineImage from 'docc-render/components/ContentNode/InlineImage.vue';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
 import Table from 'docc-render/components/ContentNode/Table.vue';
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
 import StrikeThrough from 'docc-render/components/ContentNode/StrikeThrough.vue';
 
-const { TableHeaderStyle, SectionTitle } = ContentNode.constants;
+const { TableHeaderStyle } = ContentNode.constants;
 
 const mountWithContent = (content = [], provide = { references: {} }) => (
   shallowMount(ContentNode, {

--- a/tests/unit/components/ContentNode/LinkableHeading.spec.js
+++ b/tests/unit/components/ContentNode/LinkableHeading.spec.js
@@ -9,11 +9,11 @@
 */
 
 import { shallowMount } from '@vue/test-utils';
-import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 
-describe('SectionTitle', () => {
+describe('LinkableHeading', () => {
   it('renders a default section title that is a h2 by default', () => {
-    const wrapper = shallowMount(SectionTitle, {
+    const wrapper = shallowMount(LinkableHeading, {
       slots: { default: 'Title' },
     });
     expect(wrapper.text()).toBe('Title');
@@ -22,16 +22,16 @@ describe('SectionTitle', () => {
   });
 
   it('renders a section title which heading is tag prop', () => {
-    const wrapper = shallowMount(SectionTitle, {
+    const wrapper = shallowMount(LinkableHeading, {
       propsData: {
-        tag: 'h3',
+        level: 3,
       },
     });
     expect(wrapper.is('h3')).toBe(true);
   });
 
   it('renders a section title with a header anchor and an id on the wrapper', async () => {
-    const wrapper = shallowMount(SectionTitle, {
+    const wrapper = shallowMount(LinkableHeading, {
       propsData: {
         anchor: 'title',
       },
@@ -51,7 +51,7 @@ describe('SectionTitle', () => {
     div.innerHTML = '<div id="title>';
     document.body.appendChild(div);
 
-    const wrapper = shallowMount(SectionTitle, {
+    const wrapper = shallowMount(LinkableHeading, {
       propsData: {
         anchor: 'title',
       },
@@ -65,12 +65,12 @@ describe('SectionTitle', () => {
   });
 
   it('does not render anchor if there is no anchor', () => {
-    const wrapper = shallowMount(SectionTitle);
+    const wrapper = shallowMount(LinkableHeading);
     expect(wrapper.find('.header-anchor').exists()).toBe(false);
   });
 
   it('does not render anchor if target ide is true', () => {
-    const wrapper = shallowMount(SectionTitle, {
+    const wrapper = shallowMount(LinkableHeading, {
       propsData: {
         anchor: 'title',
       },

--- a/tests/unit/components/ContentNode/LinkableHeading.spec.js
+++ b/tests/unit/components/ContentNode/LinkableHeading.spec.js
@@ -50,26 +50,6 @@ describe('LinkableHeading', () => {
     expect(headerAnchor.attributes('aria-label')).toBe('hidden');
   });
 
-  it('renders a section title with a header anchor and no id on the wrapper if it already exists on the document', () => {
-    // create element with id outside the component
-    const div = document.createElement('div');
-    div.innerHTML = '<div id="title>';
-    document.body.appendChild(div);
-
-    const wrapper = shallowMount(LinkableHeading, {
-      stubs,
-      propsData: {
-        anchor: 'title',
-      },
-      slots: { default: 'Title' },
-    });
-    expect(wrapper.text()).toBe('# Title');
-    expect(wrapper.attributes('id')).not.toBe('title');
-    const headerAnchor = wrapper.find('.header-anchor');
-    expect(headerAnchor.props('to')).toEqual({ hash: '#title' });
-    expect(headerAnchor.attributes('aria-label')).toBe('hidden');
-  });
-
   it('does not render anchor if there is no anchor', () => {
     const wrapper = shallowMount(LinkableHeading);
     expect(wrapper.find('.header-anchor').exists()).toBe(false);

--- a/tests/unit/components/ContentNode/LinkableHeading.spec.js
+++ b/tests/unit/components/ContentNode/LinkableHeading.spec.js
@@ -8,12 +8,15 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 
 describe('LinkableHeading', () => {
+  const stubs = { 'router-link': RouterLinkStub };
+
   it('renders a default section title that is a h2 by default', () => {
     const wrapper = shallowMount(LinkableHeading, {
+      stubs,
       slots: { default: 'Title' },
     });
     expect(wrapper.text()).toBe('Title');
@@ -23,6 +26,7 @@ describe('LinkableHeading', () => {
 
   it('renders a section title which heading is tag prop', () => {
     const wrapper = shallowMount(LinkableHeading, {
+      stubs,
       propsData: {
         level: 3,
       },
@@ -32,6 +36,7 @@ describe('LinkableHeading', () => {
 
   it('renders a section title with a header anchor and an id on the wrapper', async () => {
     const wrapper = shallowMount(LinkableHeading, {
+      stubs,
       propsData: {
         anchor: 'title',
       },
@@ -41,7 +46,7 @@ describe('LinkableHeading', () => {
     expect(wrapper.text()).toBe('# Title');
     expect(wrapper.attributes('id')).toBe('title');
     const headerAnchor = wrapper.find('.header-anchor');
-    expect(headerAnchor.attributes('href')).toBe('#title');
+    expect(headerAnchor.props('to')).toEqual({ hash: '#title' });
     expect(headerAnchor.attributes('aria-label')).toBe('hidden');
   });
 
@@ -52,6 +57,7 @@ describe('LinkableHeading', () => {
     document.body.appendChild(div);
 
     const wrapper = shallowMount(LinkableHeading, {
+      stubs,
       propsData: {
         anchor: 'title',
       },
@@ -60,7 +66,7 @@ describe('LinkableHeading', () => {
     expect(wrapper.text()).toBe('# Title');
     expect(wrapper.attributes('id')).not.toBe('title');
     const headerAnchor = wrapper.find('.header-anchor');
-    expect(headerAnchor.attributes('href')).toBe('#title');
+    expect(headerAnchor.props('to')).toEqual({ hash: '#title' });
     expect(headerAnchor.attributes('aria-label')).toBe('hidden');
   });
 
@@ -71,6 +77,7 @@ describe('LinkableHeading', () => {
 
   it('does not render anchor if target ide is true', () => {
     const wrapper = shallowMount(LinkableHeading, {
+      stubs,
       propsData: {
         anchor: 'title',
       },

--- a/tests/unit/components/ContentNode/LinkableHeading.spec.js
+++ b/tests/unit/components/ContentNode/LinkableHeading.spec.js
@@ -14,17 +14,16 @@ import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.
 describe('LinkableHeading', () => {
   const stubs = { 'router-link': RouterLinkStub };
 
-  it('renders a default section title that is a h2 by default', () => {
+  it('renders a default heading that is a h2 by default', () => {
     const wrapper = shallowMount(LinkableHeading, {
       stubs,
       slots: { default: 'Title' },
     });
     expect(wrapper.text()).toBe('Title');
     expect(wrapper.is('h2')).toBe(true);
-    expect(wrapper.classes()).toContain('section-title');
   });
 
-  it('renders a section title which heading is tag prop', () => {
+  it('renders a heading with a given level', () => {
     const wrapper = shallowMount(LinkableHeading, {
       stubs,
       propsData: {
@@ -34,7 +33,7 @@ describe('LinkableHeading', () => {
     expect(wrapper.is('h3')).toBe(true);
   });
 
-  it('renders a section title with a header anchor and an id on the wrapper', async () => {
+  it('renders a heading with a header anchor and an id on the wrapper', async () => {
     const wrapper = shallowMount(LinkableHeading, {
       stubs,
       propsData: {
@@ -43,11 +42,10 @@ describe('LinkableHeading', () => {
       slots: { default: 'Title' },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.text()).toBe('# Title');
     expect(wrapper.attributes('id')).toBe('title');
     const headerAnchor = wrapper.find('.header-anchor');
     expect(headerAnchor.props('to')).toEqual({ hash: '#title' });
-    expect(headerAnchor.attributes('aria-label')).toBe('hidden');
+    expect(headerAnchor.text()).toBe('Title');
   });
 
   it('does not render anchor if there is no anchor', () => {

--- a/tests/unit/components/ContentNode/SectionTitle.spec.js
+++ b/tests/unit/components/ContentNode/SectionTitle.spec.js
@@ -30,7 +30,7 @@ describe('SectionTitle', () => {
     expect(wrapper.is('h3')).toBe(true);
   });
 
-  it('renders a section title with a header anchor and an id on the wrapper', () => {
+  it('renders a section title with a header anchor and an id on the wrapper', async () => {
     const wrapper = shallowMount(SectionTitle, {
       propsData: {
         tag: 'h2',
@@ -38,6 +38,7 @@ describe('SectionTitle', () => {
       },
       slots: { default: 'Title' },
     });
+    await wrapper.vm.$nextTick();
     expect(wrapper.text()).toBe('# Title');
     expect(wrapper.attributes('id')).toBe('title');
     const headerAnchor = wrapper.find('.header-anchor');
@@ -45,11 +46,16 @@ describe('SectionTitle', () => {
     expect(headerAnchor.attributes('aria-label')).toBe('hidden');
   });
 
-  it('renders a section title with a header anchor and no id on the wrapper', () => {
+  it('renders a section title with a header anchor and no id on the wrapper if it already exists on the document', () => {
+    // create element with id outside the component
+    const div = document.createElement('div');
+    div.innerHTML = '<div id="title>';
+    document.body.appendChild(div);
+
     const wrapper = shallowMount(SectionTitle, {
       propsData: {
         tag: 'h2',
-        href: 'title',
+        anchor: 'title',
       },
       slots: { default: 'Title' },
     });
@@ -60,7 +66,7 @@ describe('SectionTitle', () => {
     expect(headerAnchor.attributes('aria-label')).toBe('hidden');
   });
 
-  it('does not render anchor if there is no anchor or href props', () => {
+  it('does not render anchor if there is no anchor', () => {
     const wrapper = shallowMount(SectionTitle);
     expect(wrapper.find('.header-anchor').exists()).toBe(false);
   });

--- a/tests/unit/components/ContentNode/SectionTitle.spec.js
+++ b/tests/unit/components/ContentNode/SectionTitle.spec.js
@@ -1,0 +1,67 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import { shallowMount } from '@vue/test-utils';
+import SectionTitle from 'docc-render/components/ContentNode/SectionTitle.vue';
+
+describe('SectionTitle', () => {
+  it('renders a default section title that is a h2 by default', () => {
+    const wrapper = shallowMount(SectionTitle, {
+      slots: { default: 'Title' },
+    });
+    expect(wrapper.text()).toBe('Title');
+    expect(wrapper.is('h2')).toBe(true);
+    expect(wrapper.classes()).toContain('section-title');
+  });
+
+  it('renders a section title which heading is tag prop', () => {
+    const wrapper = shallowMount(SectionTitle, {
+      propsData: {
+        tag: 'h3',
+      },
+    });
+    expect(wrapper.is('h3')).toBe(true);
+  });
+
+  it('renders a section title with a header anchor and an id on the wrapper', () => {
+    const wrapper = shallowMount(SectionTitle, {
+      propsData: {
+        tag: 'h2',
+        anchor: 'title',
+      },
+      slots: { default: 'Title' },
+    });
+    expect(wrapper.text()).toBe('# Title');
+    expect(wrapper.attributes('id')).toBe('title');
+    const headerAnchor = wrapper.find('.header-anchor');
+    expect(headerAnchor.attributes('href')).toBe('#title');
+    expect(headerAnchor.attributes('aria-label')).toBe('hidden');
+  });
+
+  it('renders a section title with a header anchor and no id on the wrapper', () => {
+    const wrapper = shallowMount(SectionTitle, {
+      propsData: {
+        tag: 'h2',
+        href: 'title',
+      },
+      slots: { default: 'Title' },
+    });
+    expect(wrapper.text()).toBe('# Title');
+    expect(wrapper.attributes('id')).not.toBe('title');
+    const headerAnchor = wrapper.find('.header-anchor');
+    expect(headerAnchor.attributes('href')).toBe('#title');
+    expect(headerAnchor.attributes('aria-label')).toBe('hidden');
+  });
+
+  it('does not render anchor if there is no anchor or href props', () => {
+    const wrapper = shallowMount(SectionTitle);
+    expect(wrapper.find('.header-anchor').exists()).toBe(false);
+  });
+});

--- a/tests/unit/components/ContentNode/SectionTitle.spec.js
+++ b/tests/unit/components/ContentNode/SectionTitle.spec.js
@@ -33,7 +33,6 @@ describe('SectionTitle', () => {
   it('renders a section title with a header anchor and an id on the wrapper', async () => {
     const wrapper = shallowMount(SectionTitle, {
       propsData: {
-        tag: 'h2',
         anchor: 'title',
       },
       slots: { default: 'Title' },
@@ -54,7 +53,6 @@ describe('SectionTitle', () => {
 
     const wrapper = shallowMount(SectionTitle, {
       propsData: {
-        tag: 'h2',
         anchor: 'title',
       },
       slots: { default: 'Title' },
@@ -68,6 +66,18 @@ describe('SectionTitle', () => {
 
   it('does not render anchor if there is no anchor', () => {
     const wrapper = shallowMount(SectionTitle);
+    expect(wrapper.find('.header-anchor').exists()).toBe(false);
+  });
+
+  it('does not render anchor if target ide is true', () => {
+    const wrapper = shallowMount(SectionTitle, {
+      propsData: {
+        anchor: 'title',
+      },
+      provide: {
+        isTargetIDE: true,
+      },
+    });
     expect(wrapper.find('.header-anchor').exists()).toBe(false);
   });
 });

--- a/tests/unit/components/DocumentationTopic/ContentTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/ContentTable.spec.js
@@ -11,7 +11,10 @@
 import { shallowMount } from '@vue/test-utils';
 import ContentTable from 'docc-render/components/DocumentationTopic/ContentTable.vue';
 
-const { OnThisPageSection } = ContentTable.components;
+const {
+  OnThisPageSection,
+  SectionTitle,
+} = ContentTable.components;
 
 describe('ContentTable', () => {
   let wrapper;
@@ -41,7 +44,7 @@ describe('ContentTable', () => {
   it('renders an h2 title', () => {
     const title = wrapper.find('.title');
     expect(title.exists()).toBe(true);
-    expect(title.is('h2')).toBe(true);
+    expect(title.is(SectionTitle)).toBe(true);
     expect(title.text()).toBe(propsData.title);
   });
 

--- a/tests/unit/components/DocumentationTopic/ContentTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/ContentTable.spec.js
@@ -13,7 +13,7 @@ import ContentTable from 'docc-render/components/DocumentationTopic/ContentTable
 
 const {
   OnThisPageSection,
-  SectionTitle,
+  LinkableHeading,
 } = ContentTable.components;
 
 describe('ContentTable', () => {
@@ -44,7 +44,7 @@ describe('ContentTable', () => {
   it('renders an h2 title', () => {
     const title = wrapper.find('.title');
     expect(title.exists()).toBe(true);
-    expect(title.is(SectionTitle)).toBe(true);
+    expect(title.is(LinkableHeading)).toBe(true);
     expect(title.text()).toBe(propsData.title);
   });
 

--- a/tests/unit/components/DocumentationTopic/ContentTableSection.spec.js
+++ b/tests/unit/components/DocumentationTopic/ContentTableSection.spec.js
@@ -11,6 +11,10 @@
 import { shallowMount } from '@vue/test-utils';
 import ContentTableSection from 'docc-render/components/DocumentationTopic/ContentTableSection.vue';
 
+const {
+  SectionTitle,
+} = ContentTableSection.components;
+
 describe('ContentTableSection', () => {
   /** @type {import('@vue/test-utils').Wrapper} */
   let wrapper;
@@ -26,10 +30,11 @@ describe('ContentTableSection', () => {
   it('renders the title as `h3.title` by default', () => {
     const div = wrapper.findAll('.section-title').at(0);
 
-    const title = div.find('h3');
+    const title = div.find(SectionTitle);
     expect(title.exists()).toBe(true);
+    expect(title.attributes('tag')).toBe('h3');
     expect(title.classes('title')).toBe(true);
-    expect(title.text()).toBe(propsData.title);
+    expect(title.text()).toContain(propsData.title);
   });
 
   it('renders a slot for a title', () => {

--- a/tests/unit/components/DocumentationTopic/ContentTableSection.spec.js
+++ b/tests/unit/components/DocumentationTopic/ContentTableSection.spec.js
@@ -12,7 +12,7 @@ import { shallowMount } from '@vue/test-utils';
 import ContentTableSection from 'docc-render/components/DocumentationTopic/ContentTableSection.vue';
 
 const {
-  SectionTitle,
+  LinkableHeading,
 } = ContentTableSection.components;
 
 describe('ContentTableSection', () => {
@@ -30,11 +30,20 @@ describe('ContentTableSection', () => {
   it('renders the title as `h3.title` by default', () => {
     const div = wrapper.findAll('.section-title').at(0);
 
-    const title = div.find(SectionTitle);
+    const title = div.find(LinkableHeading);
     expect(title.exists()).toBe(true);
-    expect(title.attributes('tag')).toBe('h3');
+    expect(title.props('level')).toBe(3);
     expect(title.classes('title')).toBe(true);
     expect(title.text()).toContain(propsData.title);
+  });
+
+  it('renders an `id` if `anchor` is provided', () => {
+    const title = wrapper.find('.title');
+    expect(title.attributes('id')).toBe(undefined);
+    wrapper.setProps({
+      anchor: 'foo-bar',
+    });
+    expect(title.props('anchor')).toBe('foo-bar');
   });
 
   it('renders a slot for a title', () => {

--- a/tests/unit/components/DocumentationTopic/OnThisPageSection.spec.js
+++ b/tests/unit/components/DocumentationTopic/OnThisPageSection.spec.js
@@ -35,7 +35,6 @@ describe('OnThisPageSection', () => {
 
   it('renders a <section> with an id attribute', () => {
     expect(wrapper.is('section')).toBe(true);
-    expect(wrapper.attributes('id')).toBe(propsData.anchor);
   });
 
   it('renders slot content', () => {

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/Declaration.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/Declaration.spec.js
@@ -21,7 +21,7 @@ const {
   ConditionalConstraints,
   OnThisPageSection,
   DeclarationGroup,
-  SectionTitle,
+  LinkableHeading,
 } = Declaration.components;
 
 const { ChangeTypes } = Declaration.constants;
@@ -83,9 +83,8 @@ describe('Declaration', () => {
   });
 
   it('renders an h2 section title', () => {
-    const sectionTitle = wrapper.find(SectionTitle);
+    const sectionTitle = wrapper.find(LinkableHeading);
     expect(sectionTitle.exists()).toBe(true);
-    expect(sectionTitle.attributes('tag')).toBe('h2');
     expect(sectionTitle.text()).toContain('Declaration');
   });
 

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/Declaration.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/Declaration.spec.js
@@ -21,6 +21,7 @@ const {
   ConditionalConstraints,
   OnThisPageSection,
   DeclarationGroup,
+  SectionTitle,
 } = Declaration.components;
 
 const { ChangeTypes } = Declaration.constants;
@@ -81,10 +82,11 @@ describe('Declaration', () => {
     });
   });
 
-  it('renders an h2 title', () => {
-    const h2 = wrapper.find('h2');
-    expect(h2.exists()).toBe(true);
-    expect(h2.text()).toBe('Declaration');
+  it('renders an h2 section title', () => {
+    const sectionTitle = wrapper.find(SectionTitle);
+    expect(sectionTitle.exists()).toBe(true);
+    expect(sectionTitle.attributes('tag')).toBe('h2');
+    expect(sectionTitle.text()).toContain('Declaration');
   });
 
   it('renders 1 `DeclarationGroup` and 0 labels without multiple declarations', () => {

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/Parameters.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/Parameters.spec.js
@@ -14,7 +14,7 @@ import Parameters from 'docc-render/components/DocumentationTopic/PrimaryContent
 const {
   ContentNode,
   OnThisPageSection,
-  SectionTitle,
+  LinkableHeading,
 } = Parameters.components;
 
 describe('Parameters', () => {
@@ -60,9 +60,9 @@ describe('Parameters', () => {
   });
 
   it('renders an h2 with "Parameters"', () => {
-    const h2 = wrapper.find(SectionTitle);
+    const h2 = wrapper.find(LinkableHeading);
     expect(h2.exists()).toBe(true);
-    expect(h2.attributes('tag')).toBe('h2');
+    expect(h2.props('level')).toBe(2);
     expect(h2.text()).toContain('Parameters');
   });
 

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/Parameters.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/Parameters.spec.js
@@ -14,6 +14,7 @@ import Parameters from 'docc-render/components/DocumentationTopic/PrimaryContent
 const {
   ContentNode,
   OnThisPageSection,
+  SectionTitle,
 } = Parameters.components;
 
 describe('Parameters', () => {
@@ -59,9 +60,10 @@ describe('Parameters', () => {
   });
 
   it('renders an h2 with "Parameters"', () => {
-    const h2 = wrapper.find('h2');
+    const h2 = wrapper.find(SectionTitle);
     expect(h2.exists()).toBe(true);
-    expect(h2.text()).toBe('Parameters');
+    expect(h2.attributes('tag')).toBe('h2');
+    expect(h2.text()).toContain('Parameters');
   });
 
   it('renders a <dl>', () => {

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyListKeyDetails.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyListKeyDetails.spec.js
@@ -14,6 +14,7 @@ import PropertyListKeyDetails from 'docc-render/components/DocumentationTopic/Pr
 const {
   OnThisPageSection,
   PropertyListKeyType,
+  LinkableHeading,
 } = PropertyListKeyDetails.components;
 
 describe('PropertyKeyListDetails', () => {
@@ -50,10 +51,11 @@ describe('PropertyKeyListDetails', () => {
     });
   });
 
-  it('renders an h2 with "Details"', () => {
-    const h2 = wrapper.find('h2');
-    expect(h2.exists()).toBe(true);
-    expect(h2.text()).toBe('Details');
+  it('renders a title with "Details"', () => {
+    const title = wrapper.find(LinkableHeading);
+    expect(title.exists()).toBe(true);
+    expect(title.text()).toBe('Details');
+    expect(title.props('anchor')).toBe('details');
   });
 
   it('renders a <dl>', () => {

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyTable.spec.js
@@ -19,7 +19,7 @@ const {
   ParameterAttributes,
   ParametersTable,
   WordBreak,
-  SectionTitle,
+  LinkableHeading,
 } = PropertyTable.components;
 
 const { AttributeKind } = PropertyTable.components.ParameterAttributes.constants;
@@ -130,7 +130,7 @@ describe('PropertyTable', () => {
   });
 
   it('renders an h2 section title', () => {
-    const sectionTitle = mountComponent().find(SectionTitle);
+    const sectionTitle = mountComponent().find(LinkableHeading);
     expect(sectionTitle.exists()).toBe(true);
     expect(sectionTitle.text()).toContain(propsData.title);
   });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyTable.spec.js
@@ -19,6 +19,7 @@ const {
   ParameterAttributes,
   ParametersTable,
   WordBreak,
+  SectionTitle,
 } = PropertyTable.components;
 
 const { AttributeKind } = PropertyTable.components.ParameterAttributes.constants;
@@ -128,10 +129,10 @@ describe('PropertyTable', () => {
     expect(section.props('title')).toBe(propsData.title);
   });
 
-  it('renders an h2 title', () => {
-    const h2 = mountComponent().find('h2');
-    expect(h2.exists()).toBe(true);
-    expect(h2.text()).toBe(propsData.title);
+  it('renders an h2 section title', () => {
+    const sectionTitle = mountComponent().find(SectionTitle);
+    expect(sectionTitle.exists()).toBe(true);
+    expect(sectionTitle.text()).toContain(propsData.title);
   });
 
   it('displays the property information', () => {

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyTable.spec.js
@@ -115,7 +115,7 @@ describe('PropertyTable', () => {
 
   function mountComponent(options) {
     return mount(PropertyTable, {
-      stubs: ['ContentNode'],
+      stubs: ['ContentNode', 'router-link'],
       propsData,
       provide,
       ...options,

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestBody.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestBody.spec.js
@@ -20,7 +20,7 @@ const {
   PossiblyChangedMimetype,
   WordBreak,
   PossiblyChangedTextAttribute,
-  SectionTitle,
+  LinkableHeading,
 } = RestBody.components;
 
 const { ChangesKey } = RestBody.constants;
@@ -77,7 +77,7 @@ describe('RestBody', () => {
   });
 
   it('renders an h2 section title', () => {
-    const sectionTitle = wrapper.find(SectionTitle);
+    const sectionTitle = wrapper.find(LinkableHeading);
     expect(sectionTitle.exists()).toBe(true);
     expect(sectionTitle.text()).toContain(propsData.title);
   });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestBody.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestBody.spec.js
@@ -20,6 +20,7 @@ const {
   PossiblyChangedMimetype,
   WordBreak,
   PossiblyChangedTextAttribute,
+  SectionTitle,
 } = RestBody.components;
 
 const { ChangesKey } = RestBody.constants;
@@ -75,10 +76,10 @@ describe('RestBody', () => {
     });
   });
 
-  it('renders an h2 title', () => {
-    const h2 = wrapper.find('h2');
-    expect(h2.exists()).toBe(true);
-    expect(h2.text()).toBe(propsData.title);
+  it('renders an h2 section title', () => {
+    const sectionTitle = wrapper.find(SectionTitle);
+    expect(sectionTitle.exists()).toBe(true);
+    expect(sectionTitle.text()).toContain(propsData.title);
   });
 
   it('renders a single `ParametersTable`', () => {

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestEndpoint.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestEndpoint.spec.js
@@ -12,7 +12,7 @@ import { shallowMount } from '@vue/test-utils';
 import RestEndpoint from 'docc-render/components/DocumentationTopic/PrimaryContent/RestEndpoint.vue';
 
 const {
-  SectionTitle,
+  LinkableHeading,
 } = RestEndpoint.components;
 
 describe('RestEndpoint', () => {
@@ -28,7 +28,7 @@ describe('RestEndpoint', () => {
         tokens,
       },
     });
-    expect(wrapper.find(SectionTitle).text()).toContain('URL');
+    expect(wrapper.find(LinkableHeading).text()).toContain('URL');
 
     const source = wrapper.find({ name: 'DeclarationSource' });
     expect(source.exists()).toBe(true);

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestEndpoint.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestEndpoint.spec.js
@@ -11,6 +11,10 @@
 import { shallowMount } from '@vue/test-utils';
 import RestEndpoint from 'docc-render/components/DocumentationTopic/PrimaryContent/RestEndpoint.vue';
 
+const {
+  SectionTitle,
+} = RestEndpoint.components;
+
 describe('RestEndpoint', () => {
   it('renders the component with source and a title', () => {
     const tokens = [
@@ -24,7 +28,7 @@ describe('RestEndpoint', () => {
         tokens,
       },
     });
-    expect(wrapper.find('h2').text()).toContain('URL');
+    expect(wrapper.find(SectionTitle).text()).toContain('URL');
 
     const source = wrapper.find({ name: 'DeclarationSource' });
     expect(source.exists()).toBe(true);

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestParameters.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestParameters.spec.js
@@ -19,6 +19,7 @@ const {
   WordBreak,
   ParameterAttributes,
   PossiblyChangedTextAttribute,
+  SectionTitle,
 } = RestParameters.components;
 
 const { AttributeKind } = RestParameters.components.ParameterAttributes.constants;
@@ -64,10 +65,10 @@ describe('RestParameters', () => {
     expect(section.props('title')).toBe(propsData.title);
   });
 
-  it('renders an h2 title', () => {
-    const h2 = mountComponent().find('h2');
-    expect(h2.exists()).toBe(true);
-    expect(h2.text()).toBe(propsData.title);
+  it('renders an h2 section title', () => {
+    const sectionTitle = mountComponent().find(SectionTitle);
+    expect(sectionTitle.exists()).toBe(true);
+    expect(sectionTitle.text()).toContain(propsData.title);
   });
 
   it('displays the parameters information', () => {

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestParameters.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestParameters.spec.js
@@ -48,7 +48,7 @@ describe('RestParameters', () => {
 
   function mountComponent({ propsData: props, ...others } = {}) {
     return mount(RestParameters, {
-      stubs: ['ContentNode'],
+      stubs: ['ContentNode', 'router-link'],
       propsData: {
         ...propsData,
         ...props,

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestParameters.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestParameters.spec.js
@@ -19,7 +19,7 @@ const {
   WordBreak,
   ParameterAttributes,
   PossiblyChangedTextAttribute,
-  SectionTitle,
+  LinkableHeading,
 } = RestParameters.components;
 
 const { AttributeKind } = RestParameters.components.ParameterAttributes.constants;
@@ -66,7 +66,7 @@ describe('RestParameters', () => {
   });
 
   it('renders an h2 section title', () => {
-    const sectionTitle = mountComponent().find(SectionTitle);
+    const sectionTitle = mountComponent().find(LinkableHeading);
     expect(sectionTitle.exists()).toBe(true);
     expect(sectionTitle.text()).toContain(propsData.title);
   });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestResponses.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestResponses.spec.js
@@ -17,7 +17,7 @@ const {
   PossiblyChangedType,
   PossiblyChangedMimetype,
   ParametersTable,
-  SectionTitle,
+  LinkableHeading,
 } = RestResponses.components;
 
 describe('RestResponses', () => {
@@ -73,7 +73,7 @@ describe('RestResponses', () => {
   });
 
   it('renders an h2 section title', () => {
-    const sectionTitle = mountComponent().find(SectionTitle);
+    const sectionTitle = mountComponent().find(LinkableHeading);
     expect(sectionTitle.exists()).toBe(true);
     expect(sectionTitle.text()).toContain(propsData.title);
   });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestResponses.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestResponses.spec.js
@@ -57,7 +57,7 @@ describe('RestResponses', () => {
 
   function mountComponent(options) {
     const wrapper = mount(RestResponses, {
-      stubs: ['ContentNode'],
+      stubs: ['ContentNode', 'router-link'],
       propsData,
       provide,
       ...options,

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestResponses.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestResponses.spec.js
@@ -17,6 +17,7 @@ const {
   PossiblyChangedType,
   PossiblyChangedMimetype,
   ParametersTable,
+  SectionTitle,
 } = RestResponses.components;
 
 describe('RestResponses', () => {
@@ -71,10 +72,10 @@ describe('RestResponses', () => {
     expect(section.props('title')).toBe(propsData.title);
   });
 
-  it('renders an h2 title', () => {
-    const h2 = mountComponent().find('h2');
-    expect(h2.exists()).toBe(true);
-    expect(h2.text()).toBe(propsData.title);
+  it('renders an h2 section title', () => {
+    const sectionTitle = mountComponent().find(SectionTitle);
+    expect(sectionTitle.exists()).toBe(true);
+    expect(sectionTitle.text()).toContain(propsData.title);
   });
 
   it('renders a `ParametersTable`', () => {

--- a/tests/unit/components/DocumentationTopic/Relationships.spec.js
+++ b/tests/unit/components/DocumentationTopic/Relationships.spec.js
@@ -47,6 +47,7 @@ describe('Relationships', () => {
           foo.identifier,
           bar.identifier,
         ],
+        anchor: 'inherits-from',
       },
       {
         type: 'conformsTo',
@@ -83,6 +84,7 @@ describe('Relationships', () => {
 
     const firstSection = sections.at(0);
     expect(firstSection.props('title')).toBe(propsData.sections[0].title);
+    expect(firstSection.props('anchor')).toBe(propsData.sections[0].anchor);
     const firstList = firstSection.find(List);
     expect(firstList.exists()).toBe(true);
     expect(firstList.props('symbols')).toEqual([
@@ -93,6 +95,7 @@ describe('Relationships', () => {
 
     const lastSection = sections.at(1);
     expect(lastSection.props('title')).toBe(propsData.sections[1].title);
+    expect(lastSection.props('anchor')).toBe(null);
     const lastList = lastSection.find(List);
     expect(lastList.exists()).toBe(true);
     expect(lastList.props('symbols')).toEqual([baz]);

--- a/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
@@ -12,7 +12,7 @@ import { shallowMount } from '@vue/test-utils';
 import TopicsTable from 'docc-render/components/DocumentationTopic/TopicsTable.vue';
 
 const {
-  ContentTable, TopicsLinkBlock, ContentTableSection, ContentNode, WordBreak,
+  ContentTable, TopicsLinkBlock, ContentTableSection, ContentNode, WordBreak, SectionTitle,
 } = TopicsTable.components;
 
 describe('TopicsTable', () => {
@@ -140,8 +140,11 @@ describe('TopicsTable', () => {
     expect(wordBreak.exists()).toBe(false);
 
     wrapper.setProps({ wrapTitle: true });
+    const sectionTitle = wrapper.find(SectionTitle);
     wordBreak = wrapper.find(WordBreak);
-    expect(wordBreak.attributes('tag')).toBe('h3');
     expect(wordBreak.text()).toEqual(propsData.sections[0].title);
+    expect(sectionTitle.exists()).toBe(true);
+    expect(sectionTitle.attributes('tag')).toBe('h3');
+    expect(sectionTitle.attributes('href')).toBe('topics');
   });
 });

--- a/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
@@ -12,7 +12,7 @@ import { shallowMount } from '@vue/test-utils';
 import TopicsTable from 'docc-render/components/DocumentationTopic/TopicsTable.vue';
 
 const {
-  ContentTable, TopicsLinkBlock, ContentTableSection, ContentNode, WordBreak, SectionTitle,
+  ContentTable, TopicsLinkBlock, ContentTableSection, ContentNode, WordBreak, LinkableHeading,
 } = TopicsTable.components;
 
 describe('TopicsTable', () => {
@@ -44,6 +44,7 @@ describe('TopicsTable', () => {
         abstract: [{ type: 'text', text: 'foo abstract' }],
         discussion: { type: 'content', content: [{ type: 'text', text: 'foo discussion' }] },
         identifiers: [foo.identifier, 'bar'],
+        anchor: 'foobar',
       },
       {
         title: 'Baz',
@@ -77,7 +78,9 @@ describe('TopicsTable', () => {
     const sections = wrapper.findAll(ContentTableSection);
     expect(sections.length).toBe(propsData.sections.length);
     expect(sections.at(0).props('title')).toBe(propsData.sections[0].title);
+    expect(sections.at(0).props('anchor')).toBe(propsData.sections[0].anchor);
     expect(sections.at(1).props('title')).toBe(propsData.sections[1].title);
+    expect(sections.at(1).props('anchor')).toBe(null);
   });
 
   it('renders a `TopicsLinkBlock` for each topic with reference data in a section', () => {
@@ -140,11 +143,11 @@ describe('TopicsTable', () => {
     expect(wordBreak.exists()).toBe(false);
 
     wrapper.setProps({ wrapTitle: true });
-    const sectionTitle = wrapper.find(SectionTitle);
+    const linkableHeading = wrapper.find(LinkableHeading);
     wordBreak = wrapper.find(WordBreak);
     expect(wordBreak.text()).toEqual(propsData.sections[0].title);
-    expect(sectionTitle.exists()).toBe(true);
-    expect(sectionTitle.attributes('tag')).toBe('h3');
-    expect(sectionTitle.attributes('anchor')).toBe('topics');
+    expect(linkableHeading.exists()).toBe(true);
+    expect(linkableHeading.props('level')).toBe(3);
+    expect(linkableHeading.attributes('anchor')).toBe('topics');
   });
 });

--- a/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
@@ -148,6 +148,6 @@ describe('TopicsTable', () => {
     expect(wordBreak.text()).toEqual(propsData.sections[0].title);
     expect(linkableHeading.exists()).toBe(true);
     expect(linkableHeading.props('level')).toBe(3);
-    expect(linkableHeading.attributes('anchor')).toBe('topics');
+    expect(linkableHeading.attributes('anchor')).toBe(propsData.sections[0].anchor);
   });
 });

--- a/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
@@ -145,6 +145,6 @@ describe('TopicsTable', () => {
     expect(wordBreak.text()).toEqual(propsData.sections[0].title);
     expect(sectionTitle.exists()).toBe(true);
     expect(sectionTitle.attributes('tag')).toBe('h3');
-    expect(sectionTitle.attributes('href')).toBe('topics');
+    expect(sectionTitle.attributes('anchor')).toBe('topics');
   });
 });

--- a/tests/unit/components/Tutorial/NavigationBar.spec.js
+++ b/tests/unit/components/Tutorial/NavigationBar.spec.js
@@ -19,7 +19,7 @@ import { flushPromises } from '../../../../test-utils';
 
 jest.mock('docc-render/mixins/scrollToElement');
 
-scrollToElement.methods.scrollToElement.mockResolvedValue(true);
+scrollToElement.methods.handleFocusAndScroll.mockResolvedValue(true);
 
 const {
   PrimaryDropdown,
@@ -241,16 +241,16 @@ describe('NavigationBar', () => {
       const dropdown = wrapper.find(MobileDropdown);
       dropdown.vm.$emit('select-section', 'path/to/item#section-foo');
       await flushPromises();
-      expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledTimes(1);
-      expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledWith('#section-foo');
+      expect(scrollToElement.methods.handleFocusAndScroll).toHaveBeenCalledTimes(1);
+      expect(scrollToElement.methods.handleFocusAndScroll).toHaveBeenCalledWith('section-foo');
     });
 
     it('scrolls to a section, on `@select-section`, on SecondaryDropdown', async () => {
       const dropdown = wrapper.find(SecondaryDropdown);
       dropdown.vm.$emit('select-section', 'path/to/item#section-foo');
       await flushPromises();
-      expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledTimes(1);
-      expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledWith('#section-foo');
+      expect(scrollToElement.methods.handleFocusAndScroll).toHaveBeenCalledTimes(1);
+      expect(scrollToElement.methods.handleFocusAndScroll).toHaveBeenCalledWith('section-foo');
     });
 
     it('renders a "Primary Dropdown" with chapters', () => {

--- a/tests/unit/components/TutorialsOverview/TutorialsNavigationLink.spec.js
+++ b/tests/unit/components/TutorialsOverview/TutorialsNavigationLink.spec.js
@@ -17,7 +17,7 @@ import TutorialsNavigationLink
 import scrollToElement from 'docc-render/mixins/scrollToElement';
 
 jest.mock('docc-render/mixins/scrollToElement', () => ({
-  methods: { scrollToElement: jest.fn() },
+  methods: { handleFocusAndScroll: jest.fn() },
 }));
 
 describe('TutorialsNavigationLink', () => {
@@ -79,16 +79,9 @@ describe('TutorialsNavigationLink', () => {
   });
 
   it('focuses the element when clicked, used for AX', async () => {
-    const mockObject = { focus: jest.fn() };
-    const getElementSpy = jest.spyOn(document, 'getElementById').mockReturnValue(mockObject);
-    const spy = scrollToElement.methods.scrollToElement.mockReturnValueOnce(mockObject);
     const link = wrapper.find(RouterLinkStub);
     link.trigger('click');
     await wrapper.vm.$nextTick();
-    expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledWith('#hello-world');
-    expect(mockObject.focus).toHaveBeenCalledTimes(1);
-    expect(getElementSpy).toHaveBeenCalledTimes(1);
-    spy.mockRestore();
-    getElementSpy.mockRestore();
+    expect(scrollToElement.methods.handleFocusAndScroll).toHaveBeenCalledWith('hello-world');
   });
 });

--- a/tests/unit/mixins/scrollToElement.spec.js
+++ b/tests/unit/mixins/scrollToElement.spec.js
@@ -15,31 +15,31 @@ import * as loading from 'docc-render/utils/loading';
 const framesWait = jest.spyOn(loading, 'waitFrames');
 
 describe('scrollToElement', () => {
-  it('scrolls to the correct element when "scrollToElement" is called', async () => {
-    const scrollOffset = { x: 0, y: 14 };
-    const anchor = 'heres-why';
+  const scrollOffset = { x: 0, y: 14 };
+  const anchor = 'heres-why';
 
-    const wrapper = shallowMount({
-      name: 'MyComponent',
-      mixins: [scrollToElement],
-      render() {
-        return `<div id="${anchor}"/>`;
-      },
-    }, {
-      mocks: {
-        $router: {
-          resolve: ({ hash }) => ({ route: { hash } }),
-          options: {
-            scrollBehavior(to) {
-              return new Promise(resolve => (
-                resolve({ selector: to.hash, offset: scrollOffset })
-              ));
-            },
+  const wrapper = shallowMount({
+    name: 'MyComponent',
+    mixins: [scrollToElement],
+    render() {
+      return `<div id="${anchor}"/>`;
+    },
+  }, {
+    mocks: {
+      $router: {
+        resolve: ({ hash }) => ({ route: { hash } }),
+        options: {
+          scrollBehavior(to) {
+            return new Promise(resolve => (
+              resolve({ selector: to.hash, offset: scrollOffset })
+            ));
           },
         },
       },
-    });
+    },
+  });
 
+  it('scrolls to the correct element when "scrollToElement" is called', async () => {
     const scrollIntoViewMock = jest.fn();
     const mockElement = { scrollIntoView: scrollIntoViewMock };
 
@@ -71,5 +71,32 @@ describe('scrollToElement', () => {
     expect(framesWait).toHaveBeenLastCalledWith(8);
 
     expect(scrollByMock).toBeCalledWith(-scrollOffset.x, -scrollOffset.y);
+  });
+
+  it('focuses element and scrolls to it', async () => {
+    wrapper.vm.scrollToElement = jest.fn();
+    const hash = 'foo';
+    const mockObject = { focus: jest.fn() };
+    const getElementSpy = jest.spyOn(document, 'getElementById').mockReturnValue(mockObject);
+
+    await wrapper.vm.handleFocusAndScroll(hash);
+    // focus element
+    expect(mockObject.focus).toHaveBeenCalledTimes(1);
+    expect(getElementSpy).toHaveBeenCalledTimes(1);
+    // scrolls to element
+    expect(wrapper.vm.scrollToElement).toBeCalled();
+    expect(wrapper.vm.scrollToElement).toBeCalledWith(`#${hash}`);
+    getElementSpy.mockRestore();
+  });
+
+  it('does not focus element and scroll if element is not in the document', async () => {
+    wrapper.vm.scrollToElement = jest.fn();
+    const hash = 'foo';
+    const getElementSpy = jest.spyOn(document, 'getElementById').mockReturnValue(null);
+
+    await wrapper.vm.handleFocusAndScroll(hash);
+    // scrolls to element
+    expect(wrapper.vm.scrollToElement).not.toBeCalled();
+    getElementSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Bug/issue #96943502, if applicable: 

## Summary

Add anchor for section titles for quick sharing of sections.
This anchor shows when user hovers the title section.

Issue: https://github.com/apple/swift-docc-render/issues/273

## Dependencies

NA

## Testing

Steps:
1. Open any docc archive
2. Assert that all h2 and h3 titles in documentation pages show an anchor when hovering the title

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
