### PR TITLE
Fix performance issues with quick searching on very large collections

### DIFF
--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -158,6 +158,7 @@ export default {
       children,
       fuzzyMatch,
       processedUserInput,
+      childrenMap,
       orderSymbolsByPriority,
     }) => {
       const symbols = children.filter(symbol => (
@@ -166,9 +167,10 @@ export default {
       ));
       if (!processedUserInput) return [];
       const matches = fuzzyMatch({
-        processedUserInput,
+        inputLength: processedUserInput.length,
         symbols,
         processedInputRegex: new RegExp(constructFuzzyRegex(processedUserInput), 'i'),
+        childrenMap,
       });
       // Return the first 20 symbols out of sorted ones
       return orderSymbolsByPriority(matches).slice(0, 20);
@@ -216,21 +218,22 @@ export default {
     formatSymbolTitle(symbolTitle, symbolStart, symbolEnd) {
       return symbolTitle.slice(symbolStart, symbolEnd);
     },
-    fuzzyMatch({ processedUserInput, symbols, processedInputRegex }) {
+    fuzzyMatch({
+      inputLength, symbols, processedInputRegex, childrenMap,
+    }) {
       return symbols.map((symbol) => {
         const match = processedInputRegex.exec(symbol.title);
         // Dismiss if symbol isn't matched
         if (!match) return false;
 
         const matchLength = match[0].length;
-        const inputLength = processedUserInput.length;
         // Dismiss if match length is greater than 3x the input's length
         if (matchLength > inputLength * 3) return false;
         return ({
           uid: symbol.uid,
           title: symbol.title,
           path: symbol.path,
-          parents: getParents(symbol.parent, this.childrenMap),
+          parents: getParents(symbol.parent, childrenMap),
           type: symbol.type,
           inputLengthDifference: symbol.title.length - inputLength,
           matchLength,


### PR DESCRIPTION
Bug/issue #, if applicable: 102424873

## Summary

This fixes an issue where quick search struggles with searching on very large frameworks. This is due to some Vue internals, like accessing a computed property that returns a none-primitive on each iteration for the collections.

## Dependencies

NA

## Testing

Steps:
1. Load the app with a very large archive
2. Assert that searching for a very common word is as fast as searching for a less common one.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~ - this is Vue internals, and we dont do perf tests in unit tests.
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
