### PR TITLE
Anchor icon overlapping in Safari

### DIFF
--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -72,6 +72,7 @@ $icon-margin: 7px;
 
   .icon {
     position: absolute;
+    right: 0;
     bottom: .2em;
     display: none;
     height: $icon-size-default;


### PR DESCRIPTION
Bug/issue #101386117, if applicable: 

## Summary

Anchor icon overlapping in Safari

## Dependencies

NA

## Testing

Steps:
1. Run SlothCreator
2. Open Safari
3. Go to http://localhost:8080/documentation/slothcreator/activity or any page with Declarations
4. Assert that when hovering in the Declaration title, the anchor icon is on the right side

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
