### PR TITLE
[5.8] Make sure ParametersTable with changes has equal width columns

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/ParametersTable.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/ParametersTable.vue
@@ -105,6 +105,9 @@ $param-spacing: rem(28px);
     flex-flow: row wrap;
     width: 100%;
     @include change-highlight-target();
+    // Move the responsibility of the left padding to the first element instead.
+    // This is only for Large screens
+    padding-left: 0;
 
     & + & {
       margin-top: $param-spacing/2;
@@ -134,8 +137,15 @@ $param-spacing: rem(28px);
 .param-symbol {
   text-align: right;
 
+  .changed & {
+    @include change-highlight-end-spacing()
+  }
+
   @include breakpoint(small) {
     text-align: left;
+    .changed & {
+      padding-left: 0;
+    }
   }
 
   /deep/ .type-identifier-link {


### PR DESCRIPTION
- Explanation: Ensures columns inside the ParametersTable have the same width, even if wrapped in a `changes` class.
- Scope: API changes visuals on ParameterTables in Doc pages
- Issue: rdar://103421001
- Risk: May impact the visual appearance of the ParametersTable
- Testing: visual inspection of pages with ParametersTable that have changes.
- Reviewer: @mportiz08 
- Original PR: https://github.com/apple/swift-docc-render/pull/521