### PR TITLE
Quick Navigation default enablement

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -173,7 +173,7 @@ export default {
       return objcVariant ? objcVariant.patch : null;
     },
     enableQuickNavigation: ({ isTargetIDE }) => (
-      !isTargetIDE && getSetting(['features', 'docs', 'quickNavigation', 'enable'], false)
+      !isTargetIDE && getSetting(['features', 'docs', 'quickNavigation', 'enable'], true)
     ),
     topicData: {
       get() {


### PR DESCRIPTION
Bug/issue #, if applicable:  N/A

## Summary

Introduce quick navigation as a default feature in docc-render by defaulting `getSetting` for the `enableQuickNavigation` function to true, still working as a customization point through a theme settings file.

## Dependencies

N/A

## Testing

Steps:
1. Render any archive without a theme file
2. Assert that Quick Navigation is enabled

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests (N/A)
- [X] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary (N/A)
