### PR TITLE
Fix issue with images not rendered inside a tabnav, in Safari

### DIFF
--- a/src/components/ContentNode/TabNavigator.vue
+++ b/src/components/ContentNode/TabNavigator.vue
@@ -33,6 +33,7 @@
 <script>
 import Tabnav from 'docc-render/components/Tabnav.vue';
 import TabnavItem from 'docc-render/components/TabnavItem.vue';
+import ImageLoadingStrategy from '@/constants/ImageLoadingStrategy';
 
 /**
  * Tab navigation component, that renders `ContentNode`,
@@ -45,6 +46,9 @@ export default {
   components: {
     TabnavItem,
     Tabnav,
+  },
+  provide: {
+    imageLoadingStrategy: ImageLoadingStrategy.eager,
   },
   props: {
     vertical: {

--- a/src/components/ContentNode/TabNavigator.vue
+++ b/src/components/ContentNode/TabNavigator.vue
@@ -33,7 +33,7 @@
 <script>
 import Tabnav from 'docc-render/components/Tabnav.vue';
 import TabnavItem from 'docc-render/components/TabnavItem.vue';
-import ImageLoadingStrategy from '@/constants/ImageLoadingStrategy';
+import ImageLoadingStrategy from 'docc-render/constants/ImageLoadingStrategy';
 
 /**
  * Tab navigation component, that renders `ContentNode`,

--- a/src/components/ImageAsset.vue
+++ b/src/components/ImageAsset.vue
@@ -93,6 +93,11 @@ function constructAttributes(sources) {
 export default {
   name: 'ImageAsset',
   mixins: [imageAsset],
+  inject: {
+    imageLoadingStrategy: {
+      default: null,
+    },
+  },
   data: () => ({
     appState: AppStore.state,
     fallbackImageSrcSet: null,
@@ -109,7 +114,10 @@ export default {
     }) => lightVariantAttributes || darkVariantAttributes,
     darkVariantAttributes: ({ darkVariants }) => constructAttributes(darkVariants),
     lightVariantAttributes: ({ lightVariants }) => constructAttributes(lightVariants),
-    loading: ({ appState }) => appState.imageLoadingStrategy,
+    loading: ({ appState, imageLoadingStrategy }) => (
+      // use an image loading strategy, injected by a parent component, or the default app one
+      imageLoadingStrategy || appState.imageLoadingStrategy
+    ),
     preferredColorScheme: ({ appState }) => appState.preferredColorScheme,
     prefersAuto: ({ preferredColorScheme }) => preferredColorScheme === ColorScheme.auto.value,
     prefersDark: ({ preferredColorScheme }) => preferredColorScheme === ColorScheme.dark.value,

--- a/tests/unit/components/ContentNode/TabNavigator.spec.js
+++ b/tests/unit/components/ContentNode/TabNavigator.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import TabNavigator from '@/components/ContentNode/TabNavigator.vue';
 import { mount } from '@vue/test-utils';

--- a/tests/unit/components/ContentNode/TabNavigator.spec.js
+++ b/tests/unit/components/ContentNode/TabNavigator.spec.js
@@ -6,13 +6,14 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import TabNavigator from '@/components/ContentNode/TabNavigator.vue';
 import { mount } from '@vue/test-utils';
 import Tabnav from '@/components/Tabnav.vue';
 import TabnavItem from '@/components/TabnavItem.vue';
 import { flushPromises } from '../../../../test-utils';
+import ImageLoadingStrategy from '@/constants/ImageLoadingStrategy';
 
 const titles = ['Long tab title', 'A Longer tab title'];
 const scopedSlots = {
@@ -45,6 +46,8 @@ describe('TabNavigator.spec', () => {
     });
     expect(wrapper.findAll(TabnavItem)).toHaveLength(2);
     expect(wrapper.find('.tabs-content').text()).toEqual('First');
+    // eslint-disable-next-line no-underscore-dangle
+    expect(wrapper.vm._provided).toHaveProperty('imageLoadingStrategy', ImageLoadingStrategy.eager);
   });
 
   it('sets the TabNavigator in `vertical` mode', async () => {

--- a/tests/unit/components/ContentNode/TabNavigator.spec.js
+++ b/tests/unit/components/ContentNode/TabNavigator.spec.js
@@ -12,8 +12,8 @@ import TabNavigator from '@/components/ContentNode/TabNavigator.vue';
 import { mount } from '@vue/test-utils';
 import Tabnav from '@/components/Tabnav.vue';
 import TabnavItem from '@/components/TabnavItem.vue';
-import { flushPromises } from '../../../../test-utils';
 import ImageLoadingStrategy from '@/constants/ImageLoadingStrategy';
+import { flushPromises } from '../../../../test-utils';
 
 const titles = ['Long tab title', 'A Longer tab title'];
 const scopedSlots = {

--- a/tests/unit/components/ImageAsset.spec.js
+++ b/tests/unit/components/ImageAsset.spec.js
@@ -11,8 +11,8 @@
 import { shallowMount } from '@vue/test-utils';
 import ImageAsset from 'docc-render/components/ImageAsset.vue';
 
-import { flushPromises } from '../../../test-utils';
 import ImageLoadingStrategy from '@/constants/ImageLoadingStrategy';
+import { flushPromises } from '../../../test-utils';
 
 jest.mock('docc-render/stores/AppStore', () => ({
   state: {

--- a/tests/unit/components/ImageAsset.spec.js
+++ b/tests/unit/components/ImageAsset.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import { shallowMount } from '@vue/test-utils';
 import ImageAsset from 'docc-render/components/ImageAsset.vue';

--- a/tests/unit/components/ImageAsset.spec.js
+++ b/tests/unit/components/ImageAsset.spec.js
@@ -6,12 +6,13 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import { shallowMount } from '@vue/test-utils';
 import ImageAsset from 'docc-render/components/ImageAsset.vue';
 
 import { flushPromises } from '../../../test-utils';
+import ImageLoadingStrategy from '@/constants/ImageLoadingStrategy';
 
 jest.mock('docc-render/stores/AppStore', () => ({
   state: {
@@ -430,5 +431,32 @@ describe('ImageAsset', () => {
     expect(console.error).toHaveBeenCalledWith('Unable to calculate optimal image width');
 
     consoleSpy.mockRestore();
+  });
+
+  it('allows setting the loading strategy by a parent component', async () => {
+    const url = 'https://www.example.com/image.png';
+    const wrapper = shallowMount(ImageAsset, {
+      provide: {
+        imageLoadingStrategy: ImageLoadingStrategy.eager,
+      },
+      propsData: {
+        variants: [
+          {
+            traits: [
+              '2x',
+              'light',
+            ],
+            url,
+            size: {
+              width: 1202,
+              height: 630,
+            },
+          },
+        ],
+      },
+    });
+
+    const image = wrapper.find('img');
+    expect(image.attributes('loading')).toBe(ImageLoadingStrategy.eager);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 105363672

## Summary

This fixes a bug where images are not rendered inside tabnavs, for Safari only.

This only happens if the image is a `display: block`, and has some element before it. Really strange, but removing the `loading: lazy` fixes it.

## Dependencies

NA

## Testing

Compile and try with this:

```md
@TabNavigator{
  @Tab("Image With Title"){
    **Strong Title**

    @Image(source: example.png)
  }
  @Tab("Image with Caption"){
    @Image(source: example.png){ Some text as a placeholder }
  }
}
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
