### PR TITLE
Minimized view should display less content 

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -31,7 +31,7 @@
           :objcPath="objcPath"
           :swiftPath="swiftPath"
         />
-        <Title :eyebrow="roleHeading">
+        <Title :eyebrow="roleHeading" v-if="!enableMinimized">
           <component :is="titleBreakComponent">{{ title }}</component>
           <small
             v-if="isSymbolDeprecated || isSymbolBeta"
@@ -45,7 +45,7 @@
           <DownloadButton class="sample-download" :action="sampleCodeDownload.action" />
         </div>
         <Availability
-          v-if="hasAvailability"
+          v-if="shouldShowAvailability"
           :platforms="platforms" :technologies="technologies"
         />
       </DocumentationHero>
@@ -69,7 +69,7 @@
             </div>
             <PrimaryContent
               v-if="primaryContentSections && primaryContentSections.length"
-              :class="{ 'with-border': !enhanceBackground }"
+              :class="{ 'with-border': !enhanceBackground && !enableMinimized }"
               :conformance="conformance"
               :source="remoteSource"
               :sections="primaryContentSections"
@@ -83,16 +83,19 @@
             :topicStyle="topicSectionsStyle"
           />
           <DefaultImplementations
-            v-if="defaultImplementationsSections"
+            v-if="defaultImplementationsSections && !enableMinimized"
             :sections="defaultImplementationsSections"
             :isSymbolDeprecated="isSymbolDeprecated"
             :isSymbolBeta="isSymbolBeta"
           />
-          <Relationships v-if="relationshipsSections" :sections="relationshipsSections" />
+          <Relationships
+            v-if="relationshipsSections && !enableMinimized"
+            :sections="relationshipsSections"
+          />
           <!-- NOTE: see also may contain information about other apis, so we cannot
           pass deprecation and beta information -->
           <SeeAlso
-            v-if="seeAlsoSections"
+            v-if="seeAlsoSections && !enableMinimized"
             :sections="seeAlsoSections"
           />
         </div>
@@ -333,8 +336,8 @@ export default {
         0,
       );
     },
-    hasAvailability: ({ platforms, technologies }) => (
-      (platforms || []).length || (technologies || []).length
+    shouldShowAvailability: ({ platforms, technologies, enableMinimized }) => (
+      ((platforms || []).length || (technologies || []).length) && !enableMinimized
     ),
     hasBetaContent:
       ({ platforms }) => platforms
@@ -344,8 +347,13 @@ export default {
     pageDescription: ({ abstract, extractFirstParagraphText }) => (
       abstract ? extractFirstParagraphText(abstract) : null
     ),
-    shouldShowLanguageSwitcher: ({ objcPath, swiftPath, isTargetIDE }) => (
-      !!(objcPath && swiftPath && isTargetIDE)
+    shouldShowLanguageSwitcher: ({
+      objcPath,
+      swiftPath,
+      isTargetIDE,
+      enableMinimized,
+    }) => (
+      !!(objcPath && swiftPath && isTargetIDE) && !enableMinimized
     ),
     enhanceBackground: ({ symbolKind, disableHeroBackground, topicSectionsStyle }) => {
       if (
@@ -409,10 +417,14 @@ export default {
     shouldRenderTopicSection: ({
       topicSectionsStyle,
       topicSections,
-    }) => topicSections && topicSectionsStyle !== TopicSectionsStyle.hidden,
+      enableMinimized,
+    }) => topicSections && topicSectionsStyle !== TopicSectionsStyle.hidden && !enableMinimized,
     isOnThisPageNavVisible: ({ topicState }) => (
       topicState.contentWidth > ON_THIS_PAGE_CONTAINER_BREAKPOINT
     ),
+    enableMinimized({ $route }) {
+      return $route ? $route.path.split('/')[1] === 'minimized' : false;
+    },
   },
   methods: {
     normalizePath(path) {

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -304,6 +304,10 @@ export default {
       type: Array,
       required: false,
     },
+    enableMinimized: {
+      type: Boolean,
+      default: false,
+    },
     enableOnThisPageNav: {
       type: Boolean,
       default: false,
@@ -422,9 +426,6 @@ export default {
     isOnThisPageNavVisible: ({ topicState }) => (
       topicState.contentWidth > ON_THIS_PAGE_CONTAINER_BREAKPOINT
     ),
-    enableMinimized({ $route }) {
-      return $route ? $route.path.split('/')[1] === 'minimized' : false;
-    },
   },
   methods: {
     normalizePath(path) {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -87,6 +87,7 @@
           :isSymbolBeta="isSymbolBeta"
           :languagePaths="languagePaths"
           :enableOnThisPageNav="enableOnThisPageNav"
+          :enableMinimized="enableMinimized"
         />
       </component>
     </template>
@@ -150,6 +151,7 @@ export default {
       showQuickNavigationModal: false,
       store: DocumentationTopicStore,
       BreakpointName,
+      enableMinimized: false,
     };
   },
   computed: {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -142,6 +142,12 @@ export default {
     MagnifierIcon,
   },
   mixins: [communicationBridgeUtils, onPageLoadScrollToFragment, OnThisPageRegistrator],
+  props: {
+    enableMinimized: {
+      type: Boolean,
+      default: false,
+    },
+  },
   data() {
     return {
       topicDataDefault: null,
@@ -151,7 +157,6 @@ export default {
       showQuickNavigationModal: false,
       store: DocumentationTopicStore,
       BreakpointName,
-      enableMinimized: false,
     };
   },
   computed: {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -752,7 +752,7 @@ describe('DocumentationTopic', () => {
     });
 
     it('routes to the objc variant of a page if that is the preferred language', async () => {
-      const $route = { query: {} };
+      const $route = { query: {}, path: '' };
       const $router = { replace: jest.fn() };
       const store = {
         reset: () => {},

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -334,7 +334,7 @@ describe('DocumentationTopic', () => {
     expect(title.find(WordBreak).exists()).toBe(false);
 
     // Minimized view should not render Title
-    wrapper.vm.$route.path = '/minimized';
+    wrapper.setProps({ enableMinimized: true });
     expect(wrapper.find(DocumentationHero).find(Title).exists()).toBe(false);
   });
 
@@ -485,7 +485,7 @@ describe('DocumentationTopic', () => {
       expect(list.props('platforms')).toEqual(propsData.platforms);
 
       // Minimized view should not render Availability
-      wrapper.vm.$route.path = '/minimized';
+      wrapper.setProps({ enableMinimized: true });
       expect(wrapper.find(Availability).exists()).toBe(false);
     });
   });
@@ -524,7 +524,7 @@ describe('DocumentationTopic', () => {
     });
 
     // Minimized view should not render LanguageSwitcher
-    wrapper.vm.$route.path = '/minimized';
+    wrapper.setProps({ enableMinimized: true });
     expect(wrapper.find(LanguageSwitcher).exists()).toBe(false);
   });
 
@@ -552,7 +552,7 @@ describe('DocumentationTopic', () => {
     expect(topics.props('topicStyle')).toBe(TopicSectionsStyle.detailedGrid);
 
     // Minimized view should not render Topics
-    wrapper.vm.$route.path = '/minimized';
+    wrapper.setProps({ enableMinimized: true });
     expect(wrapper.find(Topics).exists()).toBe(false);
   });
 
@@ -590,7 +590,7 @@ describe('DocumentationTopic', () => {
     expect(seeAlso.props('sections')).toBe(seeAlsoSections);
 
     // Minimized view should not render See Also
-    wrapper.vm.$route.path = '/minimized';
+    wrapper.setProps({ enableMinimized: true });
     expect(wrapper.find(SeeAlso).exists()).toBe(false);
   });
 
@@ -619,7 +619,7 @@ describe('DocumentationTopic', () => {
     expect(relationships.props('sections')).toBe(relationshipsSections);
 
     // Minimized view should not render Relationships
-    wrapper.vm.$route.path = '/minimized';
+    wrapper.setProps({ enableMinimized: true });
     expect(wrapper.find(Relationships).exists()).toBe(false);
   });
 
@@ -675,7 +675,7 @@ describe('DocumentationTopic', () => {
     expect(defaults.props('sections')).toEqual(defaultImplementationsSections);
 
     // Minimized view should not render DefaultImplementations
-    wrapper.vm.$route.path = '/minimized';
+    wrapper.setProps({ enableMinimized: true });
     expect(wrapper.find(DefaultImplementations).exists()).toBe(false);
   });
 

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -167,11 +167,6 @@ describe('DocumentationTopic', () => {
           reset() {},
         },
       },
-      mocks: {
-        $route: {
-          path: '/foo',
-        },
-      },
     });
   });
 
@@ -506,15 +501,7 @@ describe('DocumentationTopic', () => {
 
   it('renders a `LanguageSwitcher` if TargetIDE', () => {
     const provide = { isTargetIDE: true };
-    wrapper = shallowMount(DocumentationTopic, {
-      propsData,
-      provide,
-      mocks: {
-        $route: {
-          path: '/foo',
-        },
-      },
-    });
+    wrapper = shallowMount(DocumentationTopic, { propsData, provide });
     const switcher = wrapper.find(LanguageSwitcher);
     expect(switcher.exists()).toBe(true);
     expect(switcher.props()).toEqual({
@@ -793,7 +780,7 @@ describe('DocumentationTopic', () => {
     });
 
     it('routes to the objc variant of a page if that is the preferred language', async () => {
-      const $route = { query: {}, path: '' };
+      const $route = { query: {} };
       const $router = { replace: jest.fn() };
       const store = {
         reset: () => {},

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -167,6 +167,11 @@ describe('DocumentationTopic', () => {
           reset() {},
         },
       },
+      mocks: {
+        $route: {
+          path: '/foo',
+        },
+      },
     });
   });
 
@@ -327,6 +332,10 @@ describe('DocumentationTopic', () => {
     expect(title.props('eyebrow')).toBe(propsData.roleHeading);
     expect(title.text()).toBe(propsData.title);
     expect(title.find(WordBreak).exists()).toBe(false);
+
+    // Minimized view should not render Title
+    wrapper.vm.$route.path = '/minimized';
+    expect(wrapper.find(DocumentationHero).find(Title).exists()).toBe(false);
   });
 
   it('uses `WordBreak` in the title for symbol pages', () => {
@@ -474,6 +483,10 @@ describe('DocumentationTopic', () => {
       const list = wrapper.find(Availability);
       expect(list.exists()).toBe(true);
       expect(list.props('platforms')).toEqual(propsData.platforms);
+
+      // Minimized view should not render Availability
+      wrapper.vm.$route.path = '/minimized';
+      expect(wrapper.find(Availability).exists()).toBe(false);
     });
   });
 
@@ -493,7 +506,15 @@ describe('DocumentationTopic', () => {
 
   it('renders a `LanguageSwitcher` if TargetIDE', () => {
     const provide = { isTargetIDE: true };
-    wrapper = shallowMount(DocumentationTopic, { propsData, provide });
+    wrapper = shallowMount(DocumentationTopic, {
+      propsData,
+      provide,
+      mocks: {
+        $route: {
+          path: '/foo',
+        },
+      },
+    });
     const switcher = wrapper.find(LanguageSwitcher);
     expect(switcher.exists()).toBe(true);
     expect(switcher.props()).toEqual({
@@ -501,6 +522,10 @@ describe('DocumentationTopic', () => {
       objcPath: propsData.languagePaths.occ[0],
       swiftPath: propsData.languagePaths.swift[0],
     });
+
+    // Minimized view should not render LanguageSwitcher
+    wrapper.vm.$route.path = '/minimized';
+    expect(wrapper.find(LanguageSwitcher).exists()).toBe(false);
   });
 
   it('renders `Topics` if there are topic sections, passing the `topicSectionsStyle` over', () => {
@@ -525,6 +550,10 @@ describe('DocumentationTopic', () => {
     expect(topics.exists()).toBe(true);
     expect(topics.props('sections')).toBe(topicSections);
     expect(topics.props('topicStyle')).toBe(TopicSectionsStyle.detailedGrid);
+
+    // Minimized view should not render Topics
+    wrapper.vm.$route.path = '/minimized';
+    expect(wrapper.find(Topics).exists()).toBe(false);
   });
 
   it('does not render the `Topics` if the `topicSectionsStyle` is `hidden`', () => {
@@ -559,6 +588,10 @@ describe('DocumentationTopic', () => {
     const seeAlso = wrapper.find(SeeAlso);
     expect(seeAlso.exists()).toBe(true);
     expect(seeAlso.props('sections')).toBe(seeAlsoSections);
+
+    // Minimized view should not render See Also
+    wrapper.vm.$route.path = '/minimized';
+    expect(wrapper.find(SeeAlso).exists()).toBe(false);
   });
 
   it('renders `Relationships` if there are relationship sections', () => {
@@ -584,6 +617,10 @@ describe('DocumentationTopic', () => {
     const relationships = wrapper.find(Relationships);
     expect(relationships.exists()).toBe(true);
     expect(relationships.props('sections')).toBe(relationshipsSections);
+
+    // Minimized view should not render Relationships
+    wrapper.vm.$route.path = '/minimized';
+    expect(wrapper.find(Relationships).exists()).toBe(false);
   });
 
   it('renders `Relationships` before `SeeAlso`', () => {
@@ -636,6 +673,10 @@ describe('DocumentationTopic', () => {
     const defaults = wrapper.find(DefaultImplementations);
     expect(defaults.exists()).toBe(true);
     expect(defaults.props('sections')).toEqual(defaultImplementationsSections);
+
+    // Minimized view should not render DefaultImplementations
+    wrapper.vm.$route.path = '/minimized';
+    expect(wrapper.find(DefaultImplementations).exists()).toBe(false);
   });
 
   it('computes isSymbolBeta', () => {

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -667,6 +667,7 @@ describe('DocumentationTopic', () => {
         swift: ['documentation/swift'],
       },
       enableOnThisPageNav: true, // enabled by default
+      enableMinimized: false, // disabled by default
       topicSectionsStyle: TopicSectionsStyle.list, // default value
       disableHeroBackground: false,
     });


### PR DESCRIPTION
Bug/issue #, if applicable: 103149476

## Summary
The minimized view should not display the following items:
1. Title and eyebrow
2. Language Switcher
3. Availability
5. Topics section
6. Default Implementations
7. Relationships
8. See Also

## Testing
Steps:
1. Test with this DocC Archive: 
[SlothCreator_Minimized_View.doccarchive.zip](https://github.com/apple/swift-docc-render/files/10240143/SlothCreator_Minimized_View.doccarchive.zip)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary

