### PR TITLE
Remove extra content border

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -47,8 +47,8 @@
         />
       </DocumentationHero>
       <div class="doc-content-wrapper">
-        <div class="doc-content">
-          <div v-if="showContainer" class="container">
+        <div class="doc-content" :class="{ 'no-primary-content': !hasPrimaryContent }">
+          <div v-if="hasPrimaryContent" class="container">
             <div class="description" :class="{ 'after-enhanced-hero': enhanceBackground }">
               <RequirementMetadata
                 v-if="isRequirement"
@@ -376,7 +376,7 @@ export default {
     titleBreakComponent: ({ enhanceBackground }) => (enhanceBackground
       ? 'span'
       : WordBreak),
-    showContainer: ({
+    hasPrimaryContent: ({
       isRequirement,
       deprecationSummary,
       downloadNotAvailableSummary,
@@ -482,7 +482,7 @@ export default {
 
 // remove border-top for first section of the page
 /deep/ {
-  .documentation-hero + .contenttable {
+  .no-primary-content {
     .container > .title {
       border-top: none;
     }

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -483,9 +483,7 @@ export default {
 // remove border-top for first section of the page
 /deep/ {
   .no-primary-content {
-    .container > .title {
-      border-top: none;
-    }
+    --content-table-title-border-width: 0px;
   }
 }
 

--- a/src/components/DocumentationTopic/ContentTable.vue
+++ b/src/components/DocumentationTopic/ContentTable.vue
@@ -49,6 +49,6 @@ export default {
   padding-top: $section-spacing-single-side;
   border-top-color: var(--color-grid);
   border-top-style: solid;
-  border-top-width: 1px;
+  border-top-width: var(--content-table-title-border-width, 1px);
 }
 </style>

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -467,6 +467,20 @@ describe('DocumentationTopic', () => {
     });
   });
 
+  it('does not render any primary content or related markup, if not provided', () => {
+    const docContent = wrapper.find('.doc-content');
+    expect(docContent.classes()).not.toContain('no-primary-content');
+    wrapper.setProps({
+      primaryContentSections: [],
+      isRequirement: false,
+      deprecationSummary: null,
+      downloadNotAvailableSummary: null,
+    });
+    expect(wrapper.find(PrimaryContent).exists()).toBe(false);
+    expect(wrapper.find('.description').exists()).toBe(false);
+    expect(docContent.classes()).toContain('no-primary-content');
+  });
+
   it('renders a `LanguageSwitcher` if TargetIDE', () => {
     const provide = { isTargetIDE: true };
     wrapper = shallowMount(DocumentationTopic, { propsData, provide });


### PR DESCRIPTION
Bug/issue #, if applicable: 101513120

## Summary

Removes extra border from Topics title, if there is no primary content above the Topics section.

## Dependencies

NA

## Testing

Steps:
1. Go to a page that has no content, only topics.
2. Assert there is no border rendered on the page.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
