### PR TITLE
Use Reference for NavMenuLink

### DIFF
--- a/src/components/NavMenuLink.vue
+++ b/src/components/NavMenuLink.vue
@@ -18,21 +18,23 @@
   >
     <slot />
   </span>
-  <router-link
+  <Reference
     v-else
     class="nav-menu-link"
-    :to="url"
+    :url="url"
     tabindex="0"
   >
     <slot />
-  </router-link>
+  </Reference>
 </template>
 
 <script>
 import { buildUrl } from 'docc-render/utils/url-helper';
+import Reference from 'docc-render/components/ContentNode/Reference.vue';
 
 export default {
   name: 'NavMenuLink',
+  components: { Reference },
   computed: {
     isCurrent: ({ $route, url }) => ((typeof url === 'string') ? (
       // Use the `buildUrl` to compare urls, as we dont want to compare unnecessary query params

--- a/tests/unit/components/NavMenuLink.spec.js
+++ b/tests/unit/components/NavMenuLink.spec.js
@@ -9,10 +9,10 @@
 */
 
 import NavMenuLink from 'docc-render/components/NavMenuLink.vue';
-import { RouterLinkStub, shallowMount } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
+import Reference from '@/components/ContentNode/Reference.vue';
 
 const mountItem = attrs => shallowMount(NavMenuLink, {
-  stubs: { RouterLinkStub },
   ...attrs,
 });
 
@@ -50,18 +50,17 @@ describe('NavMenuLink', () => {
     expect(wrapper.find('span.nav-menu-link').classes()).toContain('current');
   });
 
-  it('renders a <router-link> for local routes', () => {
+  it('renders a <Reference> for local routes', () => {
     const wrapper = mountItem({
-      propsData: { url: { name: 'blah' } },
-      mocks: { $route: { name: 'foobar' } },
-      stubs: { 'router-link': RouterLinkStub },
+      propsData: { url: '/foo/bar' },
+      mocks: { $route: { path: '/foo/baz', query: {} } },
       slots: { default: 'Blah' },
     });
 
-    const link = wrapper.find(RouterLinkStub);
+    const link = wrapper.find(Reference);
     expect(link.exists()).toBe(true);
     expect(link.classes('nav-menu-link')).toBe(true);
-    expect(link.props('to')).toEqual({ name: 'blah' });
+    expect(link.props('url')).toEqual('/foo/bar');
     expect(link.text()).toBe('Blah');
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 97716953

## Summary

Navigation links use router-link directly, but if we use the References, we can add links to external sites, disable links if they are falsy and more.

## Dependencies

NA

## Testing

1. Assert everything works just as before

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
