### PR TITLE
`Minimized` style updates

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -17,6 +17,7 @@
       <DocumentationHero
         :role="role"
         :enhanceBackground="enhanceBackground"
+        :enableMinimized="enableMinimized"
         :shortHero="shortHero"
         :shouldShowLanguageSwitcher="shouldShowLanguageSwitcher"
         :iconOverride="references[pageIcon]"
@@ -40,7 +41,12 @@
             :data-tag-name="tagName"
           />
         </Title>
-        <Abstract v-if="abstract" :content="abstract" />
+        <LinkableHeading v-else class="minimized-summary">Summary</LinkableHeading>
+        <Abstract
+          v-if="abstract"
+          :class="{ 'minimized-abstract': enableMinimized }"
+          :content="abstract"
+        />
         <div v-if="sampleCodeDownload">
           <DownloadButton class="sample-download" :action="sampleCodeDownload.action" />
         </div>
@@ -124,6 +130,7 @@ import DocumentationHero from 'docc-render/components/DocumentationTopic/Documen
 import WordBreak from 'docc-render/components/WordBreak.vue';
 import { TopicSectionsStyle } from 'docc-render/constants/TopicSectionsStyle';
 import OnThisPageNav from 'theme/components/OnThisPageNav.vue';
+import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
 import Abstract from './DocumentationTopic/Description/Abstract.vue';
 import ContentNode from './DocumentationTopic/ContentNode.vue';
 import CallToActionButton from './CallToActionButton.vue';
@@ -163,6 +170,7 @@ export default {
     OnThisPageStickyContainer,
     OnThisPageNav,
     DocumentationHero,
+    LinkableHeading,
     Abstract,
     Aside,
     BetaLegalText,
@@ -486,6 +494,13 @@ export default {
       flex: 1;
     }
   }
+}
+
+.minimized-summary {
+  @include font-styles(heading-2);
+}
+.minimized-abstract {
+  @include font-styles(body);
 }
 
 .container {

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -32,7 +32,8 @@
           :objcPath="objcPath"
           :swiftPath="swiftPath"
         />
-        <Title :eyebrow="roleHeading" v-if="!enableMinimized">
+        <LinkableHeading v-if="enableMinimized" class="minimized-summary">Summary</LinkableHeading>
+        <Title v-else :eyebrow="roleHeading">
           <component :is="titleBreakComponent">{{ title }}</component>
           <small
             v-if="isSymbolDeprecated || isSymbolBeta"
@@ -41,7 +42,6 @@
             :data-tag-name="tagName"
           />
         </Title>
-        <LinkableHeading v-else class="minimized-summary">Summary</LinkableHeading>
         <Abstract
           v-if="abstract"
           :class="{ 'minimized-abstract': enableMinimized }"

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -29,8 +29,9 @@
     </div>
     <div
       class="documentation-hero__content"
-      :class="{ 'short-hero': shortHero, 'extra-bottom-padding': shouldShowLanguageSwitcher }"
-    >
+      :class="{ 'short-hero': shortHero,
+        'extra-bottom-padding': shouldShowLanguageSwitcher,
+        'minimized-hero': enableMinimized }">
       <slot />
     </div>
   </div>
@@ -54,6 +55,10 @@ export default {
     enhanceBackground: {
       type: Boolean,
       required: true,
+    },
+    enableMinimized: {
+      type: Boolean,
+      default: false,
     },
     shortHero: {
       type: Boolean,
@@ -179,6 +184,11 @@ $doc-hero-icon-dimension: 250px;
     position: relative;
     z-index: 1;
     @include dynamic-content-container;
+  }
+
+  .minimized-hero {
+    padding-top: rem(20px);
+    padding-bottom: 0;
   }
 
   &__above-content {

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -15,7 +15,9 @@
 /// The base/default font-size for the html element in browsers is 16px.
 /// This makes the base font-size match our $-base-font-size.
 html {
-  font: var(--typography-html-font, $body-font-size $font-content);
+  @include inTargetWeb {
+    font: var(--typography-html-font, $body-font-size $font-content);
+  }
   quotes: "“" "”";
 }
 

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -33,6 +33,7 @@ const {
   SeeAlso,
   Topics,
   Title,
+  LinkableHeading,
   BetaLegalText,
   WordBreak,
 } = DocumentationTopic.components;
@@ -242,6 +243,7 @@ describe('DocumentationTopic', () => {
     expect(hero.props()).toEqual({
       role: propsData.role,
       enhanceBackground: true,
+      enableMinimized: false,
       shortHero: false,
       shouldShowLanguageSwitcher: false,
       iconOverride,
@@ -257,6 +259,7 @@ describe('DocumentationTopic', () => {
     expect(hero.props()).toEqual({
       role: propsData.role,
       enhanceBackground: true,
+      enableMinimized: false,
       shortHero: false,
       shouldShowLanguageSwitcher: false,
       iconOverride: undefined,
@@ -268,6 +271,7 @@ describe('DocumentationTopic', () => {
     expect(hero.props()).toEqual({
       role: TopicTypes.collection,
       enhanceBackground: true,
+      enableMinimized: false,
       shortHero: false,
       shouldShowLanguageSwitcher: false,
     });
@@ -298,6 +302,7 @@ describe('DocumentationTopic', () => {
     expect(hero.props()).toEqual({
       role: 'symbol',
       enhanceBackground: false,
+      enableMinimized: false,
       shortHero: false,
       shouldShowLanguageSwitcher: false,
     });
@@ -331,6 +336,13 @@ describe('DocumentationTopic', () => {
     // Minimized view should not render Title
     wrapper.setProps({ enableMinimized: true });
     expect(wrapper.find(DocumentationHero).find(Title).exists()).toBe(false);
+  });
+
+  it('renders a `LinkableHeading`, in minimized mode, if `enableMinimized` prop is `true`', () => {
+    const heading = wrapper.find(LinkableHeading);
+    expect(heading.exists()).toBe(false);
+    wrapper.setProps({ enableMinimized: true });
+    expect(wrapper.find(LinkableHeading).exists()).toBe(true);
   });
 
   it('uses `WordBreak` in the title for symbol pages', () => {

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -18,6 +18,7 @@ import { TopicRole } from '@/constants/roles';
 const defaultProps = {
   role: TopicTypes.class,
   enhanceBackground: true,
+  enableMinimized: false,
   shortHero: true,
   shouldShowLanguageSwitcher: true,
   iconOverride: { variants: ['foo'] },
@@ -91,6 +92,18 @@ describe('DocumentationHero', () => {
       shouldShowLanguageSwitcher: false,
     });
     expect(content.classes()).not.toContain('extra-bottom-padding');
+  });
+
+  it('renders the right classes based on `enableMininized` prop', () => {
+    const wrapper = createWrapper();
+    const content = wrapper.find('.documentation-hero__content');
+
+    expect(content.classes()).not.toContain('minimized-hero');
+
+    wrapper.setProps({
+      enableMinimized: true,
+    });
+    expect(content.classes()).toContain('minimized-hero');
   });
 
   it('finds aliases, for the color', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 103150108

## Summary
This PR covers some style updates for minimized.

## Testing
Steps:
1. Manually verify that the following items are achieved when the prop `enableMinimized` is set to true:
- Use "Summary" as the heading for abstracts
- Remove extra padding at the bottom of hero section
2. Verify that we now allow browsers to set the default font size when the target is IDE (Here's the [Draft PR](https://github.com/apple/swift-docc-render/pull/500) from earlier)
