### PR TITLE
Fix issues with spacing of sibling components 

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -273,10 +273,15 @@ function renderNode(createElement, references) {
       }, (
         renderListItems(node.items)
       ));
-    case BlockType.paragraph:
-      return createElement('p', {}, (
+    case BlockType.paragraph: {
+      const hasSingleImage = node.inlineContent.length === 1
+        && node.inlineContent[0].type === InlineType.image;
+      const props = hasSingleImage ? { class: ['inline-image-container'] } : {};
+
+      return createElement('p', props, (
         renderChildren(node.inlineContent)
       ));
+    }
     case BlockType.table:
       if (node.metadata && node.metadata.anchor) {
         return renderFigure(node);

--- a/src/components/ContentNode/Table.vue
+++ b/src/components/ContentNode/Table.vue
@@ -32,10 +32,7 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .table-wrapper {
-  & + *,
-  * + & {
-    margin-top: $stacked-margin-xlarge;
-  }
+  @include space-out-between-siblings($stacked-margin-xlarge);
 }
 </style>
 

--- a/src/components/DocumentationTopic/ContentNode.vue
+++ b/src/components/DocumentationTopic/ContentNode.vue
@@ -30,6 +30,10 @@ export default {
 
 $docs-code-listing-border-width: 1px !default;
 
+@function between-elements-selector($el) {
+  @return '* + #{$el}, #{$el} + *'
+}
+
 /deep/ {
   .code-listing {
     background: var(--background, var(--color-code-background));
@@ -37,11 +41,6 @@ $docs-code-listing-border-width: 1px !default;
     border-color: var(--colors-grid, var(--color-grid));
     border-width: var(--code-border-width, $docs-code-listing-border-width);
     border-style: var(--code-border-style, solid);
-
-    & + *,
-    * + & {
-      margin-top: $stacked-margin-xlarge;
-    }
 
     pre {
       padding: $code-block-style-elements-padding;
@@ -54,36 +53,24 @@ $docs-code-listing-border-width: 1px !default;
     }
   }
 
-  .endpoint-example {
-    & + *,
-    * + & {
-      margin-top: $stacked-margin-xlarge;
-    }
+  // use a helper function to generate common selectors.
+  // Using `space-out-between-siblings` mixin does not work, because we are inside `/deep/`.
+  #{between-elements-selector('.code-listing')},
+  #{between-elements-selector('.endpoint-example')},
+  #{between-elements-selector('.inline-image-container')},
+  #{between-elements-selector(figure)},
+  #{between-elements-selector(aside)}, {
+    margin-top: $stacked-margin-xlarge;
   }
 
-  // move outside of aside, otherwise scoping breaks it
-  * + figure,
-  figure + *,
-  * + aside,
-  aside + * {
-    margin-top: $stacked-margin-xlarge;
+  #{between-elements-selector(dl)} {
+    margin-top: $stacked-margin-large;
   }
 
   img {
     display: block;
-    margin: $stacked-margin-xlarge auto;
+    margin: auto;
     max-width: 100%;
-  }
-
-  // if the image is inside a figure, and caption is after it, remove the bottom margin
-  figure > picture:first-child {
-    img {
-      margin-bottom: 0;
-    }
-    // ensure the figcaption has the same bottom margin as the img top margin
-    + figcaption {
-      margin-bottom: $stacked-margin-xlarge;
-    }
   }
 
   ol,
@@ -96,13 +83,6 @@ $docs-code-listing-border-width: 1px !default;
 
     @include breakpoint(small) {
       margin-left: 1.25rem;
-    }
-  }
-
-  dl {
-    & + *,
-    * + & {
-      margin-top: $stacked-margin-large;
     }
   }
 

--- a/src/components/DocumentationTopic/ContentNode.vue
+++ b/src/components/DocumentationTopic/ContentNode.vue
@@ -30,7 +30,10 @@ export default {
 
 $docs-code-listing-border-width: 1px !default;
 
-@function between-elements-selector($el) {
+// Generates a selector to match $el, when its after an item, or when an item is after it.
+// This is different than `space-out-between-siblings`, as that used `&` selector for parents,
+// which does not work here, as we are already nested inside `/deep/`.
+@function between-els($el) {
   @return '* + #{$el}, #{$el} + *'
 }
 
@@ -55,15 +58,15 @@ $docs-code-listing-border-width: 1px !default;
 
   // use a helper function to generate common selectors.
   // Using `space-out-between-siblings` mixin does not work, because we are inside `/deep/`.
-  #{between-elements-selector('.code-listing')},
-  #{between-elements-selector('.endpoint-example')},
-  #{between-elements-selector('.inline-image-container')},
-  #{between-elements-selector(figure)},
-  #{between-elements-selector(aside)}, {
+  #{between-els('.code-listing')},
+  #{between-els('.endpoint-example')},
+  #{between-els('.inline-image-container')},
+  #{between-els(figure)},
+  #{between-els(aside)}, {
     margin-top: $stacked-margin-xlarge;
   }
 
-  #{between-elements-selector(dl)} {
+  #{between-els(dl)} {
     margin-top: $stacked-margin-large;
   }
 

--- a/src/components/Tabnav.vue
+++ b/src/components/Tabnav.vue
@@ -67,7 +67,7 @@ $-tabnav-top-margin: rem(15px);
 $-tabnav-bottom-margin: rem(25px);
 
 .tabnav {
-  margin: $-tabnav-top-margin 0 $-tabnav-bottom-margin 0;
+  margin: 0 0 $-tabnav-bottom-margin 0;
   display: flex;
 
   &--center {

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -283,6 +283,36 @@ describe('ContentNode', () => {
       const paragraph = wrapper.find('.content p');
       expect(paragraph.exists()).toBe(true);
       expect(paragraph.text()).toBe('foobar');
+      expect(paragraph.classes()).toHaveLength(0);
+    });
+
+    it('renders a `<p> with a special class, if it has a single image inside', () => {
+      const references = {
+        'figure1.png': {
+          variants: [
+            {
+              traits: ['3x', 'light'],
+              url: '',
+              size: { width: 1202, height: 630 },
+            },
+          ],
+        },
+      };
+
+      const wrapper = mountWithItem({
+        type: 'paragraph',
+        inlineContent: [
+          {
+            type: 'image',
+            identifier: 'figure1.png',
+          },
+        ],
+      }, references);
+
+      const paragraph = wrapper.find('.content p');
+      expect(paragraph.classes()).toContain('inline-image-container');
+      const inlineImage = paragraph.find(InlineImage);
+      expect(inlineImage.exists()).toBe(true);
     });
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 101955529

## Summary

Fixes issues with spacing out components like `img` or `code-listing`, when in around siblings.

This should make `img` wrapped in a `figure` consistently spaced out.

Also fixes some issues from nesting elements inside `/deep/`, which we did not spot before.

## Dependencies

NA

## Testing

[build.zip](https://github.com/apple/swift-docc-render/files/9938077/build.zip)

Steps:
1. Ensure the refactored elements are now properly spaced apart from siblings.
2. Ensure images with/without figure are properly spaced out. Even if inside rows/columns/tabnavs. You can use the archive attached above.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
