### PR TITLE
Select input text when opening Quick Navigation

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -71,6 +71,7 @@
               type="text"
               class="filter__input"
               v-on="inputMultipleSelectionListeners"
+              @focus="selectInputOnFocus && selectInputAndTags()"
               @keydown.down.prevent="downHandler"
               @keydown.up.prevent="upHandler"
               @keydown.left="leftKeyInputHandler"
@@ -196,6 +197,10 @@ export default {
       default: false,
     },
     focusInputWhenEmpty: {
+      type: Boolean,
+      default: false,
+    },
+    selectInputOnFocus: {
       type: Boolean,
       default: false,
     },

--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -30,6 +30,7 @@
           placeholder="Search symbols"
           focusInputWhenCreated
           focusInputWhenEmpty
+          selectInputOnFocus
           @input="focusedIndex = 0"
         >
           <template #icon>

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -222,6 +222,22 @@ describe('FilterInput', () => {
     expect(wrapper.emitted('input')).toEqual([['/']]);
   });
 
+  it('selects input on focus if `selectInputOnFocus` prop is true', async () => {
+    wrapper = shallowMount(FilterInput, {
+      propsData: {
+        ...propsData,
+        selectInputOnFocus: true,
+        value: inputValue,
+      },
+    });
+    input = wrapper.find('input');
+    jest.spyOn(wrapper.vm, 'selectInputAndTags').mockImplementation();
+    input.setValue(inputValue);
+    input.trigger('focus');
+    expect(wrapper.vm.selectInputAndTags).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.inputIsSelected()).toBeTruthy();
+  });
+
   describe('copy/paste', () => {
     let clipboardData = {};
 

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -232,7 +232,6 @@ describe('FilterInput', () => {
     });
     input = wrapper.find('input');
     jest.spyOn(wrapper.vm, 'selectInputAndTags').mockImplementation();
-    input.setValue(inputValue);
     input.trigger('focus');
     expect(wrapper.vm.selectInputAndTags).toHaveBeenCalledTimes(1);
     expect(wrapper.vm.inputIsSelected()).toBeTruthy();

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -275,6 +275,7 @@ describe('NavigatorCard', () => {
         'Tutorials',
       ],
       value: '',
+      selectInputOnFocus: false,
       clearFilterOnTagSelect: false,
     });
   });

--- a/tests/unit/components/Navigator/QuickNavigationModal.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationModal.spec.js
@@ -131,6 +131,7 @@ describe('QuickNavigationModal', () => {
       selectedTags: [],
       shouldTruncateTags: false,
       tags: [],
+      selectInputOnFocus: true,
       clearFilterOnTagSelect: true,
     });
   });


### PR DESCRIPTION
Bug/issue #490, if applicable: 

## Summary

With this implementation, the input text is automatically selected to overwrite it with a new query when reopening Quick Navigation after a previous search.

## Dependencies

N/A

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. Turn on the feature flag for Quick Navigation
2. Open the Quick Navigation search bar, type a query, and proceed to close it again
3. Open Quick Navigation and assert that the input text is selected

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary (N/A)
