### PR TITLE
fix: card cover styling for fallback images

### DIFF
--- a/src/components/CardCover.vue
+++ b/src/components/CardCover.vue
@@ -52,15 +52,14 @@ export default {
 
   &.fallback, /deep/ img {
     width: 100%;
-    height: 100%;
     object-fit: cover;
     object-position: center;
     display: block;
     margin: 0;
   }
   // make sure we dont override the height for the fallback
-  &.fallback {
-    height: var(--card-cover-height, 180px);
+  /deep/ img {
+    height: 100%;
   }
 }
 </style>

--- a/src/components/CardCover.vue
+++ b/src/components/CardCover.vue
@@ -50,7 +50,7 @@ export default {
   // default height for a card, if no size is specified
   height: var(--card-cover-height, 180px);
 
-  /deep/ img {
+  &.fallback, /deep/ img {
     width: 100%;
     height: 100%;
     object-fit: cover;

--- a/src/components/CardCover.vue
+++ b/src/components/CardCover.vue
@@ -58,5 +58,9 @@ export default {
     display: block;
     margin: 0;
   }
+  // make sure we dont override the height for the fallback
+  &.fallback {
+    height: var(--card-cover-height, 180px);
+  }
 }
 </style>


### PR DESCRIPTION
Bug/issue #, if applicable: 100705861

## Summary

Fixes an issue with cards not styling fallback images as cover, when the correct image cannot be loaded.

## After

![image](https://user-images.githubusercontent.com/9863944/193523947-dd5ed0ec-607c-4797-b3e2-0c519d0d8be8.png)

## Before
![image](https://user-images.githubusercontent.com/9863944/193520996-4a8bf311-f1b8-4bd9-b41b-86615ab8d8f3.png)


## Dependencies

NA

## Testing

Mount the provided docc-archive - [docc-build.zip](https://github.com/apple/swift-docc-render/files/9695519/docc-build.zip)


Steps:
1. Go to http://localhost:8081/documentation/docc/formatting-your-documentation-content
2. Block the card image in Developer Tools from downloading
3. Refresh and assert the fallback is properly aligned. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~ - no need, css only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
