### PR TITLE
add docs about using nvm to readme and contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,9 @@ more details.
 ### Run Steps
 
 > Note: requires [Node.js](https://nodejs.org/en/download/) v14
-> and [npm](https://www.npmjs.com/package/npm) v6.14
+> and [npm](https://www.npmjs.com/package/npm) v6.14. An easy way to set these up is to install
+> [nvm](https://github.com/nvm-sh/nvm) and run `nvm install` from within the Swift-DocC-Render
+> repository. To use these versions as the default, add `--default` to the installation command.
 
 1. Checkout this repository using:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ SPAs are web apps that render dynamically at runtime entirely in the browser, us
 ## Getting Started
 
 > Note: requires [Node.js](https://nodejs.org/en/download/) v14
-> and [npm](https://www.npmjs.com/package/npm) v6.14
+> and [npm](https://www.npmjs.com/package/npm) v6.14. An easy way to set these up is to install
+> [nvm](https://github.com/nvm-sh/nvm) and run `nvm install` from within the Swift-DocC-Render
+> repository. To use these versions as the default, add `--default` to the installation command.
 
 1. **Download this repository and go to its folder**
 


### PR DESCRIPTION
Bug/issue #, if applicable: None

## Summary

This PR adds a blurb to the README and CONTRIBUTING.md files about using `nvm` to handle installing Node and npm. Since Swift-DocC-Render has an `.nvmrc` file, this provides a quick way to ensure that you have the right versions of Node/npm before working on the project itself.

## Dependencies

None

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
