### PR TITLE
Fix navigator content jump on mobile

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1114,6 +1114,9 @@ $filter-height-small: 62px;
   .sidebar-transitioning & {
     flex: 1 0 $filter-height;
     overflow: hidden;
+    @include breakpoint(medium, nav) {
+      flex-basis: $filter-height-small;
+    }
   }
 }
 </style>


### PR DESCRIPTION
Bug/issue #, if applicable: 102032532

## Summary

Fix sidebar content jump on mobile

## Dependencies

NA

## Testing

Steps:
1. Open the navigator on a mobile screen size
2. Assert it does not cause the content to lightly jump up

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - no need, css only
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
