### PR TITLE
Allow skipping fetching data

### DIFF
--- a/src/mixins/communicationBridgeUtils.js
+++ b/src/mixins/communicationBridgeUtils.js
@@ -41,5 +41,11 @@ export default {
         },
       });
     },
+    /**
+     * @param {Object} data
+     */
+    handleContentUpdateFromBridge(data) {
+      this.topicData = data;
+    },
   },
 };

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -362,6 +362,11 @@ export default {
     this.$bridge.off('codeColors', this.handleCodeColorsChange);
   },
   beforeRouteEnter(to, from, next) {
+    if (to.meta.skipFetchingData) {
+      next(vm => vm.newContentMounted());
+      return;
+    }
+
     fetchDataForRouteEnter(to, from, next).then(data => next((vm) => {
       vm.topicData = data; // eslint-disable-line no-param-reassign
       if (to.query.language === Language.objectiveC.key.url && vm.objcOverrides) {

--- a/src/views/Topic.vue
+++ b/src/views/Topic.vue
@@ -30,7 +30,7 @@ import TopicStore from 'docc-render/stores/TopicStore';
 import Article from 'docc-render/components/Article.vue';
 import Tutorial from 'docc-render/components/Tutorial.vue';
 
-import performanceMetrics from 'docc-render/mixins/performanceMetrics';
+import communicationBridgeUtils from 'docc-render/mixins/communicationBridgeUtils';
 import onPageLoadScrollToFragment from 'docc-render/mixins/onPageLoadScrollToFragment';
 
 const TopicKind = {
@@ -45,7 +45,7 @@ export default {
       default: false,
     },
   },
-  mixins: [performanceMetrics, onPageLoadScrollToFragment],
+  mixins: [communicationBridgeUtils, onPageLoadScrollToFragment],
   data() {
     return {
       topicData: null,
@@ -97,9 +97,10 @@ export default {
     this.store.reset();
   },
   mounted() {
-    this.$bridge.on('contentUpdate', (data) => {
-      this.topicData = data;
-    });
+    this.$bridge.on('contentUpdate', this.handleContentUpdateFromBridge);
+  },
+  beforeDestroy() {
+    this.$bridge.off('contentUpdate', this.handleContentUpdateFromBridge);
   },
   methods: {
     componentFor(topic) {

--- a/src/views/Topic.vue
+++ b/src/views/Topic.vue
@@ -75,6 +75,10 @@ export default {
     ].join(),
   },
   beforeRouteEnter(to, from, next) {
+    if (to.meta.skipFetchingData) {
+      next(vm => vm.newContentMounted());
+      return;
+    }
     fetchDataForRouteEnter(to, from, next).then(data => next((vm) => {
       vm.topicData = data; // eslint-disable-line no-param-reassign
     })).catch(next);

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -794,19 +794,15 @@ describe('DocumentationTopic', () => {
       },
     };
 
-    wrapper = shallowMount(DocumentationTopic, {
-      mocks: {
-        ...mocks,
-        $bridge: {
-          ...mocks.$bridge,
-          on(type, handler) {
-            handler(data);
-          },
-        },
-      },
-    });
-
+    expect(mocks.$bridge.on).toHaveBeenNthCalledWith(1, 'contentUpdate', expect.any(Function));
+    expect(mocks.$bridge.on).toHaveBeenNthCalledWith(2, 'codeColors', expect.any(Function));
+    // invoke the callback on the $bridge
+    mocks.$bridge.on.mock.calls[0][1](data);
+    // assert the data is stored
     expect(wrapper.vm.topicData).toEqual(data);
+    // destroy the instance
+    wrapper.destroy();
+    expect(mocks.$bridge.off).toHaveBeenNthCalledWith(1, 'contentUpdate', expect.any(Function));
   });
 
   it('applies ObjC data when provided as overrides', () => {

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -882,6 +882,23 @@ describe('DocumentationTopic', () => {
     expect(next).toBeCalled();
   });
 
+  it('skips fetching data, if `meta.skipFetchingData` is `true`', () => {
+    const next = jest.fn();
+    DocumentationTopic.beforeRouteEnter({ meta: { skipFetchingData: true } }, {}, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(dataUtils.fetchDataForRouteEnter).toHaveBeenCalledTimes(0);
+    // now call without `skipFetchingData`
+    const params = {
+      to: { name: 'foo', meta: {} },
+      from: { name: 'bar' },
+      next: jest.fn(),
+    };
+    DocumentationTopic.beforeRouteEnter(params.to, params.from, params.next);
+    expect(dataUtils.fetchDataForRouteEnter).toHaveBeenCalledTimes(1);
+    expect(dataUtils.fetchDataForRouteEnter)
+      .toHaveBeenCalledWith(params.to, params.from, params.next);
+  });
+
   describe('isTargetIDE', () => {
     const provide = { isTargetIDE: true };
 

--- a/tests/unit/views/Topic.spec.js
+++ b/tests/unit/views/Topic.spec.js
@@ -34,6 +34,7 @@ describe('Topic', () => {
   let wrapper;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     wrapper = shallowMount(Topic, { mocks });
   });
 
@@ -140,19 +141,14 @@ describe('Topic', () => {
       identifier: 'myIdentifier',
     };
 
-    wrapper = shallowMount(Topic, {
-      mocks: {
-        ...mocks,
-        $bridge: {
-          ...mocks.$bridge,
-          on(type, handler) {
-            handler(data);
-          },
-        },
-      },
-    });
-
+    expect(mocks.$bridge.on).toHaveBeenNthCalledWith(1, 'contentUpdate', expect.any(Function));
+    // invoke the callback on the $bridge
+    mocks.$bridge.on.mock.calls[0][1](data);
+    // assert the data is stored
     expect(wrapper.vm.topicData).toEqual(data);
+    // destroy the instance
+    wrapper.destroy();
+    expect(mocks.$bridge.off).toHaveBeenNthCalledWith(1, 'contentUpdate', expect.any(Function));
   });
 
   describe('with article data', () => {

--- a/tests/unit/views/Topic.spec.js
+++ b/tests/unit/views/Topic.spec.js
@@ -14,8 +14,12 @@ import Topic from 'docc-render/views/Topic.vue';
 import TopicStore from 'docc-render/stores/TopicStore';
 import Tutorial from 'docc-render/components/Tutorial.vue';
 import onPageLoadScrollToFragment from 'docc-render/mixins/onPageLoadScrollToFragment';
+import { fetchDataForRouteEnter } from '@/utils/data';
 
 jest.mock('docc-render/mixins/onPageLoadScrollToFragment');
+jest.mock('@/utils/data');
+
+fetchDataForRouteEnter.mockResolvedValue({});
 
 const mocks = {
   $bridge: {
@@ -54,6 +58,23 @@ describe('Topic', () => {
   it('provides `TopicStore` as `store`', () => {
     // eslint-disable-next-line no-underscore-dangle
     expect(wrapper.vm._provided.store).toEqual(TopicStore);
+  });
+
+  it('skips fetching data, if `meta.skipFetchingData` is `true`', () => {
+    const next = jest.fn();
+    Topic.beforeRouteEnter({ meta: { skipFetchingData: true } }, {}, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(fetchDataForRouteEnter).toHaveBeenCalledTimes(0);
+    // now call without `skipFetchingData`
+    const params = {
+      to: { name: 'foo', meta: {} },
+      from: { name: 'bar' },
+      next: jest.fn(),
+    };
+    Topic.beforeRouteEnter(params.to, params.from, params.next);
+    expect(fetchDataForRouteEnter).toHaveBeenCalledTimes(1);
+    expect(fetchDataForRouteEnter)
+      .toHaveBeenCalledWith(params.to, params.from, params.next);
   });
 
   async function testRenderedMessageWithProvide(provide) {

--- a/tests/unit/views/TutorialsOverview.spec.js
+++ b/tests/unit/views/TutorialsOverview.spec.js
@@ -19,24 +19,26 @@ describe('TutorialsOverview', () => {
   let wrapper;
 
   const mocks = {
-    $bridge: { send: jest.fn() },
+    $bridge: { send: jest.fn(), on: jest.fn(), off: jest.fn() },
     $route: { path: '/tutorials/swiftui', params: {} },
   };
 
+  const topicData = {
+    identifier: {
+      interfaceLanguage: 'swift',
+      url: '/tutorials/swiftui',
+    },
+    metadata: {},
+    references: {},
+    sections: [],
+  };
+
   beforeEach(() => {
+    jest.clearAllMocks();
     wrapper = shallowMount(TutorialsOverview, { mocks });
   });
 
   it('renders an `Overview` with data', () => {
-    const topicData = {
-      identifier: {
-        interfaceLanguage: 'swift',
-        url: '/tutorials/swiftui',
-      },
-      metadata: {},
-      references: {},
-      sections: [],
-    };
     wrapper.setData({ topicData });
 
     const overview = wrapper.find(Overview);
@@ -45,5 +47,15 @@ describe('TutorialsOverview', () => {
 
   it('uses the onPageLoadScrollToFragment mixin', () => {
     expect(onPageLoadScrollToFragment.mounted).toHaveBeenCalled();
+  });
+
+  it('updates the content on mounted', () => {
+    expect(mocks.$bridge.on).toHaveBeenCalledTimes(1);
+    expect(mocks.$bridge.on).toHaveBeenCalledWith('contentUpdate', expect.any(Function));
+    mocks.$bridge.on.mock.calls[0][1](topicData);
+    expect(wrapper.vm.topicData).toEqual(topicData);
+    wrapper.destroy();
+    expect(mocks.$bridge.off).toHaveBeenCalledTimes(1);
+    expect(mocks.$bridge.off).toHaveBeenCalledWith('contentUpdate', expect.any(Function));
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 100890249

## Summary

Refactors the $bridge interface and allows skipping fetching for routes.

## Dependencies

NA

## Testing

NA

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
