### PR TITLE
Bugfix: Remove repeated symbols from QN search results

### DIFF
--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -172,8 +172,12 @@ export default {
         processedInputRegex: new RegExp(constructFuzzyRegex(processedUserInput), 'i'),
         childrenMap,
       });
-      // Return the first 20 symbols out of sorted ones
-      return orderSymbolsByPriority(matches).slice(0, 20);
+      // Filter symbols with repeated paths and return the first 20
+      return orderSymbolsByPriority(
+        matches.filter((s1, index) => (
+          index === matches.findIndex(s2 => s2.path === s1.path)
+        )),
+      ).slice(0, 20);
     },
     isVisible: {
       get: ({ showQuickNavigationModal }) => showQuickNavigationModal,

--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -172,12 +172,9 @@ export default {
         processedInputRegex: new RegExp(constructFuzzyRegex(processedUserInput), 'i'),
         childrenMap,
       });
-      // Filter symbols with repeated paths and return the first 20
-      return orderSymbolsByPriority(
-        matches.filter((s1, index) => (
-          index === matches.findIndex(s2 => s2.path === s1.path)
-        )),
-      ).slice(0, 20);
+      // Filter repeated matches and return the first 20
+      const uniqueMatches = [...new Map(matches.map(match => [match.path, match])).values()];
+      return orderSymbolsByPriority(uniqueMatches).slice(0, 20);
     },
     isVisible: {
       get: ({ showQuickNavigationModal }) => showQuickNavigationModal,

--- a/tests/unit/components/Navigator/QuickNavigationModal.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationModal.spec.js
@@ -310,4 +310,26 @@ describe('QuickNavigationModal', () => {
     });
     expect(wrapper.vm.processedUserInput).toBe('barfoo');
   });
+  it('it removes filtered symbols with duplicate paths', () => {
+    const symbolsWithRepeatedPaths = [
+      {
+        title: 'foo',
+        path: '/foo',
+      },
+      {
+        title: 'foo',
+        path: '/foo',
+      },
+    ];
+    wrapper = shallowMount(QuickNavigationModal, {
+      propsData: {
+        children: symbolsWithRepeatedPaths,
+        showQuickNavigationModal: true,
+      },
+    });
+    wrapper.setData({
+      debouncedInput: 'foo',
+    });
+    expect(wrapper.vm.filteredSymbols.length).toBe(1);
+  });
 });

--- a/tests/unit/components/Navigator/QuickNavigationModal.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationModal.spec.js
@@ -320,6 +320,10 @@ describe('QuickNavigationModal', () => {
         title: 'foo',
         path: '/foo',
       },
+      {
+        title: 'foo',
+        path: '/bar',
+      },
     ];
     wrapper = shallowMount(QuickNavigationModal, {
       propsData: {
@@ -330,6 +334,6 @@ describe('QuickNavigationModal', () => {
     wrapper.setData({
       debouncedInput: 'foo',
     });
-    expect(wrapper.vm.filteredSymbols.length).toBe(1);
+    expect(wrapper.vm.filteredSymbols.length).toBe(2);
   });
 });


### PR DESCRIPTION
Bug/issue #489, if applicable: 

## Summary

When an author curates the documentation symbols these might appear repeated times in the index, even if they have different UIDs conceptually they are the same, so when filtering symbols on quick navigation we have to check path uniqueness and remove the duplicates.

In this PR I tweaked the `filteredSymbols` computed property to filter symbols by path uniqueness, removing the duplicates from the results

## Dependencies

N/A

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. Turn on the feature flag for Quick Navigation
2. Assert that symbols with the same path appear once on Quick Navigation results

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary (N/A)
