### PR TITLE
Fix table spacing between elements

### DIFF
--- a/src/components/ContentNode/Table.vue
+++ b/src/components/ContentNode/Table.vue
@@ -28,20 +28,13 @@ export default {
 };
 </script>
 
-<style lang="scss">
-@import 'docc-render/styles/_core.scss';
-
-.table-wrapper {
-  @include space-out-between-siblings($stacked-margin-xlarge);
-}
-</style>
-
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
 .table-wrapper {
   overflow: auto;
   -webkit-overflow-scrolling: touch;
+  @include space-out-between-siblings($stacked-margin-xlarge);
 }
 
 table {


### PR DESCRIPTION
Bug/issue #, if applicable: 103365463

## Summary

Fixes issues with table spacing introduced in #478

## Dependencies

NA

## Testing

Assert that elements after tables are properly spaced out properly

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - no need, css only
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
