### PR TITLE
Fix issue where linking to an anchor on another page doesn't work as expected

### DIFF
--- a/src/utils/router-utils.js
+++ b/src/utils/router-utils.js
@@ -59,6 +59,12 @@ export async function scrollBehavior(to, from, savedPosition) {
     const offset = baseNavOffset + apiChangesNavHeight + getExtraScrollOffset(to);
 
     const y = process.env.VUE_APP_TARGET === 'ide' ? 0 : offset;
+
+    // Wait until the page has been rendered if the navigation to a hash is
+    // triggered from a previous route.
+    if (from) {
+      await this.app.$nextTick();
+    }
     return { selector: cssEscapeTopicIdHash(hash), offset: { x: 0, y } };
   }
   if (areEquivalentLocations(to, from)) {

--- a/tests/unit/utils/router-utils.spec.js
+++ b/tests/unit/utils/router-utils.spec.js
@@ -76,6 +76,7 @@ describe('router-utils', () => {
       const routeDocsNoChanges = createRoute(documentationTopicName, {}, 'bar');
 
       const resolved = await scrollBehavior(routeDocsNoChanges, routeBar);
+      expect(mockApp.app.$nextTick).toHaveBeenCalled();
       expect(resolved).toEqual({
         selector: routeDocsNoChanges.hash,
         offset: { x: 0, y: baseNavHeight + EXTRA_DOCUMENTATION_OFFSET },


### PR DESCRIPTION
Bug/issue #, if applicable: 102985056

## Summary

This fixes a problematic scenario where a user clicks a link to an anchor on another page and the location isn't updated to the right place (is usually a little too early in the page than where the actual anchor should be).

I believe this is a timing issue where the logic to scroll is happening before the page has fully rendered. To fix this, I've added a line to wait for the next Vue tick _only_ when clicking a link to an anchor on another page (and not other scenarios like if the URL was directly loaded). I'm honestly not sure why adding this wait unconditionally doesn't work in the scenario where the URL is directly loaded—it seems to have the inverse problem.

## Testing

Steps:
1. Run `env VUE_APP_DEV_SERVER_PROXY=https://krilnon.github.io/swift-book npm run serve` to start the dev server using data from the [swift-book](https://krilnon.github.io/swift-book/documentation/tspl/) content.
2. Open http://localhost:8080/documentation/the-swift-programming-language/generics
3. Find the first link to "In-Out Parameters" on the page and click it
4. Verify that the "In-Out Parameters" section heading is visible at the top of the screen, as expected
5. Load http://localhost:8080/documentation/the-swift-programming-language/functions#In-Out-Parameters directly in a new tab/window and verify that the "In-Out Parameters" section heading is visible at the top of the screen, as expected
6. Load http://localhost:8080/documentation/the-swift-programming-language/functions#In-Out-Parameters directly or from a link and refresh the page, then verify that the "In-Out Parameters" section heading is visible at the top of the screen
7. Try other linking scenarios and/or other content to verify that there are no regressions introduced by this change

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
