### PR TITLE
Fix long titles for OnThisPageNav

### DIFF
--- a/src/components/OnThisPageNav.vue
+++ b/src/components/OnThisPageNav.vue
@@ -20,7 +20,7 @@
           class="base-link"
           @click.native="handleFocusAndScroll(item.anchor)"
         >
-          {{ item.title }}
+          <WordBreak>{{ item.title }}</WordBreak>
         </router-link>
       </li>
     </ul>
@@ -32,9 +32,11 @@ import throttle from 'docc-render/utils/throttle';
 import { waitFrames } from 'docc-render/utils/loading';
 import ScrollToElement from 'docc-render/mixins/scrollToElement';
 import { buildUrl } from 'docc-render/utils/url-helper';
+import WordBreak from 'docc-render/components/WordBreak.vue';
 
 export default {
   name: 'OnThisPageNav',
+  components: { WordBreak },
   mixins: [ScrollToElement],
   inject: {
     store: {

--- a/src/components/OnThisPageNav.vue
+++ b/src/components/OnThisPageNav.vue
@@ -141,6 +141,7 @@ ul {
   display: inline-block;
   margin-bottom: 5px;
   transition: color 0.15s ease-in;
+  max-width: 100%;
 }
 
 .active .base-link {

--- a/tests/unit/components/OnThisPageNav.spec.js
+++ b/tests/unit/components/OnThisPageNav.spec.js
@@ -13,6 +13,7 @@ import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import OnThisPageNav from '@/components/OnThisPageNav.vue';
 import { AppTopID } from '@/constants/AppTopID';
 import { createEvent, flushPromises } from '../../../test-utils';
+import WordBreak from '@/components/WordBreak';
 
 jest.mock('docc-render/utils/throttle', () => jest.fn(v => v));
 jest.mock('docc-render/utils/loading', () => ({ waitFrames: jest.fn() }));
@@ -101,11 +102,12 @@ describe('OnThisPageNav', () => {
     // assert first parent is active
     expect(firstParent.classes()).not.toContain('active');
     expect(parentLink1.props('to')).toEqual(`?language=objc#${sections[0].anchor}`);
-    expect(parentLink1.text()).toBe(sections[0].title);
+    expect(parentLink1.find(WordBreak).text()).toBe(sections[0].title);
     // assert second parent
     const secondParent = parents.at(1);
     expect(secondParent.classes()).toContain('active');
     expect(secondParent.find(RouterLinkStub).props('to')).toEqual(`?language=objc#${sections[1].anchor}`);
+    expect(secondParent.find(WordBreak).text()).toBe(sections[1].title);
     // assert "children" items
     const children = wrapper.findAll('.child-item');
     expect(children).toHaveLength(1);

--- a/tests/unit/components/OnThisPageNav.spec.js
+++ b/tests/unit/components/OnThisPageNav.spec.js
@@ -12,8 +12,8 @@ import Vue from 'vue';
 import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import OnThisPageNav from '@/components/OnThisPageNav.vue';
 import { AppTopID } from '@/constants/AppTopID';
+import WordBreak from '@/components/WordBreak.vue';
 import { createEvent, flushPromises } from '../../../test-utils';
-import WordBreak from '@/components/WordBreak';
 
 jest.mock('docc-render/utils/throttle', () => jest.fn(v => v));
 jest.mock('docc-render/utils/loading', () => ({ waitFrames: jest.fn() }));


### PR DESCRIPTION
Bug/issue #, if applicable: 102897555

## Summary

With the addition of page titles to the OnThisPage, there are cases where the title is just too long and requires a new line break. This PR adds that break.

## Dependencies

NA

## Testing

Use an archive that has very long page titles. Assert those dont go beyond the OnThisPageNav width.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests - no need, css only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
