### PR TITLE
Replayable video styling change

### DIFF
--- a/src/components/ReplayableVideoAsset.vue
+++ b/src/components/ReplayableVideoAsset.vue
@@ -25,11 +25,11 @@
       class="replay-button"
       href="#"
       :class="{ visible: this.showsReplayButton }"
+      :title="text"
       @click.prevent="replay"
     >
-      {{ text }}
-      <InlineReplayIcon v-if="played" class="replay-icon icon-inline" />
-      <PlayIcon v-else class="replay-icon icon-inline" />
+      <InlineReplayIcon v-if="played" class="action-icon icon-inline" />
+      <PlayIcon v-else class="action-icon icon-inline" />
     </a>
   </div>
 </template>
@@ -69,7 +69,7 @@ export default {
     },
   },
   computed: {
-    text: ({ played }) => (played ? 'Replay' : 'Play'),
+    text: ({ played }) => (played ? 'Replay Video' : 'Play Video'),
   },
   data() {
     return {
@@ -105,23 +105,42 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
+.video-replay-container {
+  position: relative;
+}
+
 .replay-button {
-  display: flex;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  visibility: hidden;
-  margin-top: .5rem;
   -webkit-tap-highlight-color: transparent;
+  color: light-color(fill);
+  background: change-color(dark-color(fill), $alpha: 0.2);
+  transition: background linear 0.15s;
 
-  &.visible {
-    visibility: visible;
+  &:hover {
+    text-shadow: 0 0 2px light-color(text);
+    background: change-color(dark-color(fill), $alpha: 0.32);
+
+    .action-icon {
+      transform: scale(1.05)
+    }
   }
 
-  svg.replay-icon {
-    height: 12px;
-    width: 12px;
-    margin-left: .3em;
+  &.visible {
+    display: flex;
+  }
+
+  svg.action-icon {
+    height: 118px;
+    width: 118px;
+    transition: transform linear 0.15s;
   }
 }
 </style>

--- a/tests/unit/components/ReplayableVideoAsset.spec.js
+++ b/tests/unit/components/ReplayableVideoAsset.spec.js
@@ -63,12 +63,12 @@ describe('ReplayableVideoAsset', () => {
     expect(replayButton.exists()).toBe(true);
     expect(replayButton.classes('visible')).toBe(false);
 
-    expect(replayButton.find('.replay-icon').is(PlayIcon)).toBe(true);
+    expect(replayButton.find('.action-icon').is(PlayIcon)).toBe(true);
     const video = wrapper.find(VideoAsset);
     video.vm.$emit('ended');
 
     expect(replayButton.classes('visible')).toBe(true);
-    expect(wrapper.find('.replay-icon').is(InlineReplayIcon)).toBe(true);
+    expect(wrapper.find('.action-icon').is(InlineReplayIcon)).toBe(true);
 
     // When the video is playing, the replay button should be hidden.
     replayButton.trigger('click');
@@ -90,17 +90,17 @@ describe('ReplayableVideoAsset', () => {
       autoplays: false,
     });
     const replay = wrapper.find('.replay-button');
-    expect(replay.text()).toBe('Play');
+    expect(replay.attributes('title')).toBe('Play Video');
     expect(replay.classes()).toContain('visible');
     replay.trigger('click');
     await flushPromises();
     // text is not changed, but its invisible
-    expect(replay.text()).toBe('Play');
+    expect(replay.attributes('title')).toBe('Play Video');
     expect(replay.classes()).not.toContain('visible');
     // now end the video
     wrapper.find({ ref: 'asset' }).trigger('ended');
     // assert text changed and its visible
-    expect(replay.text()).toBe('Replay');
+    expect(replay.attributes('title')).toBe('Replay Video');
     expect(replay.classes()).toContain('visible');
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 99975532

## Summary

Improves the design for the Replayable videos to have a replay button overlayed on top of video

## Dependencies

NA

## Testing

Steps:
1. Open an archive that has either Videos in doc pages or in a Tutorial.
2. Assert it renders the video with a Play icon on top and Replay when it finishes.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
