### PR TITLE
Make sure ParametersTable with changes has equal width columns

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/ParametersTable.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/ParametersTable.vue
@@ -105,6 +105,9 @@ $param-spacing: rem(28px);
     flex-flow: row wrap;
     width: 100%;
     @include change-highlight-target();
+    // Move the responsibility of the left padding to the first element instead.
+    // This is only for Large screens
+    padding-left: 0;
 
     & + & {
       margin-top: $param-spacing/2;
@@ -134,8 +137,15 @@ $param-spacing: rem(28px);
 .param-symbol {
   text-align: right;
 
+  .changed & {
+    @include change-highlight-end-spacing()
+  }
+
   @include breakpoint(small) {
     text-align: left;
+    .changed & {
+      padding-left: 0;
+    }
   }
 
   /deep/ .type-identifier-link {


### PR DESCRIPTION
Bug/issue #, if applicable: 103421001

## Summary

Ensures columns inside the ParametersTable have the same width, even if wrapped in a `changes` class.

## Dependencies

NA

## Testing

Steps:
1. Ensure that adding a `changes` class to the `row` does not affect the width of the columns.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~ - no css only
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
