### PR TITLE
[5.8] Minimized mode should display less content

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -31,7 +31,7 @@
           :objcPath="objcPath"
           :swiftPath="swiftPath"
         />
-        <Title :eyebrow="roleHeading">
+        <Title :eyebrow="roleHeading" v-if="!enableMinimized">
           <component :is="titleBreakComponent">{{ title }}</component>
           <small
             v-if="isSymbolDeprecated || isSymbolBeta"
@@ -45,7 +45,7 @@
           <DownloadButton class="sample-download" :action="sampleCodeDownload.action" />
         </div>
         <Availability
-          v-if="hasAvailability"
+          v-if="shouldShowAvailability"
           :platforms="platforms" :technologies="technologies"
         />
       </DocumentationHero>
@@ -69,7 +69,7 @@
             </div>
             <PrimaryContent
               v-if="primaryContentSections && primaryContentSections.length"
-              :class="{ 'with-border': !enhanceBackground }"
+              :class="{ 'with-border': !enhanceBackground && !enableMinimized }"
               :conformance="conformance"
               :source="remoteSource"
               :sections="primaryContentSections"
@@ -83,16 +83,19 @@
             :topicStyle="topicSectionsStyle"
           />
           <DefaultImplementations
-            v-if="defaultImplementationsSections"
+            v-if="defaultImplementationsSections && !enableMinimized"
             :sections="defaultImplementationsSections"
             :isSymbolDeprecated="isSymbolDeprecated"
             :isSymbolBeta="isSymbolBeta"
           />
-          <Relationships v-if="relationshipsSections" :sections="relationshipsSections" />
+          <Relationships
+            v-if="relationshipsSections && !enableMinimized"
+            :sections="relationshipsSections"
+          />
           <!-- NOTE: see also may contain information about other apis, so we cannot
           pass deprecation and beta information -->
           <SeeAlso
-            v-if="seeAlsoSections"
+            v-if="seeAlsoSections && !enableMinimized"
             :sections="seeAlsoSections"
           />
         </div>
@@ -301,6 +304,10 @@ export default {
       type: Array,
       required: false,
     },
+    enableMinimized: {
+      type: Boolean,
+      default: false,
+    },
     enableOnThisPageNav: {
       type: Boolean,
       default: false,
@@ -333,8 +340,8 @@ export default {
         0,
       );
     },
-    hasAvailability: ({ platforms, technologies }) => (
-      (platforms || []).length || (technologies || []).length
+    shouldShowAvailability: ({ platforms, technologies, enableMinimized }) => (
+      ((platforms || []).length || (technologies || []).length) && !enableMinimized
     ),
     hasBetaContent:
       ({ platforms }) => platforms
@@ -344,8 +351,13 @@ export default {
     pageDescription: ({ abstract, extractFirstParagraphText }) => (
       abstract ? extractFirstParagraphText(abstract) : null
     ),
-    shouldShowLanguageSwitcher: ({ objcPath, swiftPath, isTargetIDE }) => (
-      !!(objcPath && swiftPath && isTargetIDE)
+    shouldShowLanguageSwitcher: ({
+      objcPath,
+      swiftPath,
+      isTargetIDE,
+      enableMinimized,
+    }) => (
+      !!(objcPath && swiftPath && isTargetIDE) && !enableMinimized
     ),
     enhanceBackground: ({ symbolKind, disableHeroBackground, topicSectionsStyle }) => {
       if (
@@ -409,7 +421,8 @@ export default {
     shouldRenderTopicSection: ({
       topicSectionsStyle,
       topicSections,
-    }) => topicSections && topicSectionsStyle !== TopicSectionsStyle.hidden,
+      enableMinimized,
+    }) => topicSections && topicSectionsStyle !== TopicSectionsStyle.hidden && !enableMinimized,
     isOnThisPageNavVisible: ({ topicState }) => (
       topicState.contentWidth > ON_THIS_PAGE_CONTAINER_BREAKPOINT
     ),

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -88,6 +88,7 @@
           :isSymbolBeta="isSymbolBeta"
           :languagePaths="languagePaths"
           :enableOnThisPageNav="enableOnThisPageNav"
+          :enableMinimized="enableMinimized"
         />
       </component>
     </template>
@@ -142,6 +143,12 @@ export default {
     MagnifierIcon,
   },
   mixins: [communicationBridgeUtils, onPageLoadScrollToFragment, OnThisPageRegistrator],
+  props: {
+    enableMinimized: {
+      type: Boolean,
+      default: false,
+    },
+  },
   data() {
     return {
       topicDataDefault: null,

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -327,6 +327,10 @@ describe('DocumentationTopic', () => {
     expect(title.props('eyebrow')).toBe(propsData.roleHeading);
     expect(title.text()).toBe(propsData.title);
     expect(title.find(WordBreak).exists()).toBe(false);
+
+    // Minimized view should not render Title
+    wrapper.setProps({ enableMinimized: true });
+    expect(wrapper.find(DocumentationHero).find(Title).exists()).toBe(false);
   });
 
   it('uses `WordBreak` in the title for symbol pages', () => {
@@ -474,6 +478,10 @@ describe('DocumentationTopic', () => {
       const list = wrapper.find(Availability);
       expect(list.exists()).toBe(true);
       expect(list.props('platforms')).toEqual(propsData.platforms);
+
+      // Minimized view should not render Availability
+      wrapper.setProps({ enableMinimized: true });
+      expect(wrapper.find(Availability).exists()).toBe(false);
     });
   });
 
@@ -501,6 +509,10 @@ describe('DocumentationTopic', () => {
       objcPath: propsData.languagePaths.occ[0],
       swiftPath: propsData.languagePaths.swift[0],
     });
+
+    // Minimized view should not render LanguageSwitcher
+    wrapper.setProps({ enableMinimized: true });
+    expect(wrapper.find(LanguageSwitcher).exists()).toBe(false);
   });
 
   it('renders `Topics` if there are topic sections, passing the `topicSectionsStyle` over', () => {
@@ -525,6 +537,10 @@ describe('DocumentationTopic', () => {
     expect(topics.exists()).toBe(true);
     expect(topics.props('sections')).toBe(topicSections);
     expect(topics.props('topicStyle')).toBe(TopicSectionsStyle.detailedGrid);
+
+    // Minimized view should not render Topics
+    wrapper.setProps({ enableMinimized: true });
+    expect(wrapper.find(Topics).exists()).toBe(false);
   });
 
   it('does not render the `Topics` if the `topicSectionsStyle` is `hidden`', () => {
@@ -559,6 +575,10 @@ describe('DocumentationTopic', () => {
     const seeAlso = wrapper.find(SeeAlso);
     expect(seeAlso.exists()).toBe(true);
     expect(seeAlso.props('sections')).toBe(seeAlsoSections);
+
+    // Minimized view should not render See Also
+    wrapper.setProps({ enableMinimized: true });
+    expect(wrapper.find(SeeAlso).exists()).toBe(false);
   });
 
   it('renders `Relationships` if there are relationship sections', () => {
@@ -584,6 +604,10 @@ describe('DocumentationTopic', () => {
     const relationships = wrapper.find(Relationships);
     expect(relationships.exists()).toBe(true);
     expect(relationships.props('sections')).toBe(relationshipsSections);
+
+    // Minimized view should not render Relationships
+    wrapper.setProps({ enableMinimized: true });
+    expect(wrapper.find(Relationships).exists()).toBe(false);
   });
 
   it('renders `Relationships` before `SeeAlso`', () => {
@@ -636,6 +660,10 @@ describe('DocumentationTopic', () => {
     const defaults = wrapper.find(DefaultImplementations);
     expect(defaults.exists()).toBe(true);
     expect(defaults.props('sections')).toEqual(defaultImplementationsSections);
+
+    // Minimized view should not render DefaultImplementations
+    wrapper.setProps({ enableMinimized: true });
+    expect(wrapper.find(DefaultImplementations).exists()).toBe(false);
   });
 
   it('computes isSymbolBeta', () => {

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -667,6 +667,7 @@ describe('DocumentationTopic', () => {
         swift: ['documentation/swift'],
       },
       enableOnThisPageNav: true, // enabled by default
+      enableMinimized: false, // disabled by default
       topicSectionsStyle: TopicSectionsStyle.list, // default value
       disableHeroBackground: false,
     });


### PR DESCRIPTION
- **Explanation:** Removing unneeded content originally displayed for documentation pages for minimized mode
- **Scope:** Small changes made to conditionally display content on the documentation page.
- **Issue:** rdar://103149476
- **Risk:** Small risk for regressions of contents displayed on Documentation pages
- **Testing:** Tested for regressions via existing unit tests, added new unit tests for the minimized mode.
- **Reviewer:** @mportiz08 
- **Original PR:** #498 