### PR TITLE
Fix typo: "Declarations" section should be "Declaration"

### DIFF
--- a/src/constants/ContentSectionAnchors.js
+++ b/src/constants/ContentSectionAnchors.js
@@ -35,7 +35,7 @@ export const MainContentSectionAnchors = {
 
 export const PrimaryContentSectionAnchors = {
   [SectionKind.declarations]: {
-    title: 'Declarations',
+    title: 'Declaration',
     anchor: 'declaration',
     level: 2,
   },

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/Declaration.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/Declaration.spec.js
@@ -76,7 +76,7 @@ describe('Declaration', () => {
   it('renders an h2 section title', () => {
     const sectionTitle = wrapper.find(LinkableHeading);
     expect(sectionTitle.exists()).toBe(true);
-    expect(sectionTitle.text()).toContain('Declaration');
+    expect(sectionTitle.text()).toEqual('Declaration');
   });
 
   it('renders 1 `DeclarationGroup` and 0 labels without multiple declarations', () => {

--- a/tests/unit/mixins/__snapshots__/onThisPageRegistrator.spec.js.snap
+++ b/tests/unit/mixins/__snapshots__/onThisPageRegistrator.spec.js.snap
@@ -50,7 +50,7 @@ Array [
   Object {
     "anchor": "declaration",
     "level": 2,
-    "title": "Declarations",
+    "title": "Declaration",
   },
   Object {
     "anchor": "details",


### PR DESCRIPTION
Bug/issue #, if applicable: 101549478

## Summary

This fixes a minor typo introduced in #438 where the top level "Declaration" sections heading was mistakenly rewritten as "Declaration**s**".

## Testing

Steps:
1. Run `env VUE_APP_DEV_SERVER_PROXY=https://sofiaromorales.github.io/swift-argument-parser npm run serve`
2. Open http://localhost:8080/documentation/argumentparser/option/init(wrappedvalue:name:parsing:help:completion:)-7ilku/
3. Verify that the declaration section heading reads "Declaration" (singular)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
