### PR TITLE
Update items size when clicking around navigator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16630,9 +16630,9 @@
       "dev": true
     },
     "vue-virtual-scroller": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.0.10.tgz",
-      "integrity": "sha512-Hn4qSBDhRY4XdngPioYy/ykDjrLX/NMm1fQXm/4UQQ/Xv1x8JbHGFZNftQowTcfICgN7yc31AKnUk1UGLJ2ndA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.1.2.tgz",
+      "integrity": "sha512-SkUyc7QHCJFB5h1Fya7LxVizlVzOZZuFVipBGHYoTK8dwLs08bIz/tclvRApYhksaJIm/nn51inzO2UjpGJPMQ==",
       "requires": {
         "scrollparent": "^2.0.1",
         "vue-observe-visibility": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "highlight.js": "^11.3.1",
     "intersection-observer": "0.12.0",
     "portal-vue": "2.1.7",
-    "vue-virtual-scroller": "^1.0.10",
+    "vue-virtual-scroller": "^1.1.2",
     "webpack-theme-resolver-plugin": "3.0.0"
   },
   "devDependencies": {

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -47,7 +47,10 @@
           @keydown.up.exact.capture.prevent="focusPrev"
           @keydown.down.exact.capture.prevent="focusNext"
         >
-          <DynamicScrollerItem v-bind="{ active, item, dataIndex: index }">
+          <DynamicScrollerItem
+            v-bind="{ active, item, dataIndex: index }"
+            :ref="`dynamicScroller_${item.uid}`"
+          >
             <NavigatorCardItem
               :item="item"
               :isRendered="active"
@@ -479,6 +482,14 @@ export default {
       if (value) return;
       // if we remove APIChanges, remove all related tags as well
       this.selectedTags = this.selectedTags.filter(t => !ChangeNames[t]);
+    },
+    async activeUID(newUid, oldUID) {
+      // update the dynamicScroller item's size, when we change the UID
+      await this.$nextTick();
+      const item = this.$refs[`dynamicScroller_${oldUID}`];
+      if (item && item.updateSize) {
+        item.updateSize();
+      }
     },
   },
   methods: {

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -484,10 +484,14 @@ export default {
       this.selectedTags = this.selectedTags.filter(t => !ChangeNames[t]);
     },
     async activeUID(newUid, oldUID) {
-      // update the dynamicScroller item's size, when we change the UID
+      // Update the dynamicScroller item's size, when we change the UID,
+      // to fix cases where applying styling that changes
+      // the size of active items.
       await this.$nextTick();
       const item = this.$refs[`dynamicScroller_${oldUID}`];
       if (item && item.updateSize) {
+        // call the `updateSize` method on the `DynamicScrollerItem`, since it wont get triggered,
+        // on its own from changing the active item.
         item.updateSize();
       }
     },

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -12,7 +12,7 @@ import NavigatorCard from '@/components/Navigator/NavigatorCard.vue';
 import BaseNavigatorCard from '@/components/Navigator/BaseNavigatorCard.vue';
 import { shallowMount } from '@vue/test-utils';
 import { TopicTypes } from '@/constants/TopicTypes';
-import { DynamicScroller } from 'vue-virtual-scroller';
+import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller';
 import 'intersection-observer';
 import { INDEX_ROOT_KEY, SIDEBAR_ITEM_SIZE } from '@/constants/sidebar';
 import NavigatorCardItem from '@/components/Navigator/NavigatorCardItem.vue';
@@ -46,6 +46,16 @@ const DynamicScrollerStub = {
     scrollToItem: jest.fn(),
   },
 };
+
+const DynamicScrollerItemStub = {
+  name: DynamicScrollerItem.name,
+  props: DynamicScrollerItem.props,
+  template: '<div class="dynamic-scroller-item-stub"><slot/></div>',
+  methods: {
+    updateSize: jest.fn(),
+  },
+};
+
 const root0 = {
   type: TopicTypes.collection,
   path: '/documentation/testkit',
@@ -165,6 +175,7 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(NavigatorC
   },
   stubs: {
     DynamicScroller: DynamicScrollerStub,
+    DynamicScrollerItem: DynamicScrollerItemStub,
     NavigatorCardItem: {
       props: NavigatorCardItem.props,
       template: '<div><button></button></div>',
@@ -1998,6 +2009,20 @@ describe('NavigatorCard', () => {
         enableFocus: false,
         navigatorReferences,
       });
+    });
+
+    it('updates the size of the DynamicScrollerItem, for the previous UID item', async () => {
+      attachDivWithID(root0Child0.uid);
+      const wrapper = createWrapper();
+      await flushPromises();
+      const allItems = wrapper.findAll(NavigatorCardItem);
+      const allDynamicItems = wrapper.findAll(DynamicScrollerItemStub);
+      allItems.at(2).vm.$emit('navigate', root0Child1.uid);
+      await flushPromises();
+      expect(DynamicScrollerItemStub.methods.updateSize).toHaveBeenCalledTimes(1);
+      expect(DynamicScrollerItemStub.methods.updateSize.mock.instances[0]).toEqual(
+        allDynamicItems.at(1).vm,
+      );
     });
 
     it('allows going back/forward, relative to last opened item, ignoring foreign trees', async () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 105885210

## Summary

Ensures items get their size properly updated, when clicking around the navigator. This prevents items that grew larger, to stay large if not needed anymore.

## Dependencies

NA

## Testing

Ensure items stay the correct size, like when being bolded.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
