### PR TITLE
Make sure that Quick Navigation is hidden if IDE is being targeted

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -27,6 +27,7 @@
             <template #default="slotProps">
               <div class="doc-topic-aside">
                 <QuickNavigationModal
+                  v-if="enableQuickNavigation"
                   :children="slotProps.flatChildren"
                   :showQuickNavigationModal.sync="showQuickNavigationModal"
                 />

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -164,8 +164,8 @@ export default {
       const objcVariant = variantOverrides.find(hasObjcTrait);
       return objcVariant ? objcVariant.patch : null;
     },
-    enableQuickNavigation: () => (
-      getSetting(['features', 'docs', 'quickNavigation', 'enable'], false)
+    enableQuickNavigation: ({ isTargetIDE }) => (
+      !isTargetIDE && getSetting(['features', 'docs', 'quickNavigation', 'enable'], false)
     ),
     topicData: {
       get() {

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -1005,16 +1005,16 @@ describe('DocumentationTopic', () => {
   });
 
   describe('isTargetIDE', () => {
-    const provide = { isTargetIDE: true };
+    const provideWithIDETarget = { isTargetIDE: true };
 
     it('does not render a `Nav`', () => {
-      wrapper = createWrapper({ provide });
+      wrapper = createWrapper({ provide: provideWithIDETarget });
       wrapper.setData({ topicData });
       expect(wrapper.contains(Nav)).toBe(false);
     });
 
     it('does not render an AdjustableSidebarWidth', () => {
-      wrapper = createWrapper({ provide });
+      wrapper = createWrapper({ provide: provideWithIDETarget });
       wrapper.setData({ topicData });
       expect(wrapper.find(AdjustableSidebarWidth).exists()).toBe(false);
       expect(wrapper.find(Topic).exists()).toBe(true);

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -13,6 +13,8 @@ import { shallowMount } from '@vue/test-utils';
 import DocumentationTopic from 'docc-render/views/DocumentationTopic.vue';
 import DocumentationTopicStore from 'docc-render/stores/DocumentationTopicStore';
 import onPageLoadScrollToFragment from 'docc-render/mixins/onPageLoadScrollToFragment';
+import DocumentationNav from 'docc-render/components/DocumentationTopic/DocumentationNav.vue';
+import NavBase from 'docc-render/components/NavBase.vue';
 import AdjustableSidebarWidth from '@/components/AdjustableSidebarWidth.vue';
 import NavigatorDataProvider from '@/components/Navigator/NavigatorDataProvider.vue';
 import Language from '@/constants/Language';
@@ -48,7 +50,13 @@ jest.spyOn(dataUtils, 'fetchIndexPathsData').mockResolvedValue({
 });
 getSetting.mockReturnValue(false);
 
-const { CodeTheme, Nav, Topic } = DocumentationTopic.components;
+const {
+  CodeTheme,
+  Nav,
+  Topic,
+  QuickNavigationModal,
+  MagnifierIcon,
+} = DocumentationTopic.components;
 const { NAVIGATOR_HIDDEN_ON_LARGE_KEY } = DocumentationTopic.constants;
 
 const mocks = {
@@ -138,19 +146,27 @@ const AdjustableSidebarWidthSmallStub = {
   },
 };
 
+const stubs = {
+  AdjustableSidebarWidth,
+  NavigatorDataProvider,
+};
+
+const provide = { isTargetIDE: false };
+
+const createWrapper = props => shallowMount(DocumentationTopic, {
+  stubs,
+  provide,
+  mocks,
+  ...props,
+});
+
 describe('DocumentationTopic', () => {
   /** @type {import('@vue/test-utils').Wrapper} */
   let wrapper;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    wrapper = shallowMount(DocumentationTopic, {
-      mocks,
-      stubs: {
-        AdjustableSidebarWidth,
-        NavigatorDataProvider,
-      },
-    });
+    wrapper = createWrapper();
   });
 
   afterEach(() => {
@@ -233,12 +249,95 @@ describe('DocumentationTopic', () => {
     expect(nav.props('isWideFormat')).toBe(true);
   });
 
+  it('renders QuickNavigation and MagnifierIcon if enableQuickNavigation is true', () => {
+    getSetting.mockReturnValueOnce(true);
+    wrapper = createWrapper({
+      stubs: {
+        ...stubs,
+        Nav: DocumentationNav,
+        NavBase,
+      },
+    });
+
+    wrapper.setData({
+      topicData: {
+        ...topicData,
+        schemaVersion: schemaVersionWithSidebar,
+      },
+    });
+
+    const quickNavigationModalComponent = wrapper.find(QuickNavigationModal);
+    const magnifierIconComponent = wrapper.find(MagnifierIcon);
+    expect(quickNavigationModalComponent.exists()).toBe(true);
+    expect(magnifierIconComponent.exists()).toBe(true);
+  });
+
+  it('does not render QuickNavigation and MagnifierIcon if enableQuickNavigation is false', () => {
+    wrapper = createWrapper({
+      stubs: {
+        ...stubs,
+        Nav: DocumentationNav,
+        NavBase,
+      },
+    });
+
+    wrapper.setData({
+      topicData: {
+        ...topicData,
+        schemaVersion: schemaVersionWithSidebar,
+      },
+    });
+
+    const quickNavigationModalComponent = wrapper.find(QuickNavigationModal);
+    const magnifierIconComponent = wrapper.find(MagnifierIcon);
+    expect(quickNavigationModalComponent.exists()).toBe(false);
+    expect(magnifierIconComponent.exists()).toBe(false);
+  });
+
+  it('does not render QuickNavigation and MagnifierIcon if enableNavigation is false', () => {
+    getSetting.mockReturnValueOnce(true);
+    wrapper = createWrapper({
+      stubs: {
+        ...stubs,
+        Nav: DocumentationNav,
+        NavBase,
+      },
+    });
+
+    const quickNavigationModalComponent = wrapper.find(QuickNavigationModal);
+    const magnifierIconComponent = wrapper.find(MagnifierIcon);
+    expect(quickNavigationModalComponent.exists()).toBe(false);
+    expect(magnifierIconComponent.exists()).toBe(false);
+  });
+
+  it('does not render QuickNavigation and MagnifierIcon if enableQuickNavigation is true but IDE is being targeted', () => {
+    getSetting.mockReturnValueOnce(true);
+    wrapper = createWrapper({
+      provide: { isTargetIDE: true },
+      stubs: {
+        ...stubs,
+        Nav: DocumentationNav,
+        NavBase,
+      },
+    });
+
+    wrapper.setData({
+      topicData: {
+        ...topicData,
+        schemaVersion: schemaVersionWithSidebar,
+      },
+    });
+
+    const quickNavigationModalComponent = wrapper.find(QuickNavigationModal);
+    const magnifierIconComponent = wrapper.find(MagnifierIcon);
+    expect(quickNavigationModalComponent.exists()).toBe(false);
+    expect(magnifierIconComponent.exists()).toBe(false);
+  });
+
   describe('if breakpoint is small', () => {
     beforeEach(() => {
-      wrapper = shallowMount(DocumentationTopic, {
-        mocks,
+      wrapper = createWrapper({
         stubs: {
-          // renders sidebar on a small device
           AdjustableSidebarWidth: AdjustableSidebarWidthSmallStub,
           NavigatorDataProvider,
         },
@@ -584,8 +683,7 @@ describe('DocumentationTopic', () => {
   it('passes `enableOnThisPageNav` as `false`, if in IDE', () => {
     wrapper.destroy();
     getSetting.mockReturnValue(false);
-    wrapper = shallowMount(DocumentationTopic, {
-      mocks,
+    wrapper = createWrapper({
       provide: { isTargetIDE: true },
       stubs: {
         // renders sidebar on a small device
@@ -910,27 +1008,13 @@ describe('DocumentationTopic', () => {
     const provide = { isTargetIDE: true };
 
     it('does not render a `Nav`', () => {
-      wrapper = shallowMount(DocumentationTopic, {
-        mocks,
-        stubs: {
-          AdjustableSidebarWidth,
-          NavigatorDataProvider,
-        },
-        provide,
-      });
+      wrapper = createWrapper({ provide });
       wrapper.setData({ topicData });
       expect(wrapper.contains(Nav)).toBe(false);
     });
 
     it('does not render an AdjustableSidebarWidth', () => {
-      wrapper = shallowMount(DocumentationTopic, {
-        mocks,
-        stubs: {
-          AdjustableSidebarWidth,
-          NavigatorDataProvider,
-        },
-        provide,
-      });
+      wrapper = createWrapper({ provide });
       wrapper.setData({ topicData });
       expect(wrapper.find(AdjustableSidebarWidth).exists()).toBe(false);
       expect(wrapper.find(Topic).exists()).toBe(true);


### PR DESCRIPTION
Bug/issue #101382072, if applicable: 

## Summary

Hide Quick Navigation if IDE is being targeted

## Dependencies

NA

## Testing

Steps:
1. Add the following to `theme-settings.json` file at public folder
```json
{
  "features": {
    "docs": {
      "quickNavigation": {
        "enable": true
      }
    }
  }
}
```
2. Run `export VUE_APP_TARGET='ide'`
3. Run `npm run serve`
4. Assert that quick navigation and navigator are not displayed

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
