### PR TITLE
[5.8] Localnav without navigator should take up full space.

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -15,31 +15,33 @@
     hasSolidBackground
     :hasNoBorder="hasNoBorder"
     :isDark="isDark"
-    :isWideFormat="isWideFormat"
+    isWideFormat
     hasFullWidthBorder
     class="documentation-nav"
     aria-label="API Reference"
   >
-    <template #pre-title="{ closeNav, isOpen, currentBreakpoint }" v-if="isWideFormat">
-      <transition name="sidenav-toggle">
-        <div
-          v-show="sidenavHiddenOnLarge"
-          class="sidenav-toggle-wrapper"
-        >
-          <button
-            aria-label="Open documentation navigator"
-            :id="baseNavOpenSidenavButtonId"
-            class="sidenav-toggle"
-            :tabindex="isOpen ? -1 : null"
-            @click.prevent="handleSidenavToggle(closeNav, currentBreakpoint)"
+    <template #pre-title="{ closeNav, isOpen, currentBreakpoint, className }" v-if="displaySidenav">
+      <div :class="className">
+        <transition name="sidenav-toggle">
+          <div
+            v-show="sidenavHiddenOnLarge"
+            class="sidenav-toggle-wrapper"
           >
-          <span class="sidenav-icon-wrapper">
-            <SidenavIcon class="icon-inline sidenav-icon" />
-          </span>
-          </button>
-          <span class="sidenav-toggle__separator" />
-        </div>
-      </transition>
+            <button
+              aria-label="Open documentation navigator"
+              :id="baseNavOpenSidenavButtonId"
+              class="sidenav-toggle"
+              :tabindex="isOpen ? -1 : null"
+              @click.prevent="handleSidenavToggle(closeNav, currentBreakpoint)"
+            >
+            <span class="sidenav-icon-wrapper">
+              <SidenavIcon class="icon-inline sidenav-icon" />
+            </span>
+            </button>
+            <span class="sidenav-toggle__separator" />
+          </div>
+        </transition>
+      </div>
     </template>
     <template slot="default">
       <slot
@@ -138,10 +140,6 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    isWideFormat: {
-      type: Boolean,
-      default: true,
-    },
     interfaceLanguage: {
       type: String,
       required: false,
@@ -155,6 +153,10 @@ export default {
       required: false,
     },
     sidenavHiddenOnLarge: {
+      type: Boolean,
+      default: false,
+    },
+    displaySidenav: {
       type: Boolean,
       default: false,
     },

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -19,9 +19,11 @@
       <div class="nav__background" />
       <div v-if="hasOverlay" class="nav-overlay" @click="closeNav" />
       <div class="nav-content">
-        <div class="pre-title">
-          <slot name="pre-title" v-bind="{ closeNav, inBreakpoint, currentBreakpoint, isOpen }" />
-        </div>
+        <slot
+          name="pre-title"
+          className="pre-title"
+          v-bind="{ closeNav, inBreakpoint, currentBreakpoint, isOpen }"
+        />
         <div v-if="$slots.default" class="nav-title">
           <slot />
         </div>
@@ -670,6 +672,17 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   }
 }
 
+.pre-title + .nav-title {
+  @include nav-in-breakpoint {
+    grid-area: title;
+
+    @include nav-is-wide-format(true) {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+}
+
 .nav-title {
   height: $nav-height;
   @include font-styles(nav-title);
@@ -683,15 +696,6 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
     padding-top: 0;
     height: $nav-height-small;
     width: 90%;
-  }
-
-  @include nav-in-breakpoint {
-    grid-area: title;
-
-    @include nav-is-wide-format(true) {
-      width: 100%;
-      justify-content: center;
-    }
   }
 
   /deep/ span {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -15,6 +15,7 @@
         :is="enableNavigator ? 'AdjustableSidebarWidth' : 'StaticContentWidth'"
         v-bind="sidebarProps"
         v-on="sidebarListeners"
+        class="full-width-container topic-wrapper"
       >
         <PortalTarget name="modal-destination" multiple />
         <template #aside="{ scrollLockID, breakpoint }">
@@ -63,7 +64,7 @@
           :isSymbolBeta="isSymbolBeta"
           :currentTopicTags="topicProps.tags"
           :references="topicProps.references"
-          :isWideFormat="enableNavigator"
+          :displaySidenav="enableNavigator"
           :sidenavHiddenOnLarge="sidenavHiddenOnLarge"
           @toggle-sidenav="handleToggleSidenav"
         >
@@ -323,11 +324,10 @@ export default {
     sidebarProps: ({ sidenavVisibleOnMobile, enableNavigator, sidenavHiddenOnLarge }) => (
       enableNavigator
         ? {
-          class: 'full-width-container topic-wrapper',
           shownOnMobile: sidenavVisibleOnMobile,
           hiddenOnLarge: sidenavHiddenOnLarge,
         }
-        : { class: 'static-width-container topic-wrapper' }
+        : {}
     ),
     sidebarListeners() {
       return this.enableNavigator ? ({

--- a/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationNav.spec.js
@@ -67,6 +67,7 @@ describe('DocumentationNav', () => {
     swiftPath: 'documentation/foo',
     objcPath: 'documentation/bar',
     references,
+    displaySidenav: true,
   };
 
   beforeEach(() => {
@@ -310,12 +311,12 @@ describe('DocumentationNav', () => {
     window.Event = backup;
   });
 
-  it('renders the nav, with `isWideFormat` to `false`', () => {
+  it('does not render the sidenav toggle if displaySidenav is false', () => {
     wrapper.setProps({
-      isWideFormat: false,
+      displaySidenav: false,
     });
     expect(wrapper.find(NavBase).props()).toMatchObject({
-      isWideFormat: false,
+      isWideFormat: true,
       breakpoint: BreakpointName.medium,
     });
     expect(wrapper.find('.sidenav-toggle').exists()).toBe(false);

--- a/tests/unit/components/NavBase.spec.js
+++ b/tests/unit/components/NavBase.spec.js
@@ -154,10 +154,9 @@ describe('NavBase', () => {
         },
       },
     });
-    const preTitle = wrapper.find('.pre-title');
-    expect(preTitle.exists()).toBe(true);
-    expect(preTitle.find('.pre-title-slot').text()).toBe('Pre Title');
+    expect(wrapper.find('.pre-title-slot').text()).toBe('Pre Title');
     expect(preTitleProps).toEqual({
+      className: 'pre-title',
       closeNav: expect.any(Function),
       isOpen: false,
       inBreakpoint: false,
@@ -166,6 +165,7 @@ describe('NavBase', () => {
     wrapper.find('a.nav-menucta').trigger('click');
     expect(wrapper.classes()).toContain(NavStateClasses.isOpen);
     expect(preTitleProps).toEqual({
+      className: 'pre-title',
       closeNav: expect.any(Function),
       isOpen: true,
       inBreakpoint: false,
@@ -174,6 +174,7 @@ describe('NavBase', () => {
     preTitleProps.closeNav();
     expect(wrapper.classes()).not.toContain(NavStateClasses.isOpen);
     expect(preTitleProps).toEqual({
+      className: 'pre-title',
       closeNav: expect.any(Function),
       isOpen: false,
       inBreakpoint: false,

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -246,7 +246,7 @@ describe('DocumentationTopic', () => {
     });
     // assert the nav is in wide format
     const nav = wrapper.find(Nav);
-    expect(nav.props('isWideFormat')).toBe(true);
+    expect(nav.props('displaySidenav')).toBe(true);
   });
 
   it('renders QuickNavigation and MagnifierIcon if enableQuickNavigation is true', () => {
@@ -523,10 +523,10 @@ describe('DocumentationTopic', () => {
       isDark: false,
       hasNoBorder: false,
       currentTopicTags: [],
+      displaySidenav: false,
       references: topicData.references,
       isSymbolBeta: false,
       isSymbolDeprecated: false,
-      isWideFormat: false,
       interfaceLanguage: topicData.identifier.interfaceLanguage,
       objcPath: topicData.variants[0].paths[0],
       swiftPath: topicData.variants[1].paths[0],
@@ -545,7 +545,7 @@ describe('DocumentationTopic', () => {
     expect(wrapper.find(Navigator).exists()).toBe(false);
     // assert the proper container class is applied
     expect(staticContentWidth.classes())
-      .toEqual(expect.arrayContaining(['topic-wrapper', 'static-width-container']));
+      .toEqual(expect.arrayContaining(['topic-wrapper', 'full-width-container']));
   });
 
   it('renders without NavigatorDataProvider', async () => {


### PR DESCRIPTION
- **Explanation:** Localnav without navigator should take up full space
- **Scope:** Only users who have navigator disabled
- **Issue:** (rdar://103256123)
- **Risk:** Small potential for UI regressions in the navigator
- **Testing:** Manual testing since changes affect the UI only
- **Reviewer:** @mportiz08 @dobromir-hristov
- **Original PR:** #499 