### PR TITLE
Make sure videos are as big as their poster image.

### DIFF
--- a/src/components/ImageAsset.vue
+++ b/src/components/ImageAsset.vue
@@ -62,21 +62,9 @@ import imageAsset from 'docc-render/mixins/imageAsset';
 import AppStore from 'docc-render/stores/AppStore';
 import ColorScheme from 'docc-render/constants/ColorScheme';
 import noImage from 'theme/assets/img/no-image@2x.png';
-import { normalizeAssetUrl } from 'docc-render/utils/assets';
+import { getIntrinsicDimensions, normalizeAssetUrl } from 'docc-render/utils/assets';
 
 const RADIX_DECIMAL = 10;
-
-function getIntrinsicDimensions(src) {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.src = src;
-    img.onerror = reject;
-    img.onload = () => resolve({
-      width: img.width,
-      height: img.height,
-    });
-  });
-}
 
 function constructAttributes(sources) {
   if (!sources.length) {

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -82,3 +82,20 @@ export function normalizeAssetUrl(url) {
  * @returns {string|undefined}
  */
 export function toCSSUrl(url) { return url ? `url('${normalizeAssetUrl(url)}')` : undefined; }
+
+/**
+ * Loads an image and gets its dimensions
+ * @param {String} src
+ * @returns {Promise<{width: Number, height: Number}>}
+ */
+export function getIntrinsicDimensions(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.src = src;
+    img.onerror = reject;
+    img.onload = () => resolve({
+      width: img.width,
+      height: img.height,
+    });
+  });
+}

--- a/tests/unit/components/VideoAsset.spec.js
+++ b/tests/unit/components/VideoAsset.spec.js
@@ -30,7 +30,7 @@ const data = () => ({
 const propsData = {
   posterVariants: [
     { traits: ['light', '1x'], url: 'https://www.example.com/image.png' },
-    { traits: ['dark', '1x'], url: 'https://www.example.com/image~dark.png' },
+    { traits: ['dark', '2x'], url: 'https://www.example.com/image~dark.png' },
   ],
   variants: [
     { traits: ['light', '1x'], url: 'https://www.example.com/video.mp4' },
@@ -58,19 +58,26 @@ describe('VideoAsset', () => {
     await flushPromises();
     expect(wrapper.attributes()).toMatchObject({
       width: '100',
-      height: '100',
     });
   });
 
-  it('applies a dark poster if available and target prefers dark', () => {
+  it('applies a dark poster if available and target prefers dark', async () => {
     expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(1);
     expect(getIntrinsicDimensionsSpy).toHaveBeenNthCalledWith(1, propsData.posterVariants[0].url);
+    expect(wrapper.attributes()).toMatchObject({
+      width: '100',
+    });
     wrapper.setData({
       appState: { preferredColorScheme: ColorScheme.dark.value },
     });
     expect(wrapper.find('video').attributes('poster')).toEqual(propsData.posterVariants[1].url);
     expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(2);
     expect(getIntrinsicDimensionsSpy).toHaveBeenNthCalledWith(2, propsData.posterVariants[1].url);
+    await flushPromises();
+    // dark image is 2x, so the width is half
+    expect(wrapper.attributes()).toMatchObject({
+      width: '50',
+    });
   });
 
   it('applies a light poster if there is no dark variant but target prefers dark', async () => {

--- a/tests/unit/components/VideoAsset.spec.js
+++ b/tests/unit/components/VideoAsset.spec.js
@@ -11,6 +11,13 @@
 import { shallowMount } from '@vue/test-utils';
 import ColorScheme from 'docc-render/constants/ColorScheme';
 import VideoAsset from 'docc-render/components/VideoAsset.vue';
+import * as assetUtils from 'docc-render/utils/assets';
+import { flushPromises } from '../../../test-utils';
+
+const getIntrinsicDimensionsSpy = jest.spyOn(assetUtils, 'getIntrinsicDimensions').mockResolvedValue({
+  width: 100,
+  height: 100,
+});
 
 const data = () => ({
   appState: {
@@ -35,6 +42,7 @@ describe('VideoAsset', () => {
   let wrapper;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     wrapper = shallowMount(VideoAsset, { data, propsData });
   });
 
@@ -43,18 +51,30 @@ describe('VideoAsset', () => {
     expect(wrapper.element.muted).toBe(true);
   });
 
-  it('adds a poster to the `video`, using light by default', () => {
+  it('adds a poster to the `video`, using light by default', async () => {
     expect(wrapper.find('video').attributes('poster')).toEqual(propsData.posterVariants[0].url);
+    expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(1);
+    expect(getIntrinsicDimensionsSpy).toHaveBeenCalledWith(propsData.posterVariants[0].url);
+    await flushPromises();
+    expect(wrapper.attributes()).toMatchObject({
+      width: '100',
+      height: '100',
+    });
   });
 
   it('applies a dark poster if available and target prefers dark', () => {
+    expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(1);
+    expect(getIntrinsicDimensionsSpy).toHaveBeenNthCalledWith(1, propsData.posterVariants[0].url);
     wrapper.setData({
       appState: { preferredColorScheme: ColorScheme.dark.value },
     });
     expect(wrapper.find('video').attributes('poster')).toEqual(propsData.posterVariants[1].url);
+    expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(2);
+    expect(getIntrinsicDimensionsSpy).toHaveBeenNthCalledWith(2, propsData.posterVariants[1].url);
   });
 
-  it('applies a light poster if there is no dark variant but target prefers dark', () => {
+  it('applies a light poster if there is no dark variant but target prefers dark', async () => {
+    expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(1);
     wrapper.setProps({
       posterVariants: [propsData.posterVariants[0]],
       variants: [propsData.variants[0]],
@@ -62,21 +82,36 @@ describe('VideoAsset', () => {
     wrapper.setData({
       appState: { preferredColorScheme: ColorScheme.dark.value },
     });
+    await flushPromises();
+    // the poster did not change, so the function was not called again
+    expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(1);
     expect(wrapper.find('video').attributes('poster')).toEqual(propsData.posterVariants[0].url);
   });
 
-  it('renders no poster if no light poster is provided, even if dark one exists', () => {
+  it('renders no poster if no light poster is provided, even if dark one exists', async () => {
+    expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(1);
     wrapper.setProps({
       posterVariants: [propsData.posterVariants[1]],
     });
     expect(wrapper.find('video').attributes('poster')).toEqual(undefined);
+    // not called again
+    expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(1);
+    await flushPromises();
+    expect(wrapper.attributes('width')).toBeFalsy();
+    expect(wrapper.attributes('height')).toBeFalsy();
   });
 
-  it('renders no poster if not available', () => {
+  it('renders no poster if not available', async () => {
+    expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(1);
     wrapper.setProps({
       posterVariants: [],
     });
     expect(wrapper.find('video').attributes('poster')).toEqual(undefined);
+    await flushPromises();
+    // not called again
+    expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(1);
+    expect(wrapper.attributes('width')).toBeFalsy();
+    expect(wrapper.attributes('height')).toBeFalsy();
   });
 
   it('does not show controls when `showsControls=false`', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 101373576

## Summary

Sets the width/height of video to match those of their poster image, if provided. This prevents jumping on the page, if the video and poster are different dimensions.

## Dependencies

NA

## Testing

Steps:
1. Use an archive that has a video with a cover image. The image should be smaller than the video.
2. Assert the video is rendered with the same dimensions as the poster image.
3. Assert that switching dark/light mode follows the dimensions of the poster image.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
