### PR TITLE
Localnav without navigator should take up full space.

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -20,26 +20,28 @@
     class="documentation-nav"
     aria-label="API Reference"
   >
-    <template #pre-title="{ closeNav, isOpen, currentBreakpoint }" v-if="displaySidenav">
-      <transition name="sidenav-toggle">
-        <div
-          v-show="sidenavHiddenOnLarge"
-          class="sidenav-toggle-wrapper"
-        >
-          <button
-            aria-label="Open documentation navigator"
-            :id="baseNavOpenSidenavButtonId"
-            class="sidenav-toggle"
-            :tabindex="isOpen ? -1 : null"
-            @click.prevent="handleSidenavToggle(closeNav, currentBreakpoint)"
+    <template #pre-title="{ closeNav, isOpen, currentBreakpoint, className }" v-if="displaySidenav">
+      <div :class="className">
+        <transition name="sidenav-toggle">
+          <div
+            v-show="sidenavHiddenOnLarge"
+            class="sidenav-toggle-wrapper"
           >
-          <span class="sidenav-icon-wrapper">
-            <SidenavIcon class="icon-inline sidenav-icon" />
-          </span>
-          </button>
-          <span class="sidenav-toggle__separator" />
-        </div>
-      </transition>
+            <button
+              aria-label="Open documentation navigator"
+              :id="baseNavOpenSidenavButtonId"
+              class="sidenav-toggle"
+              :tabindex="isOpen ? -1 : null"
+              @click.prevent="handleSidenavToggle(closeNav, currentBreakpoint)"
+            >
+            <span class="sidenav-icon-wrapper">
+              <SidenavIcon class="icon-inline sidenav-icon" />
+            </span>
+            </button>
+            <span class="sidenav-toggle__separator" />
+          </div>
+        </transition>
+      </div>
     </template>
     <template slot="default">
       <slot

--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -15,12 +15,12 @@
     hasSolidBackground
     :hasNoBorder="hasNoBorder"
     :isDark="isDark"
-    :isWideFormat="isWideFormat"
+    isWideFormat
     hasFullWidthBorder
     class="documentation-nav"
     aria-label="API Reference"
   >
-    <template #pre-title="{ closeNav, isOpen, currentBreakpoint }" v-if="isWideFormat">
+    <template #pre-title="{ closeNav, isOpen, currentBreakpoint }" v-if="displaySidenav">
       <transition name="sidenav-toggle">
         <div
           v-show="sidenavHiddenOnLarge"
@@ -138,10 +138,6 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    isWideFormat: {
-      type: Boolean,
-      default: true,
-    },
     interfaceLanguage: {
       type: String,
       required: false,
@@ -155,6 +151,10 @@ export default {
       required: false,
     },
     sidenavHiddenOnLarge: {
+      type: Boolean,
+      default: false,
+    },
+    displaySidenav: {
       type: Boolean,
       default: false,
     },

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -19,9 +19,11 @@
       <div class="nav__background" />
       <div v-if="hasOverlay" class="nav-overlay" @click="closeNav" />
       <div class="nav-content">
-        <div class="pre-title">
-          <slot name="pre-title" v-bind="{ closeNav, inBreakpoint, currentBreakpoint, isOpen }" />
-        </div>
+        <slot
+          name="pre-title"
+          className="pre-title"
+          v-bind="{ closeNav, inBreakpoint, currentBreakpoint, isOpen }"
+        />
         <div v-if="$slots.default" class="nav-title">
           <slot />
         </div>
@@ -670,6 +672,17 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   }
 }
 
+.pre-title + .nav-title {
+  @include nav-in-breakpoint {
+    grid-area: title;
+
+    @include nav-is-wide-format(true) {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+}
+
 .nav-title {
   height: $nav-height;
   @include font-styles(nav-title);
@@ -683,15 +696,6 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
     padding-top: 0;
     height: $nav-height-small;
     width: 90%;
-  }
-
-  @include nav-in-breakpoint {
-    grid-area: title;
-
-    @include nav-is-wide-format(true) {
-      width: 100%;
-      justify-content: center;
-    }
   }
 
   /deep/ span {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -63,7 +63,7 @@
           :isSymbolBeta="isSymbolBeta"
           :currentTopicTags="topicProps.tags"
           :references="topicProps.references"
-          :isWideFormat="enableNavigator"
+          :displaySidenav="enableNavigator"
           :sidenavHiddenOnLarge="sidenavHiddenOnLarge"
           @toggle-sidenav="handleToggleSidenav"
         >

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -15,6 +15,7 @@
         :is="enableNavigator ? 'AdjustableSidebarWidth' : 'StaticContentWidth'"
         v-bind="sidebarProps"
         v-on="sidebarListeners"
+        class="full-width-container topic-wrapper"
       >
         <PortalTarget name="modal-destination" multiple />
         <template #aside="{ scrollLockID, breakpoint }">
@@ -323,11 +324,10 @@ export default {
     sidebarProps: ({ sidenavVisibleOnMobile, enableNavigator, sidenavHiddenOnLarge }) => (
       enableNavigator
         ? {
-          class: 'full-width-container topic-wrapper',
           shownOnMobile: sidenavVisibleOnMobile,
           hiddenOnLarge: sidenavHiddenOnLarge,
         }
-        : { class: 'static-width-container topic-wrapper' }
+        : {}
     ),
     sidebarListeners() {
       return this.enableNavigator ? ({

--- a/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
@@ -67,6 +67,7 @@ describe('DocumentationNav', () => {
     swiftPath: 'documentation/foo',
     objcPath: 'documentation/bar',
     references,
+    displaySidenav: true,
   };
 
   beforeEach(() => {
@@ -308,16 +309,5 @@ describe('DocumentationNav', () => {
     expect(wrapper.emitted('toggle-sidenav')).toEqual([[BreakpointName.medium]]);
     expect(toggle.attributes()).not.toHaveProperty('tabindex');
     window.Event = backup;
-  });
-
-  it('renders the nav, with `isWideFormat` to `false`', () => {
-    wrapper.setProps({
-      isWideFormat: false,
-    });
-    expect(wrapper.find(NavBase).props()).toMatchObject({
-      isWideFormat: false,
-      breakpoint: BreakpointName.medium,
-    });
-    expect(wrapper.find('.sidenav-toggle').exists()).toBe(false);
   });
 });

--- a/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
@@ -310,4 +310,15 @@ describe('DocumentationNav', () => {
     expect(toggle.attributes()).not.toHaveProperty('tabindex');
     window.Event = backup;
   });
+
+  it('does not render the sidenav toggle if displaySidenav is false', () => {
+    wrapper.setProps({
+      displaySidenav: false,
+    });
+    expect(wrapper.find(NavBase).props()).toMatchObject({
+      isWideFormat: true,
+      breakpoint: BreakpointName.medium,
+    });
+    expect(wrapper.find('.sidenav-toggle').exists()).toBe(false);
+  });
 });

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -154,10 +154,9 @@ describe('NavBase', () => {
         },
       },
     });
-    const preTitle = wrapper.find('.pre-title');
-    expect(preTitle.exists()).toBe(true);
-    expect(preTitle.find('.pre-title-slot').text()).toBe('Pre Title');
+    expect(wrapper.find('.pre-title-slot').text()).toBe('Pre Title');
     expect(preTitleProps).toEqual({
+      className: 'pre-title',
       closeNav: expect.any(Function),
       isOpen: false,
       inBreakpoint: false,
@@ -166,6 +165,7 @@ describe('NavBase', () => {
     wrapper.find('a.nav-menucta').trigger('click');
     expect(wrapper.classes()).toContain(NavStateClasses.isOpen);
     expect(preTitleProps).toEqual({
+      className: 'pre-title',
       closeNav: expect.any(Function),
       isOpen: true,
       inBreakpoint: false,
@@ -174,6 +174,7 @@ describe('NavBase', () => {
     preTitleProps.closeNav();
     expect(wrapper.classes()).not.toContain(NavStateClasses.isOpen);
     expect(preTitleProps).toEqual({
+      className: 'pre-title',
       closeNav: expect.any(Function),
       isOpen: false,
       inBreakpoint: false,

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -246,7 +246,7 @@ describe('DocumentationTopic', () => {
     });
     // assert the nav is in wide format
     const nav = wrapper.find(Nav);
-    expect(nav.props('isWideFormat')).toBe(true);
+    expect(nav.props('displaySidenav')).toBe(true);
   });
 
   it('renders QuickNavigation and MagnifierIcon if enableQuickNavigation is true', () => {
@@ -523,10 +523,10 @@ describe('DocumentationTopic', () => {
       isDark: false,
       hasNoBorder: false,
       currentTopicTags: [],
+      displaySidenav: false,
       references: topicData.references,
       isSymbolBeta: false,
       isSymbolDeprecated: false,
-      isWideFormat: false,
       interfaceLanguage: topicData.identifier.interfaceLanguage,
       objcPath: topicData.variants[0].paths[0],
       swiftPath: topicData.variants[1].paths[0],

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -545,7 +545,7 @@ describe('DocumentationTopic', () => {
     expect(wrapper.find(Navigator).exists()).toBe(false);
     // assert the proper container class is applied
     expect(staticContentWidth.classes())
-      .toEqual(expect.arrayContaining(['topic-wrapper', 'static-width-container']));
+      .toEqual(expect.arrayContaining(['topic-wrapper', 'full-width-container']));
   });
 
   it('renders without NavigatorDataProvider', async () => {


### PR DESCRIPTION
Bug/issue #103256123, if applicable: 

## Summary

1) Localnav without navigator should take up full space.
2) Localnav without navigator on mobile viewport should be correct without toggle button

### Before

<img width="2103" alt="Screenshot 2022-12-19 at 19 46 56" src="https://user-images.githubusercontent.com/8567677/208497832-145c9831-38bb-4167-8509-25f1c952a2d9.png">

### After

![Screenshot 2022-12-21 at 18 55 47](https://user-images.githubusercontent.com/8567677/208972283-586e1722-c4bf-435e-8e05-74b8adb66daf.png)

<img width="686" alt="Screenshot 2022-12-19 at 19 44 59" src="https://user-images.githubusercontent.com/8567677/208497923-5f3d7ad8-9917-42d1-ab0e-ac212f3950b4.png">


## Dependencies

NA

## Testing

Steps:
1. Run a doccarchive without navigator
2. Assert that localnav takes full space

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
