### PR TITLE
[5.8] Fix Safari bug with language toggle width

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
+++ b/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
@@ -18,7 +18,7 @@
         aria-hidden="true"
         tabindex="-1"
       >
-        <option selected>{{ currentLanguage.name }}</option>
+        <option :key="currentLanguage.name" selected>{{ currentLanguage.name }}</option>
       </select>
       <label
         :for="hasLanguages ? 'language-toggle' : null"


### PR DESCRIPTION
- **Explanation:** Fixes bug where language toggle does not resize properly in preview versions of Safari.
- **Scope:** Safari Tech Preview only, minor Vue/HTML markup change that only impacts pages that support Swift/Objective-C when toggling
- **Issue:** rdar://104194977
- **Risk:** May impact the visual appearance of the language toggle
- **Testing:** Visual inspection in various browsers, including the problematic scenario with Safari Technology Preview
- **Reviewer:** @dobromir-hristov 
- **Original PR:** #517  