### PR TITLE
Add vertical space to the videos inside Docs

### DIFF
--- a/src/components/ContentNode/BlockVideo.vue
+++ b/src/components/ContentNode/BlockVideo.vue
@@ -36,6 +36,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'docc-render/styles/_core.scss';
+
+.asset {
+  margin: $stacked-margin-xlarge auto;
+}
+
 /deep/ video {
   display: block;
   margin-left: auto;


### PR DESCRIPTION
Bug/issue #, if applicable: 101648302

## Summary

Adds extra vertical spacing to the top/bottom of Videos rendered inside docs Articles.

## Dependencies

NA

## Testing

Test that videos inside articles have adequate vertical spacing.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
