### PR TITLE
Fix issue with shifting icons in Navigator

### DIFF
--- a/src/components/ContentNode/Row.vue
+++ b/src/components/ContentNode/Row.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { BreakpointName } from '@/utils/breakpoints';
+import { BreakpointName } from 'docc-render/utils/breakpoints';
 
 /**
  * A Row component that accepts an optional `columns` prop.

--- a/src/components/ImageAsset.vue
+++ b/src/components/ImageAsset.vue
@@ -126,6 +126,10 @@ export default {
       type: String,
       default: 'lazy',
     },
+    shouldCalculateOptimalWidth: {
+      type: Boolean,
+      default: true,
+    },
   },
   methods: {
     handleImageLoadError() {
@@ -191,6 +195,7 @@ export default {
     },
   },
   mounted() {
+    if (!this.shouldCalculateOptimalWidth) return;
     this.$refs.img.addEventListener('load', this.optimizeImageSize);
   },
 };

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -51,6 +51,7 @@
         :key="item.uid"
         :type="item.type"
         :image-override="item.icon ? navigatorReferences[item.icon] : null"
+        :shouldCalculateOptimalWidth="false"
         :class="className"
       />
       <span

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -48,6 +48,7 @@
     <template #navigator-icon="{ className }">
       <TopicTypeIcon
         v-if="!apiChange"
+        :key="item.uid"
         :type="item.type"
         :image-override="item.icon ? navigatorReferences[item.icon] : null"
         :class="className"

--- a/src/components/OverridableAsset.vue
+++ b/src/components/OverridableAsset.vue
@@ -8,7 +8,7 @@
   See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 -->
 <template>
-  <ImageAsset v-if="shouldUseAsset" :variants="variants" />
+  <ImageAsset v-if="shouldUseAsset" :variants="variants" :loading="null" />
   <SVGIcon v-else :icon-url="iconUrl" :themeId="themeId" />
 </template>
 <script>

--- a/src/components/OverridableAsset.vue
+++ b/src/components/OverridableAsset.vue
@@ -8,7 +8,10 @@
   See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 -->
 <template>
-  <ImageAsset v-if="shouldUseAsset" :variants="variants" :loading="null" />
+  <ImageAsset
+    v-if="shouldUseAsset"
+    v-bind="{ variants, loading: null, shouldCalculateOptimalWidth }"
+  />
   <SVGIcon v-else :icon-url="iconUrl" :themeId="themeId" />
 </template>
 <script>
@@ -25,6 +28,10 @@ export default {
     imageOverride: {
       type: Object,
       default: null,
+    },
+    shouldCalculateOptimalWidth: {
+      type: Boolean,
+      default: true,
     },
   },
   computed: {

--- a/src/components/TopicTypeIcon.vue
+++ b/src/components/TopicTypeIcon.vue
@@ -14,6 +14,7 @@
       v-if="imageOverride"
       :imageOverride="imageOverride"
       :style="styles"
+      :shouldCalculateOptimalWidth="shouldCalculateOptimalWidth"
       class="icon-inline"
     />
     <component
@@ -109,6 +110,10 @@ export default {
     imageOverride: {
       type: Object,
       default: null,
+    },
+    shouldCalculateOptimalWidth: {
+      type: Boolean,
+      default: true,
     },
   },
   computed: {

--- a/src/components/TopicTypeIcon.vue
+++ b/src/components/TopicTypeIcon.vue
@@ -133,6 +133,10 @@ export default {
   flex: 0 0 auto;
   color: var(--color-figure-gray-secondary);
 
+  /deep/ picture {
+    flex: 1;
+  }
+
   svg, /deep/ img {
     display: block;
     width: 100%;

--- a/tests/unit/components/Asset.spec.js
+++ b/tests/unit/components/Asset.spec.js
@@ -183,6 +183,7 @@ describe('Asset', () => {
         alt: image.alt,
         loading: 'lazy',
         variants: image.variants,
+        shouldCalculateOptimalWidth: true,
       });
     });
 
@@ -193,6 +194,7 @@ describe('Asset', () => {
         alt: image.alt,
         loading: 'lazy',
         variants: image.variants,
+        shouldCalculateOptimalWidth: true,
       });
     });
 

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -60,6 +60,7 @@ describe('DocumentationHero', () => {
       withColors: true,
       type: defaultProps.role,
       imageOverride: defaultProps.iconOverride,
+      shouldCalculateOptimalWidth: true,
     });
     expect(allIcons.at(0).classes()).toEqual(['background-icon', 'first-icon']);
     // assert slot

--- a/tests/unit/components/DocumentationTopic/TopicsLinkCardGridItem.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkCardGridItem.spec.js
@@ -104,6 +104,7 @@ describe('TopicsLinkCardGridItem', () => {
       type: defaultProps.item.role,
       imageOverride: null,
       withColors: false,
+      shouldCalculateOptimalWidth: true,
     });
   });
 

--- a/tests/unit/components/ImageAsset.spec.js
+++ b/tests/unit/components/ImageAsset.spec.js
@@ -328,6 +328,26 @@ describe('ImageAsset', () => {
     expect(img.attributes('height')).toBe('auto');
   });
 
+  it('allows disabling the optimal-width calculation', async () => {
+    const url = 'https://www.example.com/image.png';
+    const traits = ['2x'];
+    const wrapper = shallowMount(ImageAsset, {
+      propsData: {
+        variants: [
+          {
+            traits,
+            url,
+          },
+        ],
+        shouldCalculateOptimalWidth: false,
+      },
+    });
+    const img = wrapper.find('img');
+    img.trigger('load');
+    await flushPromises();
+    expect(img.attributes('width')).toBeFalsy();
+  });
+
   it('logs an error when unable to calculate the optimal width for an image', async () => {
     const url = 'https://www.example.com/image.png';
     const traits = ['2x'];

--- a/tests/unit/components/Navigator/NavigatorCardItem.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCardItem.spec.js
@@ -68,6 +68,7 @@ describe('NavigatorCardItem', () => {
       type: defaultProps.item.type,
       imageOverride: null,
       withColors: false,
+      shouldCalculateOptimalWidth: false,
     });
     const leafLink = wrapper.find('.leaf-link');
     expect(leafLink.is(Reference)).toBe(true);

--- a/tests/unit/components/OverridableAsset.spec.js
+++ b/tests/unit/components/OverridableAsset.spec.js
@@ -46,7 +46,11 @@ describe('OverridableAsset', () => {
         },
       },
     });
-    expect(wrapper.find(ImageAsset).props('variants')).toEqual([localVariantNoID]);
+    expect(wrapper.find(ImageAsset).props()).toEqual({
+      variants: [localVariantNoID],
+      loading: null,
+      alt: '',
+    });
   });
 
   it('renders an `ImageAsset` component, when the domain of the img is different', () => {

--- a/tests/unit/components/OverridableAsset.spec.js
+++ b/tests/unit/components/OverridableAsset.spec.js
@@ -50,6 +50,7 @@ describe('OverridableAsset', () => {
       variants: [localVariantNoID],
       loading: null,
       alt: '',
+      shouldCalculateOptimalWidth: true,
     });
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 101679521

## Summary

This fixes issues with Navigator icons when loaded from remote servers. 

## Dependencies

NA

## Testing

Steps:
1. Assert that overloaded icons look OK in both Navigator and Cards from `@Links` directive

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
