### PR TITLE
[5.8] Fix whitespace formatting of multi-param Swift functions that return tuples

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -114,9 +114,14 @@ export default {
             numUnclosedParens -= 1;
             // if this ")" balances out the number of "(" characters that have
             // been seen, this is the one that pairs up with the first one
-            if (openParenTokenIndex !== null && numUnclosedParens === 0) {
+            if (
+              openParenTokenIndex !== null
+              && closeParenTokenIndex == null
+              && numUnclosedParens === 0
+            ) {
               closeParenCharIndex = k;
               closeParenTokenIndex = i;
+              break;
             }
           }
         }

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -281,6 +281,122 @@ describe('Swift function/initializer formatting', () => {
     expect(tokenComponents.at(15).props('text')).toBe('\n) -> ');
   });
 
+  it('breaks apart each param onto its own line for a tuple return type', () => {
+    // Before:
+    // func foo(_ a: A, _ b: B) -> (A, B)
+    //
+    // After:
+    // func foo(
+    //     _ a: A,
+    //     _ b: B,
+    // ) -> (A, B)
+    const tokens = [
+      {
+        kind: TokenKind.keyword,
+        text: 'func',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.identifier,
+        text: 'foo',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: '_',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.internalParam,
+        text: 'a',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        identifier: 'doc://com.example/documentation/blah/a',
+        text: 'A',
+      },
+      {
+        kind: TokenKind.text,
+        text: ', ',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: '_',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.internalParam,
+        text: 'b',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        identifier: 'doc://com.example/documentation/blah/b',
+        text: 'B',
+      },
+      {
+        kind: TokenKind.text,
+        text: ') -> (',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        identifier: 'doc://com.example/documentation/blah/a',
+        text: 'A',
+      },
+      {
+        kind: TokenKind.text,
+        text: ', ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        identifier: 'doc://com.example/documentation/blah/b',
+        text: 'B',
+      },
+      {
+        kind: TokenKind.text,
+        text: ')',
+      },
+    ];
+    const wrapper = mountWithTokens(tokens);
+
+    const tokenComponents = wrapper.findAll(Token);
+    expect(tokenComponents.length).toBe(tokens.length);
+
+    const modifiedTokenIndexes = new Set([3, 9, 15]);
+    tokens.forEach((token, i) => {
+      const tokenComponent = tokenComponents.at(i);
+      expect(tokenComponent.props('kind')).toBe(token.kind);
+      if (modifiedTokenIndexes.has(i)) {
+        expect(tokenComponent.props('text')).not.toBe(token.text);
+      } else {
+        expect(tokenComponent.props('text')).toBe(token.text);
+      }
+    });
+
+    expect(tokenComponents.at(3).props('text')).toBe('(\n    ');
+    expect(tokenComponents.at(9).props('text')).toBe(',\n    ');
+    expect(tokenComponents.at(15).props('text')).toBe('\n) -> (');
+  });
+
   it('breaks apart parameters in functions with generic where clauses', () => {
     /* eslint-disable max-len */
     // Before:


### PR DESCRIPTION
- **Explanation:** Fixes bug where whitespace formatting of Swift multi-param functions returning tuple types does not look right
- **Scope:** Small JS change that improves small subset of Swift symbol pages
- **Issue:** #503 (rdar://103841947)
- **Risk:** Small potential for regressions of Swift declaration whitespace formatting
- **Testing:** Added unit test and visually inspected formatting of Swift symbol declarations, verified that multi-param functions with tuple return types look to be improved and no obvious regressions for other symbols
- **Reviewer:** @mportiz08 
- **Original PR:** #504