### PR TITLE
Ensure scrollbar is visually clipped by code listings with round borders in Safari

### DIFF
--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -187,11 +187,20 @@ code {
   flex-direction: column;
   min-height: 100%;
   border-radius: var(--code-border-radius, $border-radius);
-  overflow: auto;
+  overflow: hidden;
+  // this mask image is not actually used for any visual effect since there is
+  // no background being used on this element—however, we need this in order to
+  // establish a new stacking context, which resolves a Safari bug where the
+  // scrollbar is not clipped by this element depending on its border-radius
+  -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
 
   &.single-line {
     border-radius: $large-border-radius;
   }
+}
+
+.container-general {
+  overflow: auto;
 }
 
 .container-general,

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -200,6 +200,11 @@ $docs-declaration-source-border-width: 1px !default;
   padding: $code-block-style-elements-padding;
   speak: literal-punctuation;
   line-height: 25px;
+  // this mask image is not actually used for any visual effect since there is
+  // no background being used on this element—however, we need this in order to
+  // establish a new stacking context, which resolves a Safari bug where the
+  // scrollbar is not clipped by this element depending on its border-radius
+  -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
 
   &.has-multiple-lines {
     border-radius: $border-radius;


### PR DESCRIPTION
Bug/issue #, if applicable: 104043983

## Summary

This fixes an issue In Safari where the browser scrollbar UI is not being visually clipped by rounded borders of code listings. 

By default, code listings don't have a round enough border for this problem to be observed, but it could present itself with an updated theme with a larger border radius for these elements.

### Example

Before:
<img width="50" alt="Screenshot 2023-01-10 at 3 25 46 PM" src="https://user-images.githubusercontent.com/212918/211684293-fd535031-3666-47bb-9890-d6c405636ff4.png">

After:
<img width="50" alt="Screenshot 2023-01-10 at 3 27 04 PM" src="https://user-images.githubusercontent.com/212918/211684318-446f40b3-72ac-4f6b-a21d-8590cd12cb85.png">

## Testing

Steps:
1. Configure the global macOS setting as follows ` / System Settings... / Appearance / Show scroll bars` to `"Always"`
2. Run `env VUE_APP_DEV_SERVER_PROXY=https://mportiz08.github.io/swift-docc npm run serve` or run this branch with any other example content
3. Increase the default border-radii settings for testing purposes. A quick/easy way is to open the inspector and click the `<body>` element—then you can directly add the following CSS variables to it `--border-radius: 15px;`, `--code-border-radius: 15px;` (this bug can't be seen without doing this)
4. Find code listings that scroll horizontally (or make them scroll by changing the size of the window/sidebar) and ensure that the scrollbar isn't extending past the rounded corners.
5. Test with other browsers and ensure that there aren't any obvious regressions from these changes.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
