### PR TITLE
Make sure image spacing inside `figure` is consistent

### DIFF
--- a/src/components/ContentNode/FigureCaption.vue
+++ b/src/components/ContentNode/FigureCaption.vue
@@ -37,7 +37,7 @@ export default {
   @include font-styles(documentation-figcaption);
 
   &:last-child {
-    margin-top: $stacked-margin-xlarge;
+    margin-top: $stacked-margin-large;
   }
 
   &.centered {

--- a/src/components/DocumentationTopic/ContentNode.vue
+++ b/src/components/DocumentationTopic/ContentNode.vue
@@ -75,6 +75,17 @@ $docs-code-listing-border-width: 1px !default;
     max-width: 100%;
   }
 
+  // if the image is inside a figure, and caption is after it, remove the bottom margin
+  figure > picture:first-child {
+    img {
+      margin-bottom: 0;
+    }
+    // ensure the figcaption has the same bottom margin as the img top margin
+    + figcaption {
+      margin-bottom: $stacked-margin-xlarge;
+    }
+  }
+
   ol,
   ul {
     margin-top: $stacked-margin-large;


### PR DESCRIPTION
Bug/issue #, if applicable: 101632403

## Summary

Adjusts the bottom margin of an `img` when it has a caption, to be close to the caption itself. Moves that spacing to the caption text so spacing is consistent. 

![image](https://user-images.githubusercontent.com/9863944/199434894-a7169bfb-caed-4bc0-b5f3-5e058ab4abbd.png)


## Dependencies

NA

## Testing

Steps:
1. Assert that spacing of an image with or without a caption is the same, considering post/prior items.
2. Assert the caption is closer to the image, than the vertical space between the next element.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - no css only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
