### PR TITLE
[5.8] Quick Navigation default enablement 

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -173,7 +173,7 @@ export default {
       return objcVariant ? objcVariant.patch : null;
     },
     enableQuickNavigation: ({ isTargetIDE }) => (
-      !isTargetIDE && getSetting(['features', 'docs', 'quickNavigation', 'enable'], false)
+      !isTargetIDE && getSetting(['features', 'docs', 'quickNavigation', 'enable'], true)
     ),
     topicData: {
       get() {


### PR DESCRIPTION
- **Explanation:** Introduce quick navigation as a default feature in docc-render by defaulting `getSetting` for the `enableQuickNavigation` function to true, still working as a customization point through a theme settings file (https://forums.swift.org/t/quick-navigation-enablement-request/62523)
- **Scope:** New feature for all docs
- **Issue:** N/A
- **Risk:** 
- **Testing:** Render any archive without a theme file and assert that Quick Navigation is enabled
- **Reviewer:** @franklinsch 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/518
