### PR TITLE
Fix warning when running tests

### DIFF
--- a/tests/unit/components/Navigator/QuickNavigationModal.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationModal.spec.js
@@ -315,14 +315,17 @@ describe('QuickNavigationModal', () => {
       {
         title: 'foo',
         path: '/foo',
+        type: 'method',
       },
       {
         title: 'foo',
         path: '/foo',
+        type: 'method',
       },
       {
         title: 'foo',
         path: '/bar',
+        type: 'method',
       },
     ];
     wrapper = shallowMount(QuickNavigationModal, {


### PR DESCRIPTION
Bug/issue #103533986, if applicable:

## Summary

Fix warning: [Vue warn]: Invalid prop: type check failed for prop "type". Expected String, got Undefined 
when running tests

## Dependencies

NA

## Testing

Steps:
1. Run `npm run test`
2. Assert no warnings are displayed

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
