### PR TITLE
Remove unnecessary background color override for legal text

### DIFF
--- a/src/components/DocumentationTopic/BetaLegalText.vue
+++ b/src/components/DocumentationTopic/BetaLegalText.vue
@@ -54,9 +54,5 @@ export default {
   &-content /deep/ p {
     margin-bottom: 10px;
   }
-
-  .contenttable + & {
-    background-color: var(--color-fill);
-  }
 }
 </style>


### PR DESCRIPTION
Bug/issue #, if applicable: 99979298

## Summary

Removes an old background color override that used to be necessary with a previous layout design (pre sidebar) but is no longer needed now since the "Topics" section always has the same background color now.

## Testing

Steps:
1. Find pages with beta content, ideally both examples _with_ a "Topics" section and also one _without_ a "Topics" section.
2. Verify that the background color for the "Beta Software" element is always using the same secondary fill color.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
