### PR TITLE
Ensure user always scrolls to the right place when linking to subsections of pages

### DIFF
--- a/src/components/ImageAsset.vue
+++ b/src/components/ImageAsset.vue
@@ -109,6 +109,7 @@ export default {
     }) => lightVariantAttributes || darkVariantAttributes,
     darkVariantAttributes: ({ darkVariants }) => constructAttributes(darkVariants),
     lightVariantAttributes: ({ lightVariants }) => constructAttributes(lightVariants),
+    loading: ({ appState }) => appState.imageLoadingStrategy,
     preferredColorScheme: ({ appState }) => appState.preferredColorScheme,
     prefersAuto: ({ preferredColorScheme }) => preferredColorScheme === ColorScheme.auto.value,
     prefersDark: ({ preferredColorScheme }) => preferredColorScheme === ColorScheme.dark.value,
@@ -121,10 +122,6 @@ export default {
     variants: {
       type: Array,
       required: true,
-    },
-    loading: {
-      type: String,
-      default: 'eager',
     },
     shouldCalculateOptimalWidth: {
       type: Boolean,

--- a/src/components/ImageAsset.vue
+++ b/src/components/ImageAsset.vue
@@ -124,7 +124,7 @@ export default {
     },
     loading: {
       type: String,
-      default: 'lazy',
+      default: 'eager',
     },
     shouldCalculateOptimalWidth: {
       type: Boolean,

--- a/src/constants/ImageLoadingStrategy.js
+++ b/src/constants/ImageLoadingStrategy.js
@@ -8,6 +8,11 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+// These are possible values for the `loading` attribute of `<img>` elements.
+// When the "eager" loading strategy is used (the default without specifying),
+// images are fetched and rendered on the page as soon as possible. With the
+// "lazy" loading strategy, the images are only fetched and rendered on the page
+// when necessary as the element comes into view in the browser.
 export default {
   eager: 'eager',
   lazy: 'lazy',

--- a/src/constants/ImageLoadingStrategy.js
+++ b/src/constants/ImageLoadingStrategy.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/src/constants/ImageLoadingStrategy.js
+++ b/src/constants/ImageLoadingStrategy.js
@@ -1,0 +1,14 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+export default {
+  eager: 'eager',
+  lazy: 'lazy',
+};

--- a/src/mixins/onPageLoadScrollToFragment.js
+++ b/src/mixins/onPageLoadScrollToFragment.js
@@ -8,6 +8,8 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import AppStore from 'docc-render/stores/AppStore';
+import ImageLoadingStrategy from 'docc-render/constants/ImageLoadingStrategy';
 import scrollToElement from 'docc-render/mixins/scrollToElement';
 
 function waitForImageToLoad(img) {
@@ -39,6 +41,11 @@ export default {
     async scrollToElementIfAnchorPresent() {
       const { hash } = this.$route;
       if (hash) {
+        // Use "eager" loading for all images since they need to be loaded so
+        // that any dynamic height adjustments can be accounted for
+        const { imageLoadingStrategy } = AppStore.state;
+        AppStore.setImageLoadingStrategy(ImageLoadingStrategy.eager);
+
         // Before scrolling, wait for the next tick to ensure that the page has
         // been fully rendered with the Vue lifecycle and also wait for any
         // images to load since those will also add to the height of the page.
@@ -46,6 +53,9 @@ export default {
         await waitForImagesToLoad();
 
         this.scrollToElement(hash);
+
+        // Restore the original image loading strategy after scrolling
+        AppStore.setImageLoadingStrategy(imageLoadingStrategy);
       }
     },
   },

--- a/src/mixins/onPageLoadScrollToFragment.js
+++ b/src/mixins/onPageLoadScrollToFragment.js
@@ -40,23 +40,25 @@ export default {
   methods: {
     async scrollToElementIfAnchorPresent() {
       const { hash } = this.$route;
-      if (hash) {
-        // Use "eager" loading for all images since they need to be loaded so
-        // that any dynamic height adjustments can be accounted for
-        const { imageLoadingStrategy } = AppStore.state;
-        AppStore.setImageLoadingStrategy(ImageLoadingStrategy.eager);
-
-        // Before scrolling, wait for the next tick to ensure that the page has
-        // been fully rendered with the Vue lifecycle and also wait for any
-        // images to load since those will also add to the height of the page.
-        await this.$nextTick();
-        await waitForImagesToLoad();
-
-        this.scrollToElement(hash);
-
-        // Restore the original image loading strategy after scrolling
-        AppStore.setImageLoadingStrategy(imageLoadingStrategy);
+      if (!hash) {
+        return;
       }
+
+      // Use "eager" loading for all images since they need to be loaded so
+      // that any dynamic height adjustments can be accounted for
+      const { imageLoadingStrategy } = AppStore.state;
+      AppStore.setImageLoadingStrategy(ImageLoadingStrategy.eager);
+
+      // Before scrolling, wait for the next tick to ensure that the page has
+      // been fully rendered with the Vue lifecycle and also wait for any
+      // images to load since those will also add to the height of the page.
+      await this.$nextTick();
+      await waitForImagesToLoad();
+
+      this.scrollToElement(hash);
+
+      // Restore the original image loading strategy after scrolling
+      AppStore.setImageLoadingStrategy(imageLoadingStrategy);
     },
   },
 };

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -9,6 +9,7 @@
 */
 
 import ColorScheme from 'docc-render/constants/ColorScheme';
+import ImageLoadingStrategy from 'docc-render/constants/ImageLoadingStrategy';
 import Settings from 'docc-render/utils/settings';
 
 const supportsAutoColorScheme = (typeof window.matchMedia !== 'undefined') && [
@@ -21,9 +22,13 @@ const defaultColorScheme = supportsAutoColorScheme ? ColorScheme.auto : ColorSch
 
 export default {
   state: {
+    imageLoadingStrategy: ImageLoadingStrategy.lazy,
     preferredColorScheme: Settings.preferredColorScheme || defaultColorScheme.value,
     supportsAutoColorScheme,
     systemColorScheme: ColorScheme.light.value,
+  },
+  setImageLoadingStrategy(strategy) {
+    this.state.imageLoadingStrategy = strategy;
   },
   setPreferredColorScheme(value) {
     this.state.preferredColorScheme = value;

--- a/tests/unit/components/Asset.spec.js
+++ b/tests/unit/components/Asset.spec.js
@@ -181,7 +181,6 @@ describe('Asset', () => {
       expect(asset.exists()).toBe(true);
       expect(asset.props()).toEqual({
         alt: image.alt,
-        loading: 'lazy',
         variants: image.variants,
         shouldCalculateOptimalWidth: true,
       });
@@ -192,7 +191,6 @@ describe('Asset', () => {
       const asset = wrapper.find(ImageAsset);
       expect(asset.props()).toEqual({
         alt: image.alt,
-        loading: 'lazy',
         variants: image.variants,
         shouldCalculateOptimalWidth: true,
       });

--- a/tests/unit/components/ImageAsset.spec.js
+++ b/tests/unit/components/ImageAsset.spec.js
@@ -15,6 +15,7 @@ import { flushPromises } from '../../../test-utils';
 
 jest.mock('docc-render/stores/AppStore', () => ({
   state: {
+    imageLoadingStrategy: 'lazy',
     preferredColorScheme: 'auto',
     supportsAutoColorScheme: true,
     setPreferredColorScheme: jest.fn(),
@@ -55,6 +56,7 @@ describe('ImageAsset', () => {
     expect(image.attributes('height')).toBe('auto');
     expect(image.attributes('alt')).toBe(alt);
     expect(image.attributes('decoding')).toBe('async');
+    expect(image.attributes('loading')).toBe('lazy');
   });
 
   it('renders an image that has one variant with no appearance trait', () => {
@@ -87,6 +89,7 @@ describe('ImageAsset', () => {
     expect(image.attributes('height')).toBe('auto');
     expect(image.attributes('alt')).toBe('');
     expect(image.attributes('decoding')).toBe('async');
+    expect(image.attributes('loading')).toBe('lazy');
   });
 
   it('renders an image that has two light variants', () => {
@@ -131,6 +134,7 @@ describe('ImageAsset', () => {
     expect(image.attributes('width')).toBe('1202');
     expect(image.attributes('height')).toBe('auto');
     expect(image.attributes('decoding')).toBe('async');
+    expect(image.attributes('loading')).toBe('lazy');
   });
 
   it('renders an image that has two dark variants', () => {

--- a/tests/unit/components/OverridableAsset.spec.js
+++ b/tests/unit/components/OverridableAsset.spec.js
@@ -48,7 +48,6 @@ describe('OverridableAsset', () => {
     });
     expect(wrapper.find(ImageAsset).props()).toEqual({
       variants: [localVariantNoID],
-      loading: null,
       alt: '',
       shouldCalculateOptimalWidth: true,
     });

--- a/tests/unit/mixins/onPageLoadScrollToFragment.spec.js
+++ b/tests/unit/mixins/onPageLoadScrollToFragment.spec.js
@@ -11,6 +11,7 @@
 import onPageLoadScrollToFragment from 'docc-render/mixins/onPageLoadScrollToFragment';
 import { shallowMount } from '@vue/test-utils';
 import scrollToElement from 'docc-render/mixins/scrollToElement';
+import { flushPromises } from '../../../test-utils';
 
 jest.mock('docc-render/utils/loading', () => ({ waitFrames: () => {} }));
 jest.mock('docc-render/mixins/scrollToElement', () => ({
@@ -49,7 +50,7 @@ describe('onPageLoadScrollToFragment', () => {
         },
       },
     });
-    await Promise.resolve();
+    await flushPromises();
     expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledWith('some-hash');
   });
 

--- a/tests/unit/mixins/onPageLoadScrollToFragment.spec.js
+++ b/tests/unit/mixins/onPageLoadScrollToFragment.spec.js
@@ -42,16 +42,19 @@ describe('onPageLoadScrollToFragment', () => {
     jest.clearAllMocks();
   });
 
-  it('calls scrollToElement on mount if route has a hash', async () => {
-    createWrapper({
+  it('calls scrollToElement on mounted/updated if route has a hash', async () => {
+    const wrapper = createWrapper({
       mocks: {
         $route: {
           hash: 'some-hash',
         },
       },
     });
+    wrapper.vm.$forceUpdate();
     await flushPromises();
-    expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledWith('some-hash');
+    expect(scrollToElement.methods.scrollToElement).toHaveBeenCalledTimes(2);
+    expect(scrollToElement.methods.scrollToElement).toHaveBeenNthCalledWith(1, 'some-hash');
+    expect(scrollToElement.methods.scrollToElement).toHaveBeenNthCalledWith(2, 'some-hash');
   });
 
   it('does not call scrollToElement if no hash exists', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 102985056

## Summary

There may be times when a user clicks a link to a subsection of another page and isn't scrolled to the appropriate place—this issue is most likely happening more often on uncached, content heavy pages, especially with many and/or large images since the height of the images may be impacting the scroll location before they have fully loaded.

These 2 explicit changes were made to make sure that scrolling consistently goes to the right place in every scenario:

* Updated the `onpageLoadScrollToFragment` mixin so that the logic is also called in the `updated` hook and not just the `mounted` one. This is needed since following a link to a subsection of one documentation page from another actually updates the main component instead of remounting a new one
* Before scrolling, all images are set to eagerly load so that we can wait for them to be inserted on the page before attempting to scroll—otherwise, we may scroll to the wrong place since the loaded images will change the position on the page we need to scroll to.

## Testing

Steps:
1. Run the dev server with `env VUE_APP_DEV_SERVER_PROXY=https://krilnon.github.io/swift-book npm run serve`
2. Open http://localhost:8080/documentation/the-swift-programming-language/basicoperators
3. Click the link to "Overflow Operators" and verify that the page is scrolled to the right heading
4. Test out lots of other pages and links to subsections throughout this content since there are many examples that don't work very well today.
5. Try other content and browsers and try to test for any possible regressions

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
