### PR TITLE
Adjust syntax for some root relative imports

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -114,7 +114,7 @@ import BetaLegalText from 'theme/components/DocumentationTopic/BetaLegalText.vue
 import LanguageSwitcher from 'theme/components/DocumentationTopic/Summary/LanguageSwitcher.vue';
 import DocumentationHero from 'docc-render/components/DocumentationTopic/DocumentationHero.vue';
 import WordBreak from 'docc-render/components/WordBreak.vue';
-import { TopicSectionsStyle } from '@/constants/TopicSectionsStyle';
+import { TopicSectionsStyle } from 'docc-render/constants/TopicSectionsStyle';
 import OnThisPageNav from 'theme/components/OnThisPageNav.vue';
 import Abstract from './DocumentationTopic/Description/Abstract.vue';
 import ContentNode from './DocumentationTopic/ContentNode.vue';

--- a/src/components/DocumentationTopic/Topics.vue
+++ b/src/components/DocumentationTopic/Topics.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import { TopicSectionsStyle } from '@/constants/TopicSectionsStyle';
+import { TopicSectionsStyle } from 'docc-render/constants/TopicSectionsStyle';
 import TopicsTable from './TopicsTable.vue';
 
 export default {

--- a/src/components/DocumentationTopic/TopicsLinkCardGrid.vue
+++ b/src/components/DocumentationTopic/TopicsLinkCardGrid.vue
@@ -24,7 +24,7 @@
 <script>
 import Row from 'docc-render/components/ContentNode/Row.vue';
 import Column from 'docc-render/components/ContentNode/Column.vue';
-import { TopicSectionsStyle } from '@/constants/TopicSectionsStyle';
+import { TopicSectionsStyle } from 'docc-render/constants/TopicSectionsStyle';
 import TopicsLinkCardGridItem from './TopicsLinkCardGridItem.vue';
 
 export default {

--- a/src/components/DocumentationTopic/TopicsTable.vue
+++ b/src/components/DocumentationTopic/TopicsTable.vue
@@ -55,7 +55,7 @@
 <script>
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import WordBreak from 'docc-render/components/WordBreak.vue';
-import { TopicSectionsStyle } from '@/constants/TopicSectionsStyle';
+import { TopicSectionsStyle } from 'docc-render/constants/TopicSectionsStyle';
 import TopicsLinkCardGrid from 'docc-render/components/DocumentationTopic/TopicsLinkCardGrid.vue';
 import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 import ContentTable from './ContentTable.vue';


### PR DESCRIPTION
The `'docc-render'` prefix should be preferred over `'@'` when relevant to prevent issues with other Vue apps integrating these components.