### PR TITLE
[5.8] Ensure scrollbar is visually clipped by code listings with round borders in Safari

### DIFF
--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -187,11 +187,20 @@ code {
   flex-direction: column;
   min-height: 100%;
   border-radius: var(--code-border-radius, $border-radius);
-  overflow: auto;
+  overflow: hidden;
+  // this mask image is not actually used for any visual effect since there is
+  // no background being used on this element—however, we need this in order to
+  // establish a new stacking context, which resolves a Safari bug where the
+  // scrollbar is not clipped by this element depending on its border-radius
+  -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
 
   &.single-line {
     border-radius: $large-border-radius;
   }
+}
+
+.container-general {
+  overflow: auto;
 }
 
 .container-general,

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -200,6 +200,11 @@ $docs-declaration-source-border-width: 1px !default;
   padding: $code-block-style-elements-padding;
   speak: literal-punctuation;
   line-height: 25px;
+  // this mask image is not actually used for any visual effect since there is
+  // no background being used on this element—however, we need this in order to
+  // establish a new stacking context, which resolves a Safari bug where the
+  // scrollbar is not clipped by this element depending on its border-radius
+  -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
 
   &.has-multiple-lines {
     border-radius: $border-radius;


### PR DESCRIPTION
- **Explanation:** Fixes bug where native scrollbar UI may extend beyond rounded corners of code listings in Safari
- **Scope:** Safari only, only impacts themes with more rounded corners of code listings, small/focused CSS only fix
- **Issue:** rdar://104043983
- **Risk:** Small potential for regression in visual of code listings that scroll
- **Testing:** Visual inspection to ensure scrollbar UI is contained in declarations and code listings, tested various code listings for any regressions.
- **Reviewer:** @dobromir-hristov 
- **Original PR:** #514 