### PR TITLE
Fix issue with calculating language toggle width in Safari Tech Preview

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
+++ b/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
@@ -18,7 +18,7 @@
         aria-hidden="true"
         tabindex="-1"
       >
-        <option selected>{{ currentLanguage.name }}</option>
+        <option :key="currentLanguage.name" selected>{{ currentLanguage.name }}</option>
       </select>
       <label
         :for="hasLanguages ? 'language-toggle' : null"


### PR DESCRIPTION
Bug/issue #, if applicable: 104194977

## Summary

In the latest Safari Technology Preview, the language toggle is not being re-sized as expected when toggling between languages.

This seems to be an issue with the combination of this new browser and Vue where an invisible HTML `<option>` element is not being properly updated like it should when the toggle is used. Adding a `key` attribute fixes this, because it forces Vue to not attempt to re-use the same element for unique language choices.

With the option element updating properly, the appropriate size for the dropdown can be calculated, and the visual issue is resolved.

## Testing

Requirements:
1. Find content that supports both Swift and Objective-C
2. Download the latest [Safari Technology Preview](https://developer.apple.com/safari/technology-preview/) so the bug and its fix can be observed (does not seem to happen in normal Safari yet)

Steps:
1. Find an example page that has a language toggle
2. Use the toggle and verify that it gets sized appropriately and no text is cut off—it should grow to accommodate the text "Objective-C" when initially toggled and shrink when toggled back to "Swift"

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
