### PR TITLE
Make compactGrid a 2 column grid on Medium sizes

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -340,8 +340,9 @@ function renderNode(createElement, references) {
       ) : null;
     }
     case BlockType.row: {
+      const columns = node.numberOfColumns ? { large: node.numberOfColumns } : undefined;
       return createElement(
-        Row, { props: { columns: node.numberOfColumns } }, node.columns.map(col => (
+        Row, { props: { columns } }, node.columns.map(col => (
           createElement(
             Column, { props: { span: col.size } }, renderChildren(col.content),
           )

--- a/src/components/ContentNode/Row.vue
+++ b/src/components/ContentNode/Row.vue
@@ -14,6 +14,8 @@
 </template>
 
 <script>
+import { BreakpointName } from '@/utils/breakpoints';
+
 /**
  * A Row component that accepts an optional `columns` prop.
  * When columns is passed, the grid will have that exact number of columns.
@@ -23,10 +25,10 @@ export default {
   name: 'Row',
   props: {
     columns: {
-      type: Number,
-      default: null,
+      type: Object,
       required: false,
-      validator: v => v > 0,
+      validator: v => Object.entries(v)
+        .every(([key, value]) => BreakpointName[key] && typeof value === 'number'),
     },
     gap: {
       type: Number,
@@ -34,8 +36,10 @@ export default {
     },
   },
   computed: {
-    style: ({ columns, gap }) => ({
-      '--col-count': columns,
+    style: ({ columns = {}, gap }) => ({
+      '--col-count-large': columns.large,
+      '--col-count-medium': columns.medium,
+      '--col-count-small': columns.small || 1, // we want by default small to be 1
       '--col-gap': gap && `${gap}px`,
     }),
   },
@@ -51,18 +55,23 @@ export default {
   grid-auto-columns: 1fr;
   grid-gap: var(--col-gap, #{$article-stacked-margin-small});
 
-  &.with-columns {
-    grid-template-columns: repeat(var(--col-count), 1fr);
-    grid-auto-flow: row;
-
-    @include breakpoint(small) {
-      grid-template-columns: 1fr;
-    }
-  }
-
   @include breakpoint(small) {
     grid-template-columns: 1fr;
     grid-auto-flow: row;
+  }
+
+  &.with-columns {
+    --col-count: var(--col-count-large);
+    grid-template-columns: repeat(var(--col-count), 1fr);
+    grid-auto-flow: row;
+
+    @include breakpoint(medium) {
+      --col-count: var(--col-count-medium, var(--col-count-large));
+    }
+
+    @include breakpoint(small) {
+      --col-count: var(--col-count-small);
+    }
   }
 
   /deep/ + * {

--- a/src/components/DocumentationTopic/TopicsLinkCardGrid.vue
+++ b/src/components/DocumentationTopic/TopicsLinkCardGrid.vue
@@ -10,7 +10,10 @@
 
 <template>
   <div class="TopicsLinkCardGrid">
-    <Row :columns="compactCards ? 3 : 2">
+    <Row :columns="{
+      large: compactCards ? 3 : 2,
+      medium: 2,
+    }">
       <Column
         v-for="item in items"
         :key="item.title"

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -437,7 +437,51 @@ describe('ContentNode', () => {
       });
       const grid = wrapper.find(Row);
       expect(grid.props()).toEqual({
-        columns: 4,
+        columns: { large: 4 },
+      });
+      const columns = grid.findAll(Column);
+      expect(columns).toHaveLength(2);
+      expect(columns.at(0).props()).toEqual({ span: 2 });
+      expect(columns.at(0).find('p').text()).toBe('foo');
+      expect(columns.at(1).props()).toEqual({ span: null });
+      expect(columns.at(1).find('p').text()).toBe('bar');
+    });
+    it('renders a `<Row>` without column count specified', () => {
+      const wrapper = mountWithItem({
+        type: 'row',
+        columns: [
+          {
+            size: 2,
+            content: [
+              {
+                type: 'paragraph',
+                inlineContent: [
+                  {
+                    type: 'text',
+                    text: 'foo',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            content: [
+              {
+                type: 'paragraph',
+                inlineContent: [
+                  {
+                    type: 'text',
+                    text: 'bar',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+      const grid = wrapper.find(Row);
+      expect(grid.props()).toEqual({
+        columns: undefined,
       });
       const columns = grid.findAll(Column);
       expect(columns).toHaveLength(2);

--- a/tests/unit/components/ContentNode/Row.spec.js
+++ b/tests/unit/components/ContentNode/Row.spec.js
@@ -29,11 +29,23 @@ describe('Row', () => {
   it('renders with columns in mind', () => {
     const wrapper = createWrapper({
       propsData: {
-        columns: 4,
+        columns: { large: 4 },
       },
     });
     expect(wrapper.classes()).toContain('with-columns');
-    expect(wrapper.vm.style).toHaveProperty('--col-count', 4);
+    expect(wrapper.vm.style).toHaveProperty('--col-count-large', 4);
+    expect(wrapper.vm.style).toHaveProperty('--col-count-medium', undefined);
+    expect(wrapper.vm.style).toHaveProperty('--col-count-small', 1);
+    wrapper.setProps({
+      columns: {
+        large: 3,
+        medium: 5,
+        small: 2,
+      },
+    });
+    expect(wrapper.vm.style).toHaveProperty('--col-count-large', 3);
+    expect(wrapper.vm.style).toHaveProperty('--col-count-medium', 5);
+    expect(wrapper.vm.style).toHaveProperty('--col-count-small', 2);
   });
 
   it('provides a --col-gap', () => {

--- a/tests/unit/components/DocumentationTopic/TopicsLinkCardGrid.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkCardGrid.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import TopicsLinkCardGrid from '@/components/DocumentationTopic/TopicsLinkCardGrid.vue';
 import { shallowMount } from '@vue/test-utils';
@@ -34,7 +34,7 @@ describe('TopicsLinkCardGrid', () => {
   it('renders the TopicsLinkCardGrid', () => {
     const wrapper = createWrapper();
     expect(wrapper.find(Row).props()).toEqual({
-      columns: 3, // compact grid is a 3 column setup
+      columns: { large: 3, medium: 2 }, // compact grid is a 3 column setup
     });
     const cols = wrapper.findAll(Column);
     expect(cols).toHaveLength(2);
@@ -52,7 +52,7 @@ describe('TopicsLinkCardGrid', () => {
       },
     });
     expect(wrapper.find(Row).props()).toEqual({
-      columns: 2, // detailed grid is a 2 column setup
+      columns: { large: 2, medium: 2 }, // detailed grid is a 2 column setup
     });
     expect(wrapper.find(TopicsLinkCardGridItem).props('compact')).toBe(false);
   });

--- a/tests/unit/components/DocumentationTopic/TopicsLinkCardGrid.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkCardGrid.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import TopicsLinkCardGrid from '@/components/DocumentationTopic/TopicsLinkCardGrid.vue';
 import { shallowMount } from '@vue/test-utils';


### PR DESCRIPTION
Bug/issue #, if applicable: 101583390

## Summary

The compactGrid style for Topics should become a 2 col grid on Medium sizes, because it cramped atm on smaller sizes. On Mobile its still 1 column.

## Dependencies

NA

## Testing

Steps:
1. Set a TopicsSectionStyle to a page to compactGrid
2. Assert that the grid of card items has columns as follows: 3 on Large, 2 on medium, 1 on small.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
