### PR TITLE
Fix issue with Navigator closing sibling trees

### DIFF
--- a/src/components/Navigator/NavigatorDataProvider.vue
+++ b/src/components/Navigator/NavigatorDataProvider.vue
@@ -24,8 +24,13 @@ export default {
       type: String,
       default: Language.swift.key.url,
     },
-    technology: {
-      type: Object,
+    /**
+     * The technology we need to fetch data for.
+     * Important - We are passing just the URL, as the technology object changes
+     * between page navigations, resulting in excess re-calculations on each page change.
+     */
+    technologyUrl: {
+      type: String,
       required: true,
     },
     apiChangesVersion: {
@@ -57,9 +62,9 @@ export default {
         technologyWithChildren.children || [], null, 0, technologyWithChildren.beta,
       )
     ),
-    technologyPath: ({ technology }) => {
+    technologyPath: ({ technologyUrl }) => {
       // regex should match only the first section, no slash - `/documentation/:technology`
-      const matches = /(\/documentation\/(?:[^/]+))\/?/.exec(technology.url);
+      const matches = /(\/documentation\/(?:[^/]+))\/?/.exec(technologyUrl);
       return matches ? matches[1] : '';
     },
     /**

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -20,7 +20,7 @@
         <template #aside="{ scrollLockID, breakpoint }">
           <NavigatorDataProvider
             :interface-language="topicProps.interfaceLanguage"
-            :technology="technology"
+            :technologyUrl="technology.url"
             :api-changes-version="store.state.selectedAPIChangesVersion"
             ref="NavigatorDataProvider"
           >

--- a/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
+++ b/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
@@ -18,10 +18,7 @@ import { flushPromises } from '../../../../test-utils';
 
 jest.mock('docc-render/utils/data');
 
-const technology = {
-  title: 'Technology Name',
-  url: '/documentation/foo',
-};
+const technologyUrl = '/documentation/foo';
 
 const extendedTechnologies = {
   path: '/documentation/foo',
@@ -112,7 +109,7 @@ const flatChildren = [
 
 const swiftIndexOne = {
   id: 'foo',
-  path: technology.url,
+  path: technologyUrl,
   children: [1, 2, 3],
 };
 const swiftIndexTwo = {
@@ -122,7 +119,7 @@ const swiftIndexTwo = {
 };
 const objectiveCIndexOne = {
   id: 'foo-objc',
-  path: technology.url,
+  path: technologyUrl,
   children: [1],
 };
 
@@ -146,7 +143,7 @@ const response = {
 fetchIndexPathsData.mockResolvedValue(response);
 
 const defaultProps = {
-  technology,
+  technologyUrl,
 };
 
 let props = {};
@@ -191,10 +188,7 @@ describe('NavigatorDataProvider', () => {
     expect(fetchIndexPathsData).toHaveBeenCalledTimes(0);
     createWrapper({
       propsData: {
-        technology: {
-          ...technology,
-          url: `${technology.url}/bar/baz`,
-        },
+        technologyUrl: `${technologyUrl}/bar/baz`,
       },
     });
     expect(fetchIndexPathsData).toHaveBeenCalledTimes(1);
@@ -287,9 +281,7 @@ describe('NavigatorDataProvider', () => {
   it('returns undefined technology, if none matches', async () => {
     createWrapper({
       propsData: {
-        technology: {
-          url: '/documentation/bar',
-        },
+        technologyUrl: '/documentation/bar',
       },
     });
     await flushPromises();

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -192,7 +192,7 @@ describe('DocumentationTopic', () => {
     const technology = topicData.references['topic://foo'];
     expect(wrapper.find(NavigatorDataProvider).props()).toEqual({
       interfaceLanguage: Language.swift.key.url,
-      technology,
+      technologyUrl: technology.url,
       apiChangesVersion: null,
     });
     // its rendered by default


### PR DESCRIPTION
Bug/issue #, if applicable: 101803433

## Summary

Fixes an issue where the navigator is closing sibling trees. This is happening because of extra computed property re-calculations, from the recent PR - #396 

The exact cause of the problem is that computed properties re-calculate themselves and all depending computeds and render functions, when any of the dependencies in the chain change.

In our case, the `technology` passed to the `NavigatorDataProvider` changes on each page navigation, even though its the same object visually, it is not the same Object reference. 

This was not such a problem before, because we used to just find the Technology with the children from the already fetched navigator data set, and that object actually never changes. The `technology` on the DocumentationTopic however does change on each page nav, because we change the RenderJSON.

This was causing the flattenedChildren to get recreated on every single page navigation, causing headaches down the line. 

## Dependencies

NA

## Testing

Steps:
1. Mount any archive:
2. Open a few items
3. Start navigating across pages.
4. Assert no items are closed unintentionally

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
