### PR TITLE
Fix printing pages with code-listings

### DIFF
--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -191,8 +191,11 @@ code {
   // this mask image is not actually used for any visual effect since there is
   // no background being used on this element—however, we need this in order to
   // establish a new stacking context, which resolves a Safari bug where the
-  // scrollbar is not clipped by this element depending on its border-radius
-  -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
+  // scrollbar is not clipped by this element depending on its border-radius.
+  // It's inside a screen query, because it causes issues with printing to PDF.
+  @media screen {
+    -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
+  }
 
   &.single-line {
     border-radius: $large-border-radius;

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -204,7 +204,9 @@ $docs-declaration-source-border-width: 1px !default;
   // no background being used on this element—however, we need this in order to
   // establish a new stacking context, which resolves a Safari bug where the
   // scrollbar is not clipped by this element depending on its border-radius
-  -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
+  @media screen {
+    -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
+  }
 
   &.has-multiple-lines {
     border-radius: $border-radius;


### PR DESCRIPTION
Bug/issue #, if applicable: 104872474

## Summary

Fixes a page printing bug where code-listings where generated without code, or gradient overlays.

## Dependencies

NA

## Testing

Steps:
1. Try to print a page with a code listing

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~ - no css only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
