### PR TITLE
Page should have a transparent background when `Minimized` is enabled

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -30,6 +30,7 @@ export default {
 
 .footer {
   border-top: 1px solid var(--color-grid);
+  background: var(--colors-text-background, var(--color-text-background));
 }
 
 .row {

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -21,7 +21,9 @@ html {
 
 body {
   @include font-styles(body);
-  background-color: var(--color-text-background);
+  @include inTargetWeb {
+    background-color: var(--color-text-background);
+  }
   color: var(--colors-text, var(--color-text));
   font-style: normal;
   word-wrap: break-word;

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -469,10 +469,6 @@ export default {
   }
 }
 
-.background-disabled {
-  background-color: transparent;
-}
-
 .doc-topic-view {
   --delay: 1s;
   display: flex;
@@ -483,6 +479,10 @@ export default {
     // don't hide navigator until delay time has passed
     transition: display var(--delay);
   }
+}
+
+.background-disabled {
+  background-color: transparent;
 }
 
 .doc-topic-aside {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -9,7 +9,11 @@
 -->
 
 <template>
-  <CodeTheme class="doc-topic-view">
+  <CodeTheme
+    :class="['doc-topic-view', {
+      'background-disabled': enableMinimized,
+    }]"
+  >
     <template v-if="topicData">
       <component
         :is="enableNavigator ? 'AdjustableSidebarWidth' : 'StaticContentWidth'"
@@ -463,6 +467,10 @@ export default {
     max-width: rem(800px);
     overflow: visible;
   }
+}
+
+.background-disabled {
+  background-color: transparent;
 }
 
 .doc-topic-view {


### PR DESCRIPTION
Bug/issue #, if applicable: 103150955

## Summary
Documentation pages should have a transparent background when the prop `enableMinimized` is set to true

## Testing
Steps:
1. Manually verify that the background is set to transparent in both light and dark modes.
2. Verify that no regression is introduced when Minimized mode is not enabled. Make sure to scroll further up when the page is already at the top, and scroll further down when the page is already at the bottom.