### PR TITLE
Fix `DeclarationSource` inserts newline at incorrect close parenthesis

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -114,7 +114,11 @@ export default {
             numUnclosedParens -= 1;
             // if this ")" balances out the number of "(" characters that have
             // been seen, this is the one that pairs up with the first one
-            if (openParenTokenIndex !== null && numUnclosedParens === 0) {
+            if (
+              openParenTokenIndex !== null
+              && closeParenTokenIndex == null
+              && numUnclosedParens === 0
+            ) {
               closeParenCharIndex = k;
               closeParenTokenIndex = i;
             }

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -121,6 +121,7 @@ export default {
             ) {
               closeParenCharIndex = k;
               closeParenTokenIndex = i;
+              break;
             }
           }
         }

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -281,6 +281,122 @@ describe('Swift function/initializer formatting', () => {
     expect(tokenComponents.at(15).props('text')).toBe('\n) -> ');
   });
 
+  it('breaks apart each param onto its own line for a tuple return type', () => {
+    // Before:
+    // func foo(_ a: A, _ b: B) -> (A, B)
+    //
+    // After:
+    // func foo(
+    //     _ a: A,
+    //     _ b: B,
+    // ) -> (A, B)
+    const tokens = [
+      {
+        kind: TokenKind.keyword,
+        text: 'func',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.identifier,
+        text: 'foo',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: '_',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.internalParam,
+        text: 'a',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        identifier: 'doc://com.example/documentation/blah/a',
+        text: 'A',
+      },
+      {
+        kind: TokenKind.text,
+        text: ', ',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: '_',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.internalParam,
+        text: 'b',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        identifier: 'doc://com.example/documentation/blah/b',
+        text: 'B',
+      },
+      {
+        kind: TokenKind.text,
+        text: ') -> (',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        identifier: 'doc://com.example/documentation/blah/a',
+        text: 'A',
+      },
+      {
+        kind: TokenKind.text,
+        text: ', ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        identifier: 'doc://com.example/documentation/blah/b',
+        text: 'B',
+      },
+      {
+        kind: TokenKind.text,
+        text: ')',
+      },
+    ];
+    const wrapper = mountWithTokens(tokens);
+
+    const tokenComponents = wrapper.findAll(Token);
+    expect(tokenComponents.length).toBe(tokens.length);
+
+    const modifiedTokenIndexes = new Set([3, 9, 15]);
+    tokens.forEach((token, i) => {
+      const tokenComponent = tokenComponents.at(i);
+      expect(tokenComponent.props('kind')).toBe(token.kind);
+      if (modifiedTokenIndexes.has(i)) {
+        expect(tokenComponent.props('text')).not.toBe(token.text);
+      } else {
+        expect(tokenComponent.props('text')).toBe(token.text);
+      }
+    });
+
+    expect(tokenComponents.at(3).props('text')).toBe('(\n    ');
+    expect(tokenComponents.at(9).props('text')).toBe(',\n    ');
+    expect(tokenComponents.at(15).props('text')).toBe('\n) -> (');
+  });
+
   it('breaks apart parameters in functions with generic where clauses', () => {
     /* eslint-disable max-len */
     // Before:


### PR DESCRIPTION
Bug/issue #, if applicable: #503

## Summary

`DeclarationSource`, when formatting for multi-param symbols, incorrectly identifies the last closing parenthesis of the entire declaration, rather than the closing parenthesis for the first opening parenthesis in the declaration.

To fix, we only set closing parenthesis index when it is previously `null`.

## Testing

1. Define a public structure/object that has a method which returns a tuple, i.e:
```swift
public struct DeclarationIndentationBug<A, B> {
    public static func foo(
        _ a: A,
        _ b: B
    ) -> (A, B) {
        return (a, b)
    }
}
```

2. Build a `.doccarchive`
3. Render the `.doccarchive` using `swift-docc-render`

### Outcome

| Before | After |
| --- | --- |
|<img alt="Before" src="https://user-images.githubusercontent.com/3253505/209383331-b203d52c-66f0-478c-a556-3bad73841afa.png">|<img alt="After" src="https://user-images.githubusercontent.com/3253505/209382160-8aada621-4d5c-45c1-9428-aea03f5c791b.png">|

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
