### PR TITLE
Fix two letter icon spacing

### DIFF
--- a/src/components/Icons/TwoLetterSymbolIcon.vue
+++ b/src/components/Icons/TwoLetterSymbolIcon.vue
@@ -18,10 +18,10 @@
       <g transform="translate(1.000000, 1.000000)">
         <rect stroke="currentColor" x="0.5" y="0.5" width="13" height="13"></rect>
         <text font-size="8" font-weight="bold" fill="currentColor">
-          <tspan x="9.08984375" y="11">{{ second }}</tspan>
+          <tspan x="8.2" y="11">{{ second }}</tspan>
         </text>
         <text font-size="11" font-weight="bold" fill="currentColor">
-          <tspan x="2" y="11">{{ first }}</tspan>
+          <tspan x="1.7" y="11">{{ first }}</tspan>
         </text>
       </g>
     </g>


### PR DESCRIPTION
Bug/issue #, if applicable: 102030864

## Summary

Fixes the inside spacing of TwoLetter icons.

![image](https://user-images.githubusercontent.com/9863944/200270682-2ef3b67a-7f38-4d40-a5d4-6559ccca02ff.png)
![image](https://user-images.githubusercontent.com/9863944/200270725-13780f30-201c-4ba3-ac35-9dcb4badfdf6.png)


## Dependencies

NA

## Testing

Steps:
1. Assert two letter icons in the nav look correct

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~ - no need
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
