### PR TITLE
Re-write throttle specs to use fake timers

### DIFF
--- a/tests/unit/utils/throttle.spec.js
+++ b/tests/unit/utils/throttle.spec.js
@@ -7,34 +7,47 @@
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
-
 import throttle from 'docc-render/utils/throttle';
 
-const func = jest.fn();
-const time = 100;
-const timeout = t => new Promise(r => setTimeout(r, t));
+jest.useFakeTimers();
 
 describe('throttle', () => {
-  it('registers only the last call to a function, in a timespan', async () => {
-    const throttled = throttle(func, time);
-    // register first
-    throttled(1);
-    // drop the rest
-    throttled(2);
-    throttled(3);
-    await timeout(50);
-    throttled(4);
-    // this is the last call before the timeout ends
-    throttled(5);
-    await timeout(time * 2);
-    // register new call
-    throttled(6);
-    // make sure its called after it ends
-    await timeout(100);
+  let nowSpy;
 
-    expect(func).toHaveBeenCalledTimes(3);
-    expect(func).toHaveBeenNthCalledWith(1, 1);
-    expect(func).toHaveBeenNthCalledWith(2, 5);
-    expect(func).toHaveBeenNthCalledWith(3, 6);
+  beforeEach(() => {
+    nowSpy = jest.spyOn(global.Date, 'now');
+    nowSpy.mockReturnValue(1664227837751);
+  });
+
+  // newer version of Jest handle `Date.now()` but this version does not yet,
+  // so we need to carefully advance it in the same manner that the timeouts
+  // are since `throttle` relies on both APIs in its implementation
+  const advanceTime = (duration) => {
+    const t = Date.now();
+    nowSpy.mockReturnValue(t + duration);
+    jest.advanceTimersByTime(duration);
+  };
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  it('calls a function only once within the given interval of time', () => {
+    // simulate throttling a function so that it only ever runs once per 50ms
+    const func = jest.fn();
+    const interval = 50;
+    const throttled = throttle(func, interval);
+
+    // simulate attempting to call this throttled function every 1ms for 100ms
+    const fullTime = interval * 2 - 1;
+    for (let i = 0; i < fullTime; i += 1) {
+      throttled(i);
+      advanceTime(1);
+    }
+
+    // ensure that the function was only actually run twice during the 100ms
+    expect(func).toHaveBeenCalledTimes(2);
+    expect(func).toHaveBeenNthCalledWith(1, 0);
+    expect(func).toHaveBeenNthCalledWith(2, 49);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 100137207

## Summary

This should make these tests more stable and reliable while also ensuring that they don't take a fixed amount of real time to run.

## Testing

Steps:
1. Run `npm test` and verify that all unit tests still pass.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
