### PR TITLE
Fix error from image width calculation, when navigating fast across pages

### DIFF
--- a/src/components/ImageAsset.vue
+++ b/src/components/ImageAsset.vue
@@ -182,8 +182,8 @@ export default {
     // using the same dimensions for both 1x and 2x devices.
     async optimizeImageSize() {
       // Exit early if image size data already exists—nothing further needs to
-      // be calculated in that scenario.
-      if (this.defaultAttributes.width) {
+      // be calculated in that scenario, or the img tag is no longer in the DOM for some reason.
+      if (this.defaultAttributes.width || !this.$refs.img) {
         return;
       }
 

--- a/tests/unit/components/ImageAsset.spec.js
+++ b/tests/unit/components/ImageAsset.spec.js
@@ -328,6 +328,38 @@ describe('ImageAsset', () => {
     expect(img.attributes('height')).toBe('auto');
   });
 
+  it('does not calculate widths, if the element unmounts just as it gets loaded', async () => {
+    const url = 'https://www.example.com/image.png';
+    const traits = ['2x'];
+
+    // describe the image with a 2x trait (since it has an intrinsic width of 84
+    // pixels wide, it should be displayed as 42 pixels wide)
+    const wrapper = shallowMount(ImageAsset, {
+      propsData: {
+        variants: [
+          {
+            traits,
+            url,
+          },
+        ],
+      },
+    });
+
+    const calculateOptimalWidthSpy = jest.spyOn(wrapper.vm, 'calculateOptimalWidth')
+      .mockReturnValue(99);
+    const img = wrapper.find('img');
+
+    expect(img.attributes('width')).toBeFalsy();
+    expect(img.attributes('height')).toBeFalsy();
+
+    wrapper.destroy();
+    img.trigger('load');
+    await flushPromises();
+    expect(img.attributes('width')).toBeFalsy();
+    expect(img.attributes('height')).toBeFalsy();
+    expect(calculateOptimalWidthSpy).toHaveBeenCalledTimes(0);
+  });
+
   it('allows disabling the optimal-width calculation', async () => {
     const url = 'https://www.example.com/image.png';
     const traits = ['2x'];


### PR DESCRIPTION
Bug/issue #, if applicable: 102035423

## Summary

Fixes an error thrown in the console, from the ImageAsset, when navigating fast across pages.

## Dependencies

NA

## Testing

Steps:
1. Navigate fast across an archive with Images in the content, that do not have width attributes.
2. Assert the console no longer shows errors from `ImageAsset.vue` component

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
