### PR TITLE
Fix toggling off sibling items removes everything but groupMarkers

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -619,8 +619,9 @@ export default {
       const isOpen = this.openNodes[node.uid];
       const openNodes = clone(this.openNodes);
       const siblings = this.getSiblings(node.uid);
-      siblings.forEach(({ uid, childUIDs }) => {
-        if (!childUIDs.length) return;
+      siblings.forEach(({ uid, childUIDs, type }) => {
+        // if the item has no children or is a groupMarker, exit early
+        if (!childUIDs.length || type === TopicTypes.groupMarker) return;
         if (isOpen) {
           const children = this.getAllChildren(uid);
           // remove all children

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1694,6 +1694,30 @@ describe('NavigatorCard', () => {
       expect(items).toHaveLength(1);
       expect(items.at(0).props('item')).toEqual(root1);
     });
+
+    it('toggles siblings properly, even when there are groupMarkers', async () => {
+      const wrapper = createWrapper({
+        propsData: {
+          children: [
+            root0Updated, groupMarker, root0Child0, root0Child1, root0Child1GrandChild0, root1,
+          ],
+          activePath: [root0Updated.path],
+        },
+      });
+      await flushPromises();
+      // assert we have 5 items rendered
+      expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(5);
+      // open the item and it's siblings
+      wrapper.find(NavigatorCardItem).vm.$emit('toggle-siblings', root0Child1);
+      await flushPromises();
+      // assert we have one extra item visible
+      expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(6);
+      // close back the item
+      wrapper.find(NavigatorCardItem).vm.$emit('toggle-siblings', root0Child1);
+      await flushPromises();
+      // assert we are left with 5 items again
+      expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(5);
+    });
   });
 
   it('renders a Beta badge in the header', async () => {

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -860,6 +860,56 @@ describe('NavigatorCard', () => {
       expect(allItems.at(3).props('item')).toEqual(root1WithChildren);
       expect(allItems.at(4).props('item')).toEqual(root1Child0);
     });
+
+    it('toggles siblings properly, even when there are groupMarkers', async () => {
+      const wrapper = createWrapper({
+        propsData: {
+          children: [
+            root0WithGroupMarker,
+            groupMarker,
+            root0Child0WithChildren,
+            root0Child0WithChildrenGrandChild0,
+            root0Child1,
+            root0Child1GrandChild0,
+            root1WithChildren,
+            root1Child0,
+          ],
+          activePath: [root0WithGroupMarker.path],
+        },
+      });
+      await flushPromises();
+      // assert we have 3 items rendered
+      expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(5);
+      // open the item and it's siblings
+      wrapper.find(NavigatorCardItem).vm.$emit('toggle-siblings', root0Child1);
+      await flushPromises();
+      // assert we have one extra item visible
+      let allItems = wrapper.findAll(NavigatorCardItem);
+      // assert all items are as we expect them to be
+      expect(allItems).toHaveLength(7);
+      expect(allItems.at(0).props('item')).toEqual(root0WithGroupMarker);
+      expect(allItems.at(1).props('item')).toEqual(groupMarker);
+      expect(allItems.at(2).props('item')).toEqual(root0Child0WithChildren);
+      expect(allItems.at(3).props('item')).toEqual(root0Child0WithChildrenGrandChild0);
+      expect(allItems.at(4).props('item')).toEqual(root0Child1);
+      expect(allItems.at(5).props('item')).toEqual(root0Child1GrandChild0);
+      expect(allItems.at(6).props('item')).toEqual(root1WithChildren);
+
+      // toggle the items
+      allItems.at(0).vm.$emit('toggle-siblings', root0Child1);
+      await flushPromises();
+      allItems = wrapper.findAll(NavigatorCardItem);
+      expect(allItems).toHaveLength(5);
+      expect(allItems.at(0).props()).toMatchObject({
+        item: root0WithGroupMarker,
+        expanded: true,
+      });
+      expect(allItems.at(1).props('item')).toEqual(groupMarker);
+      expect(allItems.at(2).props())
+        .toMatchObject({ item: root0Child0WithChildren, expanded: false });
+      expect(allItems.at(3).props()).toMatchObject({ item: root0Child1, expanded: false });
+      expect(allItems.at(4).props()).toMatchObject({ item: root1WithChildren, expanded: false });
+    });
   });
 
   describe('on @focus-parent', () => {
@@ -1721,30 +1771,6 @@ describe('NavigatorCard', () => {
       // parent
       expect(items).toHaveLength(1);
       expect(items.at(0).props('item')).toEqual(root1);
-    });
-
-    it('toggles siblings properly, even when there are groupMarkers', async () => {
-      const wrapper = createWrapper({
-        propsData: {
-          children: [
-            root0Updated, groupMarker, root0Child0, root0Child1, root0Child1GrandChild0, root1,
-          ],
-          activePath: [root0Updated.path],
-        },
-      });
-      await flushPromises();
-      // assert we have 5 items rendered
-      expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(5);
-      // open the item and it's siblings
-      wrapper.find(NavigatorCardItem).vm.$emit('toggle-siblings', root0Child1);
-      await flushPromises();
-      // assert we have one extra item visible
-      expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(6);
-      // close back the item
-      wrapper.find(NavigatorCardItem).vm.$emit('toggle-siblings', root0Child1);
-      await flushPromises();
-      // assert we are left with 5 items again
-      expect(wrapper.findAll(NavigatorCardItem)).toHaveLength(5);
     });
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 99747732

## Summary

Fixes a bug where `cmd` + clicking on an item to toggle-off it and it's siblings was removing all clickable links from the list.

This was caused by a refactor in #355 to `groupMarkers`, and that extra data was not handled properly for toggling situations.

## Dependencies

NA

## Testing

Steps:
1. `cmd` + click on an item with children.
2. Assert all siblings are opened and closed without any issues or missing items from the list.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
