### PR TITLE
Fix navigator filter getting cutoff

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -26,8 +26,8 @@
         class="aside"
         ref="aside"
         :aria-hidden="hiddenOnLarge ? 'true': null"
-        @transitionstart="trackTransitionStart"
-        @transitionend="trackTransitionEnd"
+        @transitionstart.self="trackTransitionStart"
+        @transitionend.self="trackTransitionEnd"
       >
         <slot
           name="aside"


### PR DESCRIPTION
Bug/issue #, if applicable: 99316400

## Summary

Fixes an issue where the navigator filter gets cutoff when you expand a few items in the Navigator.

This happens because we were trying to catch transition events the adjustable sidebar in order to apply some extra styling mid transition. However, those event listeners would also catch deep child events as well, which was causing the bug.

A good practice with `transitionstart` event is to use the `.self` modifier, which I totally forgot.

## Dependencies

NA

## Testing

Steps:
1. Open/close a few items in the navigator
2. Assert filter is not cutoff when you click into it.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
