### PR TITLE
Allow hiding available tags in NavigatorCard.vue

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -226,6 +226,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    hideAvailableTags: {
+      type: Boolean,
+      default: false,
+    },
   },
   mixins: [
     keyboardNavigation,
@@ -266,9 +270,9 @@ export default {
      * Shows only tags, that have children matches.
      */
     availableTags: ({
-      selectedTags, renderableChildNodesMap, apiChangesObject,
+      selectedTags, renderableChildNodesMap, apiChangesObject, hideAvailableTags,
     }) => {
-      if (selectedTags.length) return [];
+      if (hideAvailableTags || selectedTags.length) return [];
       const apiChangesTypesSet = new Set(Object.values(apiChangesObject));
       const tagLabelsSet = new Set(Object.values(FILTER_TAGS_TO_LABELS));
       const generalTags = new Set([HIDE_DEPRECATED_TAG]);

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -148,6 +148,7 @@ describe('Navigator', () => {
       apiChanges: null,
       allowHiding: true,
       navigatorReferences,
+      hideAvailableTags: false,
     });
   });
 
@@ -187,6 +188,7 @@ describe('Navigator', () => {
       apiChanges: null,
       allowHiding: true,
       navigatorReferences,
+      hideAvailableTags: false,
     });
   });
 

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1159,6 +1159,19 @@ describe('NavigatorCard', () => {
     expect(all.at(3).props('item')).toEqual(root0Child1GrandChild0);
   });
 
+  it('allows hiding all available tags', async () => {
+    attachDivWithID(root0Child0.uid);
+    const wrapper = createWrapper();
+    await flushPromises();
+    const filter = wrapper.find(FilterInput);
+    expect(filter.props('tags')).toHaveLength(2);
+    wrapper.setProps({
+      hideAvailableTags: true,
+    });
+    await flushPromises();
+    expect(filter.props('tags')).toEqual([]);
+  });
+
   it('allows filtering the items using Tags, opening all items, that have matches in children', async () => {
     attachDivWithID(root0Child0.uid);
     const wrapper = createWrapper();


### PR DESCRIPTION
Bug/issue #, if applicable: 100278813

## Summary

Allows hiding any available tags in the NavigatorCard search

## Dependencies

NA

## Testing

To test this you would need to extend the NavigatorCard and apply the `hideAvailableTags: true` prop.

Assert no tags are shown, no matter what navigator items you have.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
