### PR TITLE
Shrink minimized mode border radius for Declaration, Code Listing, and Aside

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -59,13 +59,8 @@
       </DocumentationHero>
       <div class="doc-content-wrapper">
         <div class="doc-content" :class="{ 'no-primary-content': !hasPrimaryContent }">
-          <div v-if="hasPrimaryContent" class="container">
-            <div class="description"
-              :class="{
-                'after-enhanced-hero': enhanceBackground,
-                'minimized-description': enableMinimized
-              }"
-            >
+          <div v-if="hasPrimaryContent" :class="['container', { 'minimized-container': enableMinimized }]">
+            <div class="description" :class="{ 'after-enhanced-hero': enhanceBackground }">
               <RequirementMetadata
                 v-if="isRequirement"
                 :defaultImplementationsCount="defaultImplementationsCount"
@@ -82,7 +77,7 @@
             </div>
             <PrimaryContent
               v-if="primaryContentSections && primaryContentSections.length"
-              :class="{ 'with-border': !enhanceBackground, 'minimized-content': enableMinimized }"
+              :class="{ 'with-border': !enhanceBackground }"
               :conformance="conformance"
               :source="remoteSource"
               :sections="primaryContentSections"
@@ -482,9 +477,6 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-$spacing-minimized-aside-padding-top: 0.667rem;
-$spacing-minimized-aside-padding-left: 1rem;
-
 .doc-topic {
   display: flex;
   flex-direction: column;
@@ -531,6 +523,46 @@ $spacing-minimized-aside-padding-left: 1rem;
   @include dynamic-content-container;
 }
 
+/deep/ {
+  .minimized-container {
+    --spacing-stacked-margin-large: 0.667em;
+    --spacing-stacked-margin-xlarge: 1em;
+    --declaration-code-listing-margin: 1em 0;
+    --code-block-style-elements-padding: 7px 12px;
+    --code-border-radius: 10px;
+    --spacing-param: var(--spacing-stacked-margin-large);
+    --aside-border-radius: 6px;
+    --code-border-radius: 6px;
+
+    .description {
+      margin-bottom: 1.5em;
+    }
+
+    & > .primary-content > * {
+      margin-top: 1.5em;
+      margin-bottom: 1.5em;
+    }
+
+    .description {
+      margin-top: 0;
+    }
+
+    h2 {
+      font-size: 1.083rem;
+      font-weight: bold;
+    }
+
+    aside {
+      padding: 0.667rem 1rem;
+    }
+
+    .source {
+      border-radius: var(--code-border-radius);
+    }
+  }
+}
+
+
 .description {
   margin-bottom: $contenttable-spacing-single-side;
 
@@ -547,45 +579,10 @@ $spacing-minimized-aside-padding-left: 1rem;
   }
 }
 
-.minimized-description {
-  margin-bottom: 1.5em;
-
-  & > aside {
-    padding: $spacing-minimized-aside-padding-top $spacing-minimized-aside-padding-left;
-  }
-}
-
 /deep/ {
   .no-primary-content {
     // remove border-top for first section of the page
     --content-table-title-border-width: 0px;
-  }
-
-  .minimized-content {
-    --spacing-stacked-margin-large: 0.667em;
-    --spacing-stacked-margin-xlarge: 1em;
-    --declaration-code-listing-margin: 1em 0;
-    --code-block-style-elements-padding: 7px 12px;
-    --code-border-radius: 10px;
-    --spacing-param: var(--spacing-stacked-margin-large);
-
-    & > * {
-      margin-bottom: 1.5em;
-      margin-top: 1.5em;
-
-      &:first-child {
-        margin-top: 1.5em;
-      }
-
-      & > h2 {
-        font-size: 1.083rem;
-        font-weight: bold;
-      }
-
-      & > aside {
-        padding: $spacing-minimized-aside-padding-top $spacing-minimized-aside-padding-left;
-      }
-    }
   }
 }
 

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -507,11 +507,14 @@ export default {
 }
 
 /deep/ .minimized-title {
-  font-size: 1.416rem;
-  font-weight: bold;
   margin-bottom: 0.833rem;
 
-  & > small {
+  .title {
+    font-size: 1.416rem;
+    font-weight: bold;
+  }
+
+  small {
     font-size: 1rem;
     padding-left: 0.416rem;
   }

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -565,6 +565,10 @@ export default {
     .source {
       border-radius: var(--code-border-radius);
     }
+
+    .single-line {
+      border-radius: var(--code-border-radius);
+    }
   }
 }
 

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -59,7 +59,10 @@
       </DocumentationHero>
       <div class="doc-content-wrapper">
         <div class="doc-content" :class="{ 'no-primary-content': !hasPrimaryContent }">
-          <div v-if="hasPrimaryContent" :class="['container', { 'minimized-container': enableMinimized }]">
+          <div
+            v-if="hasPrimaryContent"
+            :class="['container', { 'minimized-container': enableMinimized }]"
+          >
             <div class="description" :class="{ 'after-enhanced-hero': enhanceBackground }">
               <RequirementMetadata
                 v-if="isRequirement"
@@ -561,7 +564,6 @@ export default {
     }
   }
 }
-
 
 .description {
   margin-bottom: $contenttable-spacing-single-side;

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -424,14 +424,6 @@ describe('DocumentationTopic', () => {
     expect(primary.props('source')).toEqual(propsData.remoteSource);
   });
 
-  it('renders the right classes for `PrimaryContent` based on `enableMininized` prop', () => {
-    const primary = wrapper.find(PrimaryContent);
-    expect(primary.classes()).not.toContain('minimized-content');
-
-    wrapper.setProps({ enableMinimized: true });
-    expect(primary.classes()).toContain('minimized-content');
-  });
-
   it('does not render a `PrimaryContent` column when passed undefined as PrimaryContent', () => {
     wrapper.setProps({ primaryContentSections: undefined });
     expect(wrapper.contains(PrimaryContent)).toBe(false);
@@ -451,14 +443,6 @@ describe('DocumentationTopic', () => {
         symbolKind: 'something-else',
       });
       expect(description.classes()).not.toContain('after-enhanced-hero');
-    });
-
-    it('renders the right classes based on `enableMininized` prop', () => {
-      const description = wrapper.find('.description');
-      expect(description.classes()).not.toContain('minimized-description');
-
-      wrapper.setProps({ enableMinimized: true });
-      expect(description.classes()).toContain('minimized-description');
     });
 
     it('renders a deprecated `Aside` when deprecated', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 104976416

## Summary
Shrink minimized mode border radius for Declaration, Code Listing, and Aside
Also did a slight refactor for CSS rules for minimized mode

## Testing
Steps:
1. Manually verify by navigating to any page with declaration, code listing, and aside.
