### PR TITLE
Fix issues with new lines not rendering, when multiline blocks are used

### DIFF
--- a/src/utils/syntax-highlight.js
+++ b/src/utils/syntax-highlight.js
@@ -188,7 +188,7 @@ function duplicateMultilineNode(element) {
 
   // wrap each new line with the current element's class
   const result = getLines(element.innerHTML)
-    .reduce((all, lineText) => `${all}<span class="${className}">${lineText}</span>\n`, '');
+    .reduce((all, lineText) => `${all}<span class="${className}">${lineText || '\n\n'}</span>\n`, '');
 
   // return a list of newly wrapped HTML elements
   return htmlToElements(result.trim());

--- a/tests/unit/utils/syntax-highlight.spec.js
+++ b/tests/unit/utils/syntax-highlight.spec.js
@@ -90,6 +90,39 @@ describe("syntax-highlight", () => {
     `);
   });
 
+  it('adds extra line breaks to empty lines that wrap', async () => {
+    const content = [
+      'let multiline = """',
+      'Needs',
+      '',
+      'Spaces',
+      '',
+      'Between',
+      '',
+      'Lines',
+      '"""',
+    ];
+    const { highlightedCode, sanitizedCode } = await prepare(content, "js");
+    expect(sanitizedCode).not.toEqual(highlightedCode);
+    expect(sanitizedCode).toMatchInlineSnapshot(`
+      <span class="syntax-keyword">let</span> multiline = <span class="syntax-string">""</span><span class="syntax-string">"</span>
+      <span class="syntax-string">Needs</span>
+      <span class="syntax-string">
+
+      </span>
+      <span class="syntax-string">Spaces</span>
+      <span class="syntax-string">
+
+      </span>
+      <span class="syntax-string">Between</span>
+      <span class="syntax-string">
+
+      </span>
+      <span class="syntax-string">Lines</span>
+      <span class="syntax-string">"</span><span class="syntax-string">""</span>
+    `);
+  });
+
   it("wraps multiline nested highlighted blocks", async () => {
     const content = [
       "function someName(foo,",


### PR DESCRIPTION
Bug/issue #, if applicable: 103087953

## Summary

Fixes an issue where empty new lines are not rendered properly.

![image](https://user-images.githubusercontent.com/9863944/208903466-673f0f02-9dae-4182-b4c9-afeec017739b.png)


## Dependencies

NA

## Testing

[codesample.json.zip](https://github.com/apple/swift-docc-render/files/10277532/codesample.json.zip)

Using the example JSON above, try to copy the text into your editor.

1. Assert there is a single new line when you paste
2. Assert this works across browsers
3. Assert it does not regress


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
