### PR TITLE
bump TabNavigator vertical threshold to 7

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -106,7 +106,7 @@ const TableColumnAlignments = {
 };
 
 // The point after which a TabNavigator turns to vertical mode.
-const TabNavigatorVerticalThreshold = 5;
+const TabNavigatorVerticalThreshold = 7;
 
 // Recursively call the passed `createElement` function for each content node
 // and any of its children by mapping each node `type` to a given Vue component

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -592,6 +592,8 @@ describe('ContentNode', () => {
           { title: '4', content },
           { title: '5', content },
           { title: '6', content },
+          { title: '7', content },
+          { title: '8', content },
         ],
       };
       const wrapper = mountWithItem(props);


### PR DESCRIPTION
Bug/issue #, if applicable: 101369883

## Summary

Bumps the TabNavigator vertical threshold to 7, as 5 was still able to fit horizontally. 

## Dependencies

NA

## Testing

Steps:
1. Test with a tabnav that has 8 tabs to go into vertical


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
