### PR TITLE
Add the page title to the OnThisPageNav items

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@
     id="app"
     :class="{ fromkeyboard: fromKeyboard, hascustomheader: hasCustomHeader }"
   >
+    <div :id="AppTopID" />
     <a href="#main" id="skip-nav">Skip Navigation</a>
     <InitialLoadingPlaceholder />
     <slot name="header" :isTargetIDE="isTargetIDE">
@@ -38,6 +39,7 @@ import InitialLoadingPlaceholder from 'docc-render/components/InitialLoadingPlac
 import { baseNavStickyAnchorId } from 'docc-render/constants/nav';
 import { fetchThemeSettings, themeSettingsState } from 'docc-render/utils/theme-settings';
 import { objectToCustomProperties } from 'docc-render/utils/themes';
+import { AppTopID } from 'docc-render/constants/AppTopID';
 
 export default {
   name: 'CoreApp',
@@ -53,6 +55,7 @@ export default {
   },
   data() {
     return {
+      AppTopID,
       appState: AppStore.state,
       fromKeyboard: false,
       isTargetIDE: process.env.VUE_APP_TARGET === 'ide',

--- a/src/components/OnThisPageNav.vue
+++ b/src/components/OnThisPageNav.vue
@@ -115,7 +115,7 @@ export default {
     getItemClasses(item) {
       return {
         active: this.checkIsActive(item),
-        'parent-item': item.level === 2,
+        'parent-item': item.level <= 2,
         'child-item': item.level === 3,
       };
     },

--- a/src/constants/AppTopID.js
+++ b/src/constants/AppTopID.js
@@ -1,0 +1,12 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+// eslint-disable-next-line import/prefer-default-export
+export const AppTopID = 'app-top';

--- a/src/mixins/onThisPageRegistrator.js
+++ b/src/mixins/onThisPageRegistrator.js
@@ -37,12 +37,18 @@ export default {
       this.store.resetPageSections();
       // register new ones
       const {
+        metadata: { title },
         primaryContentSections,
         topicSections,
         defaultImplementationsSections,
         relationshipsSections,
         seeAlsoSections,
       } = topicData;
+      this.store.addOnThisPageSection({
+        title,
+        anchor: 'app',
+        level: 1,
+      });
       if (primaryContentSections) {
         primaryContentSections.forEach((section) => {
           switch (section.kind) {

--- a/src/mixins/onThisPageRegistrator.js
+++ b/src/mixins/onThisPageRegistrator.js
@@ -16,6 +16,7 @@ import {
   PrimaryContentSectionAnchors,
 } from 'docc-render/constants/ContentSectionAnchors';
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
+import { AppTopID } from 'docc-render/constants/AppTopID';
 
 /**
  * Crawls the `topicData` of a page, and extracts onThisPage sections.
@@ -46,7 +47,7 @@ export default {
       } = topicData;
       this.store.addOnThisPageSection({
         title,
-        anchor: 'app',
+        anchor: AppTopID,
         level: 1,
       });
       if (primaryContentSections) {

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -13,6 +13,7 @@ import Footer from 'docc-render/components/Footer.vue';
 import InitialLoadingPlaceholder from 'docc-render/components/InitialLoadingPlaceholder.vue';
 import { shallowMount } from '@vue/test-utils';
 import { baseNavStickyAnchorId } from 'docc-render/constants/nav';
+import { AppTopID } from '@/constants/AppTopID';
 import { flushPromises } from '../../test-utils';
 
 jest.mock('docc-render/utils/theme-settings', () => ({
@@ -176,6 +177,11 @@ describe('App', () => {
 
     wrapper.setData({ isTargetIDE: true });
     expect(wrapper.contains(Footer)).toBe(false);
+  });
+
+  it('renders the app-top element', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find(`#${AppTopID}`).exists()).toBe(true);
   });
 
   describe('Custom CSS Properties', () => {

--- a/tests/unit/components/OnThisPageNav.spec.js
+++ b/tests/unit/components/OnThisPageNav.spec.js
@@ -16,6 +16,7 @@ import { createEvent, flushPromises } from '../../../test-utils';
 jest.mock('docc-render/utils/throttle', () => jest.fn(v => v));
 jest.mock('docc-render/utils/loading', () => ({ waitFrames: jest.fn() }));
 const sections = [
+  { title: 'Title', level: 1, anchor: 'app' },
   { title: 'First', level: 2, anchor: 'first' },
   { title: 'Second', level: 3, anchor: 'second' },
   { title: 'Third', level: 2, anchor: 'third' },
@@ -33,6 +34,7 @@ const store = {
 // some initial values to make math easy
 const innerHeight = 500;
 const scrollHeight = 1000;
+const titleTop = 0; // very top
 const firstTop = 100; // not at the top directly
 const secondTop = 450;
 const thirdTop = 900;
@@ -46,6 +48,8 @@ Object.defineProperty(document.body, 'scrollHeight', {
 let wrapper;
 jest.spyOn(document, 'getElementById').mockImplementation((anchor) => {
   switch (anchor) {
+  case 'app':
+    return { offsetTop: titleTop };
   case 'first':
     return { offsetTop: firstTop };
   case 'second':
@@ -89,14 +93,18 @@ describe('OnThisPageNav', () => {
     createWrapper();
     const parents = wrapper.findAll('.parent-item');
     // assert parents
-    expect(parents).toHaveLength(2);
+    expect(parents).toHaveLength(3);
     // assert first parent
     const firstParent = parents.at(0);
     const parentLink1 = firstParent.find('.base-link');
     // assert first parent is active
-    expect(firstParent.classes()).toContain('active');
+    expect(firstParent.classes()).not.toContain('active');
     expect(parentLink1.props('to')).toEqual(`?language=objc#${sections[0].anchor}`);
     expect(parentLink1.text()).toBe(sections[0].title);
+    // assert second parent
+    const secondParent = parents.at(1);
+    expect(secondParent.classes()).toContain('active');
+    expect(secondParent.find(RouterLinkStub).props('to')).toEqual(`?language=objc#${sections[1].anchor}`);
     // assert "children" items
     const children = wrapper.findAll('.child-item');
     expect(children).toHaveLength(1);
@@ -104,12 +112,12 @@ describe('OnThisPageNav', () => {
     expect(children.at(0).classes()).not.toContain('active');
     const childLink = children.at(0).find(RouterLinkStub);
     expect(childLink.classes()).toEqual(['base-link']);
-    expect(childLink.props('to')).toEqual(`?language=objc#${sections[1].anchor}`);
-    // assert second parent
-    const secondParent = parents.at(1);
-    expect(secondParent.classes()).not.toContain('active');
-    expect(secondParent.find(RouterLinkStub).props('to')).toEqual(`?language=objc#${sections[2].anchor}`);
-    expect(secondParent.find('.children').exists()).toBe(false);
+    expect(childLink.props('to')).toEqual(`?language=objc#${sections[2].anchor}`);
+    // assert third parent
+    const thirdParent = parents.at(2);
+    expect(thirdParent.classes()).not.toContain('active');
+    expect(thirdParent.find(RouterLinkStub).props('to')).toEqual(`?language=objc#${sections[3].anchor}`);
+    expect(thirdParent.find('.children').exists()).toBe(false);
   });
 
   it('sets the first item as active, if at the top', async () => {
@@ -126,7 +134,7 @@ describe('OnThisPageNav', () => {
     await flushPromises();
     expect(store.setCurrentPageSection).toHaveBeenCalledTimes(1);
     expect(store.setCurrentPageSection)
-      .toHaveBeenCalledWith(sections[2].anchor);
+      .toHaveBeenCalledWith(sections[3].anchor);
   });
 
   it('updates the active item on scroll', async () => {
@@ -139,23 +147,28 @@ describe('OnThisPageNav', () => {
     // intersection point would be 250(150+100), which is not reaching second item
     await scrollWindowBy(firstTop);
     expect(store.setCurrentPageSection).toHaveBeenCalledTimes(2);
-    expect(store.setCurrentPageSection).toHaveBeenLastCalledWith(sections[0].anchor);
-    expect(parents.at(0).classes()).toContain('active');
-    expect(parents.at(1).classes()).not.toContain('active');
+    expect(store.setCurrentPageSection).toHaveBeenLastCalledWith(sections[1].anchor);
+    expect(parents.at(0).classes()).not.toContain('active');
+    expect(parents.at(1).classes()).toContain('active');
+    expect(parents.at(2).classes()).not.toContain('active');
     // intersection point would be 600(150+450), which is passed 450 for the second,
     // but not near third
     await scrollWindowBy(secondTop);
-    expect(store.setCurrentPageSection).toHaveBeenLastCalledWith(sections[1].anchor);
+    expect(store.setCurrentPageSection).toHaveBeenLastCalledWith(sections[2].anchor);
     // assert the parent is not set as active by default
     expect(parents.at(0).classes()).not.toContain('active');
-    expect(child.classes()).toContain('active');
     expect(parents.at(1).classes()).not.toContain('active');
+    expect(child.classes()).toContain('active');
+    expect(parents.at(2).classes()).not.toContain('active');
     // scroll to 900, which is beyond the third
     await scrollWindowBy(thirdTop - intersectionPoint);
-    expect(store.setCurrentPageSection).toHaveBeenLastCalledWith(sections[2].anchor);
+    expect(store.setCurrentPageSection).toHaveBeenLastCalledWith(sections[3].anchor);
     // assert active items
     expect(parents.at(0).classes()).not.toContain('active');
+    expect(parents.at(1).classes()).not.toContain('active');
     expect(child.classes()).not.toContain('active');
-    expect(parents.at(1).classes()).toContain('active');
+    expect(parents.at(2).classes()).toContain('active');
+    await scrollWindowBy(titleTop);
+    expect(store.setCurrentPageSection).toHaveBeenLastCalledWith(sections[0].anchor);
   });
 });

--- a/tests/unit/components/OnThisPageNav.spec.js
+++ b/tests/unit/components/OnThisPageNav.spec.js
@@ -11,12 +11,13 @@
 import Vue from 'vue';
 import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import OnThisPageNav from '@/components/OnThisPageNav.vue';
+import { AppTopID } from '@/constants/AppTopID';
 import { createEvent, flushPromises } from '../../../test-utils';
 
 jest.mock('docc-render/utils/throttle', () => jest.fn(v => v));
 jest.mock('docc-render/utils/loading', () => ({ waitFrames: jest.fn() }));
 const sections = [
-  { title: 'Title', level: 1, anchor: 'app' },
+  { title: 'Title', level: 1, anchor: AppTopID },
   { title: 'First', level: 2, anchor: 'first' },
   { title: 'Second', level: 3, anchor: 'second' },
   { title: 'Third', level: 2, anchor: 'third' },
@@ -48,7 +49,7 @@ Object.defineProperty(document.body, 'scrollHeight', {
 let wrapper;
 jest.spyOn(document, 'getElementById').mockImplementation((anchor) => {
   switch (anchor) {
-  case 'app':
+  case AppTopID:
     return { offsetTop: titleTop };
   case 'first':
     return { offsetTop: firstTop };

--- a/tests/unit/mixins/__snapshots__/onThisPageRegistrator.spec.js.snap
+++ b/tests/unit/mixins/__snapshots__/onThisPageRegistrator.spec.js.snap
@@ -3,6 +3,11 @@
 exports[`OnThisPageRegistrator extracts the sections from the JSON 1`] = `
 Array [
   Object {
+    "anchor": "app",
+    "level": 1,
+    "title": "PageTitle",
+  },
+  Object {
     "anchor": "provided-heading-anchor",
     "level": 2,
     "title": "Heading Level 2",

--- a/tests/unit/mixins/__snapshots__/onThisPageRegistrator.spec.js.snap
+++ b/tests/unit/mixins/__snapshots__/onThisPageRegistrator.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`OnThisPageRegistrator extracts the sections from the JSON 1`] = `
 Array [
   Object {
-    "anchor": "app",
+    "anchor": "app-top",
     "level": 1,
     "title": "PageTitle",
   },

--- a/tests/unit/mixins/onThisPageRegistrator.spec.js
+++ b/tests/unit/mixins/onThisPageRegistrator.spec.js
@@ -38,6 +38,9 @@ const contentSections = [
   },
 ];
 const topicData = () => ({
+  metadata: {
+    title: 'PageTitle',
+  },
   primaryContentSections: [
     {
       kind: SectionKind.content,
@@ -107,6 +110,7 @@ describe('OnThisPageRegistrator', () => {
     await flushPromises();
     wrapper.setData({
       topicData: {
+        metadata: { title: 'Foo' },
         primaryContentSections: [
           {
             kind: SectionKind.content,
@@ -124,6 +128,7 @@ describe('OnThisPageRegistrator', () => {
     });
     await flushPromises();
     expect(onThisPageSectionsStoreBase.state.onThisPageSections).toEqual([
+      { anchor: 'app', level: 1, title: 'Foo' },
       {
         anchor: 'provided-heading-anchor',
         level: 2,
@@ -144,6 +149,7 @@ describe('OnThisPageRegistrator', () => {
     await flushPromises();
     wrapper.setData({
       topicData: {
+        metadata: { title: 'Foo' },
         primaryContentSections: [
           {
             kind: SectionKind.content,
@@ -166,6 +172,7 @@ describe('OnThisPageRegistrator', () => {
     });
     await flushPromises();
     expect(onThisPageSectionsStoreBase.state.onThisPageSections).toEqual([
+      { anchor: 'app', level: 1, title: 'Foo' },
       {
         anchor: 'provided-heading-anchor',
         level: 2,
@@ -186,8 +193,9 @@ describe('OnThisPageRegistrator', () => {
 
   it('watches for changes, clears the store and extracts sections again', async () => {
     const wrapper = createWrapper();
-    expect(onThisPageSectionsStoreBase.state.onThisPageSections).toHaveLength(16);
+    expect(onThisPageSectionsStoreBase.state.onThisPageSections).toHaveLength(17);
     wrapper.vm.topicData = {
+      metadata: { title: 'Foo' },
       primaryContentSections: [
         {
           kind: SectionKind.content,
@@ -197,6 +205,7 @@ describe('OnThisPageRegistrator', () => {
     };
     await flushPromises();
     expect(onThisPageSectionsStoreBase.state.onThisPageSections).toEqual([
+      { anchor: 'app', level: 1, title: 'Foo' },
       {
         anchor: 'provided-heading-anchor',
         level: 2,

--- a/tests/unit/mixins/onThisPageRegistrator.spec.js
+++ b/tests/unit/mixins/onThisPageRegistrator.spec.js
@@ -13,6 +13,7 @@ import { shallowMount } from '@vue/test-utils';
 import { SectionKind } from '@/constants/PrimaryContentSection';
 import onThisPageSectionsStoreBase from '@/stores/OnThisPageSectionsStoreBase';
 import { BlockType } from 'docc-render/components/ContentNode.vue';
+import { AppTopID } from '@/constants/AppTopID';
 import { flushPromises } from '../../../test-utils';
 
 const contentSections = [
@@ -128,7 +129,7 @@ describe('OnThisPageRegistrator', () => {
     });
     await flushPromises();
     expect(onThisPageSectionsStoreBase.state.onThisPageSections).toEqual([
-      { anchor: 'app', level: 1, title: 'Foo' },
+      { anchor: AppTopID, level: 1, title: 'Foo' },
       {
         anchor: 'provided-heading-anchor',
         level: 2,
@@ -172,7 +173,7 @@ describe('OnThisPageRegistrator', () => {
     });
     await flushPromises();
     expect(onThisPageSectionsStoreBase.state.onThisPageSections).toEqual([
-      { anchor: 'app', level: 1, title: 'Foo' },
+      { anchor: AppTopID, level: 1, title: 'Foo' },
       {
         anchor: 'provided-heading-anchor',
         level: 2,
@@ -205,7 +206,7 @@ describe('OnThisPageRegistrator', () => {
     };
     await flushPromises();
     expect(onThisPageSectionsStoreBase.state.onThisPageSections).toEqual([
-      { anchor: 'app', level: 1, title: 'Foo' },
+      { anchor: AppTopID, level: 1, title: 'Foo' },
       {
         anchor: 'provided-heading-anchor',
         level: 2,


### PR DESCRIPTION
Bug/issue #, if applicable: 102188459

## Summary

Adds the page H1 Title to the OnThisPage items, as a first item, serving as a ScrollToTop.

## Dependencies

NA

## Testing

Steps:
1. Load any archive and assert the Title is added to the OnThisPage component and scrolls to top

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
