### PR TITLE
Make sure content updates, when switching TabNavigator tabs

### DIFF
--- a/src/components/ContentNode/TabNavigator.vue
+++ b/src/components/ContentNode/TabNavigator.vue
@@ -18,7 +18,7 @@
         {{ title }}
       </TabnavItem>
     </Tabnav>
-    <div class="tabs-content">
+    <div class="tabs-content" :key="currentTitle">
       <template v-for="title in titles">
         <slot v-if="title === currentTitle" :name="title" />
       </template>


### PR DESCRIPTION
Bug/issue #, if applicable: 101627936

## Summary

Makes sure content is updated when switching across tabs in a TabNavigator. If using a `@Video` tag, the video element is currently cached and never re-renders.

## Dependencies

NA

## Testing

Steps:
1. Create a TabNavigator with a video in each
2. Assert that switching tabs also switches the video sources.
3. Play one video and switch tabs. Assert the Replay button becomes Replay and video is chagned.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - Cannot add tests, internal Vue issue.
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
