### PR TITLE
Add DeviceFrames support

### DIFF
--- a/src/components/Asset.vue
+++ b/src/components/Asset.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -55,6 +55,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    deviceFrame: {
+      type: String,
+      required: false,
+    },
   },
   computed: {
     rawAsset() {
@@ -103,6 +107,7 @@ export default {
         muted: this.videoMuted,
         autoplays: this.prefersReducedMotion ? false : this.videoAutoplays,
         posterVariants: this.videoPoster ? this.videoPoster.variants : [],
+        deviceFrame: this.deviceFrame,
       };
     },
     assetListeners() {

--- a/src/components/ConditionalWrapper.vue
+++ b/src/components/ConditionalWrapper.vue
@@ -1,0 +1,28 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2023 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+<script>
+/**
+ * Conditionally renders a component around the default slot.
+ */
+export default {
+  functional: true,
+  name: 'ConditionalWrapper',
+  props: {
+    tag: [Object, String],
+    shouldWrap: Boolean,
+  },
+  render(h, context) {
+    if (context.props.shouldWrap) {
+      return h(context.props.tag, context.data, context.children);
+    }
+    return context.children;
+  },
+};
+</script>

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -28,6 +28,7 @@ import Row from './ContentNode/Row.vue';
 import TabNavigator from './ContentNode/TabNavigator.vue';
 import TaskList from './ContentNode/TaskList.vue';
 import LinksBlock from './ContentNode/LinksBlock.vue';
+import DeviceFrame from './ContentNode/DeviceFrame.vue';
 
 export const BlockType = {
   aside: 'aside',
@@ -216,9 +217,14 @@ function renderNode(createElement, references) {
       abstract = [],
       anchor,
       title,
+      ...metadata
     },
-    ...node
+    ...rest
   }) => {
+    const node = {
+      ...rest,
+      metadata,
+    };
     const figureContent = [renderChildren([node])];
     if ((title && abstract.length) || abstract.length) {
       // if there is a `title`, it should be above, otherwise below
@@ -229,6 +235,14 @@ function renderNode(createElement, references) {
     }
     return createElement(Figure, { props: { anchor } }, figureContent);
   };
+
+  const renderDeviceFrame = ({ metadata: { deviceFrame }, ...node }) => (
+    createElement(DeviceFrame, {
+      props: {
+        device: deviceFrame,
+      },
+    }, renderChildren([node]))
+  );
 
   return function render(node) {
     switch (node.type) {
@@ -335,14 +349,14 @@ function renderNode(createElement, references) {
       if (node.metadata && node.metadata.abstract) {
         return renderFigure(node);
       }
-
-      return references[node.identifier] ? (
-        createElement(BlockVideo, {
-          props: {
-            identifier: node.identifier,
-          },
-        })
-      ) : null;
+      if (!references[node.identifier]) return null;
+      const { deviceFrame } = node.metadata || {};
+      return createElement(BlockVideo, {
+        props: {
+          identifier: node.identifier,
+          deviceFrame,
+        },
+      });
     }
     case BlockType.row: {
       const columns = node.numberOfColumns ? { large: node.numberOfColumns } : undefined;
@@ -393,16 +407,16 @@ function renderNode(createElement, references) {
       }
 
       const image = references[node.identifier];
-      return image ? (
-        createElement(InlineImage, {
-          props: {
-            alt: image.alt,
-            variants: image.variants,
-          },
-        })
-      ) : (
-        null
-      );
+      if (!image) return null;
+      if (node.metadata && node.metadata.deviceFrame) {
+        return renderDeviceFrame(node);
+      }
+      return createElement(InlineImage, {
+        props: {
+          alt: image.alt,
+          variants: image.variants,
+        },
+      });
     }
     case InlineType.link:
       // Note: `InlineType.link` has been deprecated, but may still be found in old JSON.

--- a/src/components/ContentNode/BlockVideo.vue
+++ b/src/components/ContentNode/BlockVideo.vue
@@ -15,6 +15,7 @@
     :video-muted="false"
     :showsReplayButton="!isClientMobile"
     :showsVideoControls="isClientMobile"
+    :deviceFrame="deviceFrame"
   />
 </template>
 
@@ -30,6 +31,10 @@ export default {
     identifier: {
       type: String,
       required: true,
+    },
+    deviceFrame: {
+      type: String,
+      required: false,
     },
   },
 };

--- a/src/components/ContentNode/DeviceFrame.vue
+++ b/src/components/ContentNode/DeviceFrame.vue
@@ -1,0 +1,137 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+<template>
+  <div
+    class="device-frame"
+    :data-device="device"
+    :class="classes"
+    :style="styles"
+  >
+    <div class="device-screen" :class="{ 'with-device': currentDeviceAttrs }">
+      <slot />
+    </div>
+    <div class="device" />
+  </div>
+</template>
+
+<script>
+import DeviceFrames from 'theme/constants/DeviceFrames.js';
+import { getSetting } from 'docc-render/utils/theme-settings';
+
+const isTruthy = val => val && val !== Infinity;
+const round = (v, dec = 4) => (isTruthy(v) ? +(`${Math.round(`${v}e+${dec}`)}e-${dec}`) : null);
+
+export default {
+  name: 'DeviceFrame',
+  props: {
+    device: {
+      type: String,
+      required: true,
+    },
+  },
+  provide: {
+    insideDeviceFrame: true,
+  },
+  computed: {
+    currentDeviceAttrs: ({ device }) => getSetting(['theme', 'device-frames', device], DeviceFrames[device]),
+    styles: ({
+      toPixel, toUrl, toPct, currentDeviceAttrs: attrs = {},
+    }) => {
+      const {
+        screenTop, screenLeft, screenWidth, frameWidth,
+        lightUrl, darkUrl, screenHeight, frameHeight,
+      } = attrs;
+
+      return {
+        '--screen-top': toPct(screenTop / frameHeight),
+        '--screen-left': toPct(screenLeft / frameWidth),
+        '--screen-width': toPct(screenWidth / frameWidth),
+        '--screen-height': toPct(screenHeight / frameHeight),
+        '--screen-aspect': round(screenWidth / screenHeight) || null,
+
+        '--frame-width': toPixel(frameWidth),
+        '--frame-aspect': round(frameWidth / frameHeight) || null,
+
+        '--device-light-url': toUrl(lightUrl),
+        '--device-dark-url': toUrl(darkUrl),
+      };
+    },
+    classes: ({ currentDeviceAttrs }) => ({
+      'no-device': !currentDeviceAttrs,
+    }),
+  },
+  methods: {
+    toPixel: val => (isTruthy(val) ? `${val}px` : null),
+    toUrl: val => (isTruthy(val) ? `url(${val})` : null),
+    toPct: val => (isTruthy(val) ? `${round(val * 100)}%` : null),
+  },
+};
+</script>
+
+<style scoped lang='scss'>
+@import 'docc-render/styles/_core.scss';
+
+.device-frame {
+  position: relative;
+  width: var(--frame-width);
+  aspect-ratio: var(--frame-aspect);
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  overflow: hidden;
+  @include space-out-between-siblings($article-stacked-margin-large);
+}
+
+.device {
+  background-image: var(--device-light-url);
+  background-repeat: no-repeat;
+  background-size: 100%;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  pointer-events: none;
+
+  @include prefers-dark {
+    background-image: var(--device-dark-url, var(--device-light-url));
+  }
+
+  .no-device & {
+    display: none;
+  }
+}
+
+.device-screen.with-device {
+  position: absolute;
+  left: var(--screen-left);
+  top: var(--screen-top);
+  height: var(--screen-height);
+  width: var(--screen-width);
+  display: flex;
+
+  & > * {
+    flex: 1;
+  }
+
+  /deep/ img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    object-position: top;
+    margin: 0;
+  }
+
+  /deep/ video {
+    object-fit: contain;
+    object-position: top;
+    width: 100%;
+    height: auto;
+  }
+}
+</style>

--- a/src/components/ReplayableVideoAsset.vue
+++ b/src/components/ReplayableVideoAsset.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -17,6 +17,7 @@
       :showsControls="showsControls"
       :muted="muted"
       :posterVariants="posterVariants"
+      :deviceFrame="deviceFrame"
       @pause="onPause"
       @playing="onVideoPlaying"
       @ended="onVideoEnd"
@@ -24,7 +25,7 @@
     <a
       class="replay-button"
       href="#"
-      :class="{ visible: this.showsReplayButton }"
+      :class="{ visible: showsReplayButton }"
       @click.prevent="replay"
     >
       {{ text }}
@@ -67,6 +68,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    deviceFrame: {
+      type: String,
+      required: false,
+    },
   },
   computed: {
     text: ({ played }) => (played ? 'Replay' : 'Play'),
@@ -79,7 +84,7 @@ export default {
   },
   methods: {
     async replay() {
-      const videoPlayer = this.$refs.asset.$el;
+      const videoPlayer = this.$refs.asset.$refs.video;
       if (videoPlayer) {
         await videoPlayer.play();
         this.showsReplayButton = false;
@@ -105,7 +110,7 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-.replay-button {
+.video-replay-container .replay-button {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/VideoAsset.vue
+++ b/src/components/VideoAsset.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -9,25 +9,33 @@
 -->
 
 <template>
-  <video
-    :controls="showsControls"
-    :autoplay="autoplays"
-    :poster="normalisedPosterPath"
-    :muted="muted"
-    :width="optimalWidth"
-    playsinline
-    @playing="$emit('playing')"
-    @pause="$emit('pause')"
-    @ended="$emit('ended')"
+  <ConditionalWrapper
+    ref="wrapper"
+    :tag="DeviceFrameComponent"
+    :should-wrap="!!deviceFrame"
+    :device="deviceFrame"
   >
-    <!--
-      Many browsers do not support the `media` attribute for `<source>` tags
-      within a video specifically, so this implementation for dark theme assets
-      is handled with JavaScript media query listeners unlike the `<source>`
-      based implementation being used for image assets.
-    -->
-    <source :src="normalizeAssetUrl(videoAttributes.url)">
-  </video>
+    <video
+      ref="video"
+      :controls="showsControls"
+      :autoplay="autoplays"
+      :poster="normalisedPosterPath"
+      :muted="muted"
+      :width="optimalWidth"
+      playsinline
+      @playing="$emit('playing')"
+      @pause="$emit('pause')"
+      @ended="$emit('ended')"
+    >
+      <!--
+        Many browsers do not support the `media` attribute for `<source>` tags
+        within a video specifically, so this implementation for dark theme assets
+        is handled with JavaScript media query listeners unlike the `<source>`
+        based implementation being used for image assets.
+      -->
+      <source :src="normalizeAssetUrl(videoAttributes.url)">
+    </video>
+  </ConditionalWrapper>
 </template>
 
 <script>
@@ -39,9 +47,12 @@ import {
 } from 'docc-render/utils/assets';
 import AppStore from 'docc-render/stores/AppStore';
 import ColorScheme from 'docc-render/constants/ColorScheme';
+import ConditionalWrapper from 'docc-render/components/ConditionalWrapper.vue';
+import DeviceFrame from 'docc-render/components/ContentNode/DeviceFrame.vue';
 
 export default {
   name: 'VideoAsset',
+  components: { ConditionalWrapper },
   props: {
     variants: {
       type: Array,
@@ -64,12 +75,17 @@ export default {
       type: Boolean,
       default: true,
     },
+    deviceFrame: {
+      type: String,
+      required: false,
+    },
   },
   data: () => ({
     appState: AppStore.state,
     optimalWidth: null,
   }),
   computed: {
+    DeviceFrameComponent: () => DeviceFrame,
     preferredColorScheme: ({ appState }) => appState.preferredColorScheme,
     systemColorScheme: ({ appState }) => appState.systemColorScheme,
     userPrefersDark: ({

--- a/src/constants/DeviceFrames.js
+++ b/src/constants/DeviceFrames.js
@@ -1,0 +1,12 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2023 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+// Swift-DocC-Render does not provide device frames out of the box.
+export default {};

--- a/tests/unit/components/Asset.spec.js
+++ b/tests/unit/components/Asset.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -103,6 +103,17 @@ describe('Asset', () => {
     expect(videoAsset.props('posterVariants')).toEqual([]);
   });
 
+  it('passes down `deviceFrame` to `VideoAsset`', () => {
+    const wrapper = mountAsset('video', { video });
+    let videoAsset = wrapper.find(VideoAsset);
+    expect(videoAsset.props('deviceFrame')).toBeFalsy();
+    wrapper.setProps({
+      deviceFrame: 'phone',
+    });
+    videoAsset = wrapper.find(VideoAsset);
+    expect(videoAsset.props('deviceFrame')).toBe('phone');
+  });
+
   it('renders a `ReplayableVideoAsset` for video with `showsReplayButton=true`', () => {
     const wrapper = shallowMount(Asset, {
       propsData: {
@@ -117,6 +128,28 @@ describe('Asset', () => {
     expect(videoAsset.props('variants')).toBe(video.variants);
     expect(videoAsset.props('showsControls')).toBe(true);
     expect(videoAsset.props('muted')).toBe(true);
+  });
+
+  it('renders a `ReplayableVideoAsset` with deviceFrame', () => {
+    const wrapper = shallowMount(Asset, {
+      propsData: {
+        identifier: 'video',
+        showsReplayButton: true,
+        showsVideoControls: true,
+        deviceFrame: 'phone',
+      },
+      provide: { references: { video } },
+    });
+
+    const videoAsset = wrapper.find(ReplayableVideoAsset);
+    expect(videoAsset.props()).toEqual({
+      autoplays: true,
+      deviceFrame: 'phone',
+      muted: true,
+      posterVariants: [],
+      showsControls: true,
+      variants: video.variants,
+    });
   });
 
   it('renders a `VideoAsset`, without muting it', () => {

--- a/tests/unit/components/ConditionalWrapper.spec.js
+++ b/tests/unit/components/ConditionalWrapper.spec.js
@@ -1,0 +1,46 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import ConditionalWrapper from '@/components/ConditionalWrapper.vue';
+import { shallowMount } from '@vue/test-utils';
+
+describe('ConditionalWrapper', () => {
+  it('renders the `ConditionalWrapper`, with the `tag`', () => {
+    const wrapper = shallowMount(ConditionalWrapper, {
+      context: {
+        props: {
+          tag: 'span',
+          shouldWrap: true,
+        },
+        children: ['Some text'],
+      },
+      attrs: {
+        'aria-hidden': 'true',
+      },
+    });
+    const span = wrapper.find('span');
+    expect(span.attributes('aria-hidden')).toBe('true');
+    expect(wrapper.text()).toBe('Some text');
+  });
+
+  it('renders the children without the wrapping `tag`', () => {
+    const Component = {
+      template: `
+        <div>
+        <ConditionalWrapper tag="span" :shouldWrap="false">
+          <em>Foo</em>
+        </ConditionalWrapper>
+        </div>`,
+      components: { ConditionalWrapper },
+    };
+    const wrapper = shallowMount(Component, { stubs: { ConditionalWrapper } });
+    expect(wrapper.html()).toBe('<div><em>Foo</em></div>');
+  });
+});

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -30,6 +30,7 @@ import TabNavigator from '@/components/ContentNode/TabNavigator.vue';
 import TaskList from 'docc-render/components/ContentNode/TaskList.vue';
 import { TopicSectionsStyle } from '@/constants/TopicSectionsStyle';
 import LinksBlock from '@/components/ContentNode/LinksBlock.vue';
+import DeviceFrame from '@/components/ContentNode/DeviceFrame.vue';
 
 const { TableHeaderStyle, TableColumnAlignments } = ContentNode.constants;
 
@@ -805,6 +806,45 @@ describe('ContentNode', () => {
 
       expect(wrapper.find(FigureCaption).exists()).toBe(false);
     });
+
+    it('renders within a `DeviceFrame`', () => {
+      const wrapper = mountWithItem({
+        type: 'image',
+        identifier: 'figure1.png',
+        metadata: {
+          deviceFrame: 'phone',
+        },
+      }, references);
+
+      const deviceFrame = wrapper.find('.content').find(DeviceFrame);
+      expect(deviceFrame.props()).toEqual({
+        device: 'phone',
+      });
+      const inlineImage = deviceFrame.find(InlineImage);
+      expect(inlineImage.exists()).toBe(true);
+      expect(inlineImage.props('variants').length).toBe(2);
+    });
+
+    it('renders a `Figure` with a `DeviceFrame`', () => {
+      const metadata = {
+        deviceFrame: 'phone',
+        abstract: [{
+          type: 'paragraph',
+          inlineContent: [{ type: 'text', text: 'blah' }],
+        }],
+      };
+      const wrapper = mountWithItem({
+        type: 'image',
+        identifier: 'figure1.png',
+        metadata,
+      }, references);
+
+      const figure = wrapper.find(Figure);
+      expect(figure.exists()).toBe(true);
+      expect(figure.props('anchor')).toBeFalsy();
+      expect(figure.find(DeviceFrame).exists()).toBe(true);
+      expect(figure.find(InlineImage).exists()).toBe(true);
+    });
   });
 
   describe('with type="video"', () => {
@@ -900,6 +940,44 @@ describe('ContentNode', () => {
           </figurecaption-stub>
         </figure-stub>
       `);
+    });
+
+    it('passes the deviceFrame down to the BlockVideo`', () => {
+      const wrapper = mountWithItem({
+        type: 'video',
+        identifier,
+        metadata: {
+          deviceFrame: 'phone',
+        },
+      }, references);
+
+      const blockVideo = wrapper.find('.content').find(BlockVideo);
+      expect(blockVideo.exists()).toBe(true);
+
+      expect(blockVideo.props()).toEqual({
+        identifier,
+        deviceFrame: 'phone',
+      });
+    });
+
+    it('renders a `Figure` with a BlockVideo, passing frames`', () => {
+      const metadata = {
+        deviceFrame: 'phone',
+        abstract: [{
+          type: 'paragraph',
+          inlineContent: [{ type: 'text', text: 'blah' }],
+        }],
+      };
+      const wrapper = mountWithItem({
+        type: 'video',
+        identifier,
+        metadata,
+      }, references);
+
+      const figure = wrapper.find(Figure);
+      expect(figure.exists()).toBe(true);
+      expect(figure.props('anchor')).toBeFalsy();
+      expect(figure.find(BlockVideo).props('deviceFrame')).toBe('phone');
     });
   });
 

--- a/tests/unit/components/ContentNode/BlockVideo.spec.js
+++ b/tests/unit/components/ContentNode/BlockVideo.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -21,8 +21,9 @@ const defaultProps = {
   identifier: 'foo',
 };
 
-const createWrapper = () => shallowMount(BlockVideo, {
-  propsData: defaultProps,
+const createWrapper = ({ propsData, ...others } = {}) => shallowMount(BlockVideo, {
+  propsData: { ...defaultProps, ...propsData },
+  ...others,
 });
 
 describe('BlockVideo', () => {
@@ -34,6 +35,22 @@ describe('BlockVideo', () => {
       videoMuted: false,
       showsReplayButton: true,
       showsVideoControls: false,
+    });
+  });
+
+  it('passes deviceFrames down to child', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        deviceFrame: 'phone',
+      },
+    });
+    expect(wrapper.find(Asset).props()).toEqual({
+      identifier: defaultProps.identifier,
+      videoAutoplays: false,
+      videoMuted: false,
+      showsReplayButton: true,
+      showsVideoControls: false,
+      deviceFrame: 'phone',
     });
   });
 

--- a/tests/unit/components/ContentNode/DeviceFrame.spec.js
+++ b/tests/unit/components/ContentNode/DeviceFrame.spec.js
@@ -1,0 +1,167 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import DeviceFrame from '@/components/ContentNode/DeviceFrame.vue';
+import { shallowMount } from '@vue/test-utils';
+import DeviceFrames from '@/constants/DeviceFrames';
+import { getSetting } from '@/utils/theme-settings';
+
+jest.mock('@/utils/theme-settings');
+jest.mock('@/constants/DeviceFrames', () => ({
+  phone: {
+    screenTop: 15,
+    screenWidth: 210,
+    screenHeight: 460,
+    screenLeft: 15,
+
+    frameWidth: 240,
+    frameHeight: 490,
+    lightUrl: 'path/to/phone.svg',
+  },
+  tablet: {
+    screenTop: 22,
+    screenWidth: 590,
+    screenHeight: 410,
+    screenLeft: 22,
+
+    frameWidth: 640,
+    frameHeight: 460,
+    lightUrl: 'path/to/tablet.svg',
+  },
+  // the TV may have a stand, which means it has diff top/bottom offsets
+  tv: {
+    screenTop: 8,
+    screenWidth: 600,
+    screenHeight: 300,
+    screenLeft: 8,
+
+    frameWidth: 630,
+    frameHeight: 370,
+    lightUrl: 'path/to/tv.svg',
+  },
+  invalid: {
+    screenTop: 8,
+    screenWidth: 600,
+    screenHeight: 300,
+    screenLeft: 8,
+
+    framewidth: 630, // invalid name
+    'frame-height': '370',
+    lightUrl: 'path/to/tv.svg',
+  },
+}));
+
+// return the fallback by default
+getSetting.mockImplementation((path, fallback) => fallback);
+
+const defaultProps = {
+  device: 'phone',
+};
+
+const createWrapper = ({ propsData, ...others } = {}) => shallowMount(DeviceFrame, {
+  propsData: {
+    ...defaultProps,
+    ...propsData,
+  },
+  slots: {
+    default: '<div class="default-slot-content">Default Slot</div>',
+  },
+  ...others,
+});
+
+const phoneStyles = {
+  '--device-dark-url': null,
+  '--device-light-url': 'url(path/to/phone.svg)',
+  '--frame-aspect': 0.4898,
+  '--frame-width': '240px',
+  '--screen-aspect': 0.4565,
+  '--screen-height': '93.8776%',
+  '--screen-left': '6.25%',
+  '--screen-top': '3.0612%',
+  '--screen-width': '87.5%',
+};
+const tabletStyles = {
+  '--device-dark-url': null,
+  '--device-light-url': 'url(path/to/tablet.svg)',
+  '--frame-aspect': 1.3913,
+  '--frame-width': '640px',
+  '--screen-aspect': 1.439,
+  '--screen-height': '89.1304%',
+  '--screen-left': '3.4375%',
+  '--screen-top': '4.7826%',
+  '--screen-width': '92.1875%',
+};
+
+describe('DeviceFrame', () => {
+  it('renders the DeviceFrame', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.attributes('data-device')).toBe('phone');
+    const deviceScreen = wrapper.find('.device-screen');
+    expect(deviceScreen.classes()).toContain('with-device');
+    expect(deviceScreen.find('.default-slot-content').text()).toBe('Default Slot');
+    expect(wrapper.find('.device').exists()).toBe(true);
+  });
+
+  it('exposes the correct css variables', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.vm.styles).toEqual(phoneStyles);
+  });
+
+  it('renders fine, if no device frame is found', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        device: 'TV',
+      },
+    });
+    expect(wrapper.attributes('data-device')).toBe('TV');
+    expect(wrapper.classes()).toContain('no-device');
+    expect(wrapper.find('.device-screen').classes()).not.toContain('with-device');
+    expect(wrapper.vm.styles).toMatchObject({
+      '--frame-aspect': null,
+      '--frame-width': null,
+      '--screen-aspect': null,
+      '--screen-height': null,
+      '--screen-left': null,
+      '--screen-top': null,
+      '--screen-width': null,
+    });
+  });
+
+  it('renders fine, if device frame is invalid', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        device: 'invalid',
+      },
+    });
+    expect(wrapper.attributes('data-device')).toBe('invalid');
+    expect(wrapper.classes()).not.toContain('no-device');
+    expect(wrapper.vm.styles).toMatchObject({
+      '--frame-aspect': null,
+      '--frame-width': null,
+      '--screen-aspect': 2,
+      '--screen-height': null,
+      '--screen-left': null,
+      '--screen-top': null,
+      '--screen-width': null,
+    });
+  });
+
+  it('returns frames from the theme-settings', () => {
+    getSetting.mockImplementationOnce(() => DeviceFrames.tablet);
+    const wrapper = createWrapper({
+      propsData: {
+        device: 'custom-tablet',
+      },
+    });
+    expect(getSetting).toHaveBeenCalledWith(['theme', 'device-frames', 'custom-tablet'], undefined);
+    expect(wrapper.attributes('data-device')).toBe('custom-tablet');
+    expect(wrapper.vm.styles).toEqual(tabletStyles);
+  });
+});

--- a/tests/unit/components/ReplayableVideoAsset.spec.js
+++ b/tests/unit/components/ReplayableVideoAsset.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -98,7 +98,7 @@ describe('ReplayableVideoAsset', () => {
     expect(replay.text()).toBe('Play');
     expect(replay.classes()).not.toContain('visible');
     // now end the video
-    wrapper.find({ ref: 'asset' }).trigger('ended');
+    wrapper.find({ ref: 'asset' }).vm.$emit('ended');
     // assert text changed and its visible
     expect(replay.text()).toBe('Replay');
     expect(replay.classes()).toContain('visible');
@@ -117,7 +117,7 @@ describe('ReplayableVideoAsset', () => {
     // assert button is hidden
     expect(replay.classes()).not.toContain('visible');
     // pause
-    wrapper.find({ ref: 'asset' }).trigger('pause');
+    wrapper.find({ ref: 'asset' }).vm.$emit('pause');
     // assert button is visible again
     expect(replay.classes()).toContain('visible');
   });
@@ -129,8 +129,17 @@ describe('ReplayableVideoAsset', () => {
     const replay = wrapper.find('.replay-button');
     expect(replay.classes()).toContain('visible');
     // Simulate browser starts playing
-    wrapper.find({ ref: 'asset' }).trigger('playing');
+    wrapper.find({ ref: 'asset' }).vm.$emit('playing');
     // assert button is hidden
     expect(replay.classes()).not.toContain('visible');
+  });
+
+  it('provides the DeviceFrame down to the Video', () => {
+    const wrapper = mountWithProps({
+      deviceFrame: 'phone',
+    });
+    expect(wrapper.find(VideoAsset).props()).toMatchObject({
+      deviceFrame: 'phone',
+    });
   });
 });

--- a/tests/unit/components/VideoAsset.spec.js
+++ b/tests/unit/components/VideoAsset.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -12,6 +12,8 @@ import { shallowMount } from '@vue/test-utils';
 import ColorScheme from 'docc-render/constants/ColorScheme';
 import VideoAsset from 'docc-render/components/VideoAsset.vue';
 import * as assetUtils from 'docc-render/utils/assets';
+import DeviceFrame from '@/components/ContentNode/DeviceFrame.vue';
+import ConditionalWrapper from '@/components/ConditionalWrapper.vue';
 import { flushPromises } from '../../../test-utils';
 
 const getIntrinsicDimensionsSpy = jest.spyOn(assetUtils, 'getIntrinsicDimensions').mockResolvedValue({
@@ -43,28 +45,31 @@ describe('VideoAsset', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    wrapper = shallowMount(VideoAsset, { data, propsData });
+    wrapper = shallowMount(VideoAsset, { data, propsData, stubs: { ConditionalWrapper } });
   });
 
   it('renders a video', () => {
-    expect(wrapper.is('video')).toBe(true);
-    expect(wrapper.element.muted).toBe(true);
+    const video = wrapper.find('video');
+    expect(video.exists()).toBe(true);
+    expect(video.element.muted).toBe(true);
   });
 
   it('adds a poster to the `video`, using light by default', async () => {
-    expect(wrapper.find('video').attributes('poster')).toEqual(propsData.posterVariants[0].url);
+    const video = wrapper.find('video');
+    expect(video.attributes('poster')).toEqual(propsData.posterVariants[0].url);
     expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(1);
     expect(getIntrinsicDimensionsSpy).toHaveBeenCalledWith(propsData.posterVariants[0].url);
     await flushPromises();
-    expect(wrapper.attributes()).toMatchObject({
+    expect(video.attributes()).toMatchObject({
       width: '100',
     });
   });
 
   it('applies a dark poster if available and target prefers dark', async () => {
+    const video = wrapper.find('video');
     expect(getIntrinsicDimensionsSpy).toHaveBeenCalledTimes(1);
     expect(getIntrinsicDimensionsSpy).toHaveBeenNthCalledWith(1, propsData.posterVariants[0].url);
-    expect(wrapper.attributes()).toMatchObject({
+    expect(video.attributes()).toMatchObject({
       width: '100',
     });
     wrapper.setData({
@@ -75,7 +80,7 @@ describe('VideoAsset', () => {
     expect(getIntrinsicDimensionsSpy).toHaveBeenNthCalledWith(2, propsData.posterVariants[1].url);
     await flushPromises();
     // dark image is 2x, so the width is half
-    expect(wrapper.attributes()).toMatchObject({
+    expect(video.attributes()).toMatchObject({
       width: '50',
     });
   });
@@ -143,15 +148,18 @@ describe('VideoAsset', () => {
   });
 
   it('sets `autoplay` using `autoplays`', () => {
-    expect(wrapper.attributes('autoplay')).toBe('autoplay');
+    const video = wrapper.find('video');
+
+    expect(video.attributes('autoplay')).toBe('autoplay');
     wrapper.setProps({ autoplays: false });
-    expect(wrapper.attributes('autoplay')).toBe(undefined);
+    expect(video.attributes('autoplay')).toBe(undefined);
   });
 
   it('sets `controls` using `showsControls`', () => {
-    expect(wrapper.attributes('controls')).toBe('controls');
+    const video = wrapper.find('video');
+    expect(video.attributes('controls')).toBe('controls');
     wrapper.setProps({ showsControls: false });
-    expect(wrapper.attributes('controls')).toBe(undefined);
+    expect(video.attributes('controls')).toBe(undefined);
   });
 
   it('renders a source for the light variant when applicable', () => {
@@ -195,5 +203,20 @@ describe('VideoAsset', () => {
       muted: false,
     });
     expect(wrapper.element.muted).toBeFalsy();
+  });
+
+  it('renders a `ConditionalWrapper` around the video', () => {
+    expect(wrapper.find(DeviceFrame).exists()).toBeFalsy();
+    wrapper.setProps({
+      deviceFrame: 'phone',
+    });
+    const frame = wrapper.find(DeviceFrame);
+    expect(frame.props()).toEqual({
+      device: 'phone',
+    });
+
+    const video = frame.find('video');
+    expect(video.exists()).toBe(true);
+    expect(video.find('source').attributes('src')).toBe(propsData.variants[0].url);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 102182966

## Summary

Adds support for DeviceFrames for images and videos. This PR re-adds #515 

![localhost_8082_documentation_simple_simpler](https://user-images.githubusercontent.com/9863944/212119144-b8e02634-fa3d-4df5-9af7-788eb46ae2de.png)


## Dependencies

- https://github.com/apple/swift-docc/pull/462

## Testing

[simpler.json.zip](https://github.com/apple/swift-docc-render/files/10400403/simpler.json.zip) - this file is built with the docc branch above

Steps:
1. To test this you will need an archive that has `@Image` or `@Video` tags with `deviceFrames`.
2. You will also need to add deviceFrame definitions to your `theme-settings.json` file, as by default docc-render does not ship with frames. - see https://forums.swift.org/t/support-for-device-frames/62151 for more info

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
