### PR TITLE
Make sure OnThisPageNav is only rendered if enabled through theme settings

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -104,6 +104,7 @@ import { compareVersions, combineVersions } from 'docc-render/utils/schema-versi
 import { BreakpointName } from 'docc-render/utils/breakpoints';
 import { storage } from 'docc-render/utils/storage';
 import OnThisPageRegistrator from 'docc-render/mixins/onThisPageRegistrator';
+import { getSetting } from 'docc-render/utils/theme-settings';
 import QuickNavigationStore from '../stores/QuickNavigationStore';
 
 const MIN_RENDER_JSON_VERSION_WITH_INDEX = '0.3.0';
@@ -297,7 +298,9 @@ export default {
       ) >= 0
     ),
     enableOnThisPageNav: ({ isTargetIDE, store }) => (
-      !isTargetIDE && store.state.onThisPageSections.length > 2
+      getSetting(['features', 'docs', 'onThisPageNavigator', 'enable'], false)
+      && !isTargetIDE
+      && store.state.onThisPageSections.length > 2
     ),
     sidebarProps: ({ sidenavVisibleOnMobile, enableNavigator, sidenavHiddenOnLarge }) => (
       enableNavigator

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -22,6 +22,7 @@ import { storage } from '@/utils/storage';
 import { BreakpointName } from 'docc-render/utils/breakpoints';
 import StaticContentWidth from 'docc-render/components/DocumentationTopic/StaticContentWidth.vue';
 import onThisPageRegistrator from '@/mixins/onThisPageRegistrator';
+import { getSetting } from 'docc-render/utils/theme-settings';
 import { flushPromises } from '../../../test-utils';
 
 jest.mock('docc-render/mixins/onPageLoadScrollToFragment');
@@ -30,6 +31,7 @@ jest.mock('docc-render/utils/FocusTrap');
 jest.mock('docc-render/utils/changeElementVOVisibility');
 jest.mock('docc-render/utils/scroll-lock');
 jest.mock('docc-render/utils/storage');
+jest.mock('docc-render/utils/theme-settings');
 
 const TechnologyWithChildren = {
   path: '/documentation/foo',
@@ -573,6 +575,7 @@ describe('DocumentationTopic', () => {
 
   it('passes `enableOnThisPageNav` as `false`, if in IDE', () => {
     wrapper.destroy();
+    getSetting.mockReturnValue(true);
     wrapper = shallowMount(DocumentationTopic, {
       mocks,
       provide: { isTargetIDE: true },
@@ -587,11 +590,20 @@ describe('DocumentationTopic', () => {
   });
 
   it('passes `enableOnThisPageNav` as `false`, if in onThisPageSections are 2 or less', async () => {
+    getSetting.mockReturnValue(true);
     wrapper.setData({ topicData, store: { state: { onThisPageSections: ['a', 'b'] } } });
     expect(wrapper.find(Topic).props('enableOnThisPageNav')).toBe(false);
+    // assert it enables itself
     wrapper.setData({ store: { state: { onThisPageSections: ['a', 'b', 'c'] } } });
     await flushPromises();
     expect(wrapper.find(Topic).props('enableOnThisPageNav')).toBe(true);
+  });
+
+  it('sets `enableOnThisPageNav` as `false`, if not enabled in theme settings', async () => {
+    getSetting.mockReturnValue(false);
+    wrapper.setData({ topicData, store: { state: { onThisPageSections: ['a', 'b', 'c'] } } });
+    await flushPromises();
+    expect(wrapper.find(Topic).props('enableOnThisPageNav')).toBe(false);
   });
 
   it('passes `topicSectionsStyle`', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 101345143

## Summary

Disabled the OnThisPageNav, unless enabled explicitly. Fixing an oversight where it was ON by default

## Dependencies

NA

## Testing

Steps:
1. Ensure the OnThisPage is not shown unless the theme-settings file has the option enabled via `features.docs.onThisPageNavigator.enable`

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
