### PR TITLE
Prevent tabbing to body links without breaking Navigator toggle

### DIFF
--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -182,7 +182,7 @@ export default {
       this.$emit('change', value);
       if (value) {
         this.onExpand();
-        document.activeElement.blur();
+        document.activeElement.blur(); // blur focus to allow toggling the navigator
       } else {
         this.onClose();
       }

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -182,6 +182,7 @@ export default {
       this.$emit('change', value);
       if (value) {
         this.onExpand();
+        document.activeElement.blur();
       } else {
         this.onClose();
       }
@@ -315,6 +316,8 @@ export default {
       this.$emit('open');
       // hide sibling elements from VO
       changeElementVOVisibility.hide(this.$refs.wrapper);
+      // focus on the toggle to prevent tabbing to links in the body
+      this.$refs.axToggle.focus();
     },
     onClose() {
       this.$emit('close');

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -54,6 +54,7 @@
         </div>
         <div class="nav-actions">
           <a
+            ref="toggle"
             href="#"
             class="nav-menucta"
             tabindex="-1"
@@ -182,7 +183,6 @@ export default {
       this.$emit('change', value);
       if (value) {
         this.onExpand();
-        document.activeElement.blur(); // blur focus to allow toggling the navigator
       } else {
         this.onClose();
       }
@@ -316,8 +316,11 @@ export default {
       this.$emit('open');
       // hide sibling elements from VO
       changeElementVOVisibility.hide(this.$refs.wrapper);
-      // focus on the toggle to prevent tabbing to links in the body
-      this.$refs.axToggle.focus();
+      if (document.activeElement === this.$refs.toggle) {
+        // move focus to body to prevent tabbing to links in body
+        // when toggle is triggered by mouse
+        document.activeElement.blur();
+      }
     },
     onClose() {
       this.$emit('close');

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -452,6 +452,18 @@ describe('NavBase', () => {
     expect(scrollLock.unlockScroll).toHaveBeenCalledTimes(1);
   });
 
+  it('focuses on the toggle on expand before resetting focus', async () => {
+    wrapper = await createWrapper();
+    const axToggle = wrapper.find({ ref: 'axToggle' });
+    const focusSpy = jest.spyOn(axToggle.element, 'focus');
+    axToggle.trigger('click');
+
+    // assert focus on toggle is called to prevent tabbing to body links
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+    // assert focus is reset to allow navigator toggle to work
+    expect(document.activeElement).toEqual(document.body);
+  });
+
   it('changes the sibling visibility to `hidden` on expand', async () => {
     wrapper = await createWrapper();
 

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -452,15 +452,25 @@ describe('NavBase', () => {
     expect(scrollLock.unlockScroll).toHaveBeenCalledTimes(1);
   });
 
-  it('focuses on the toggle on expand before resetting focus', async () => {
+  it('stays focus on axToggle, if nav expand is toggled from axToggle', async () => {
     wrapper = await createWrapper();
     const axToggle = wrapper.find({ ref: 'axToggle' });
     const focusSpy = jest.spyOn(axToggle.element, 'focus');
     axToggle.trigger('click');
 
-    // assert focus on toggle is called to prevent tabbing to body links
-    expect(focusSpy).toHaveBeenCalledTimes(1);
-    // assert focus is reset to allow navigator toggle to work
+    // assert focus is not moved
+    expect(focusSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('blurs active element, if nav expand is toggled by mouse click', async () => {
+    wrapper = await createWrapper();
+    const navToggle = wrapper.find('.nav-menucta');
+    const blurSpy = jest.spyOn(navToggle.element, 'blur');
+    // manually focus to fix JSDom issue
+    navToggle.element.focus();
+    navToggle.trigger('click');
+    expect(blurSpy).toHaveBeenCalledTimes(1);
+    // assert focus is on the body
     expect(document.activeElement).toEqual(document.body);
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 101062950

## Summary
This PR fixes: Localnav should not FocusTrap for documentation pages without breaking navigator toggle after expanding nav menu.

## Testing
Steps:
1. Expand nav menu with mouse, cmd+tab to navigate through the links. Assert that focus is not trapped (can go up to the browser menu bar). Assert that we can't tab to links outside of the nav menu 
2. Assert that navigator toggle works after expanding and closing nav menu. Assert that navigator toggle works even with nav menu expanded. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
