### PR TITLE
Optimise the Navigator rendering, removing any unnecessary item re-renders

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -482,6 +482,11 @@ export default {
     },
   },
   methods: {
+    setUnlessEqual(property, data) {
+      if (isEqual(data, this[property])) return;
+
+      this[property] = Object.freeze(data);
+    },
     toggleAllNodes() {
       const parentNodes = this.children.filter(child => child.parent === INDEX_ROOT_KEY
         && child.type !== TopicTypes.groupMarker && child.childUIDs.length);
@@ -568,7 +573,7 @@ export default {
         all[current.uid] = true;
         return all;
       }, nodesToStartFrom);
-      this.openNodes = Object.freeze(newNodes);
+      this.setUnlessEqual('openNodes', newNodes);
 
       // merge in the new open nodes with the base nodes
       this.generateNodesToRender();
@@ -594,11 +599,11 @@ export default {
           delete openNodes[uid];
         });
         // set the new open nodes. Should be faster than iterating each and calling `this.$delete`.
-        this.openNodes = Object.freeze(openNodes);
+        this.setUnlessEqual('openNodes', openNodes);
         // exclude all items, but the first
         exclude = allChildren.slice(1);
       } else {
-        this.openNodes = Object.freeze({ ...this.openNodes, [node.uid]: true });
+        this.setUnlessEqual('openNodes', { ...this.openNodes, [node.uid]: true });
         // include all childUIDs to get opened
         include = getChildren(node.uid, this.childrenMap, this.children)
           .filter(child => this.renderableChildNodesMap[child.uid]);
@@ -628,7 +633,7 @@ export default {
       } else {
         include = allChildren.slice(1).filter(child => this.renderableChildNodesMap[child.uid]);
       }
-      this.openNodes = Object.freeze(openNodes);
+      this.setUnlessEqual('openNodes', openNodes);
       this.augmentRenderNodes({ uid: node.uid, exclude, include });
     },
     toggleSiblings(node) {
@@ -657,7 +662,7 @@ export default {
           this.augmentRenderNodes({ uid, exclude: [], include: children });
         }
       });
-      this.openNodes = Object.freeze(openNodes);
+      this.setUnlessEqual('openNodes', openNodes);
       // persist all the open nodes, as we change the openNodes after the node augment runs
       this.persistState();
     },
@@ -682,7 +687,7 @@ export default {
 
       // create a set of all matches and their parents
       // generate the list of nodes to render
-      this.nodesToRender = Object.freeze(children
+      this.setUnlessEqual('nodesToRender', children
         .filter(child => (
           // make sure the item can be rendered
           renderableChildNodesMap[child.uid]
@@ -708,13 +713,11 @@ export default {
         const clonedNodes = this.nodesToRender.slice(0);
         // inject the nodes at the index
         clonedNodes.splice(index + 1, 0, ...duplicatesRemoved);
-        this.nodesToRender = Object.freeze(clonedNodes);
+        this.setUnlessEqual('nodesToRender', clonedNodes);
       } else if (exclude.length) {
         // if remove, filter out those items
         const excludeSet = new Set(exclude);
-        this.nodesToRender = Object.freeze(
-          this.nodesToRender.filter(item => !excludeSet.has(item)),
-        );
+        this.setUnlessEqual('nodesToRender', this.nodesToRender.filter(item => !excludeSet.has(item)));
       }
       this.persistState();
     },
@@ -823,10 +826,10 @@ export default {
         return;
       }
       // create the openNodes map
-      this.openNodes = Object.freeze(Object.fromEntries(openNodes.map(n => [n, true])));
+      this.setUnlessEqual('openNodes', Object.fromEntries(openNodes.map(n => [n, true])));
       // get all the nodes to render
       // generate the array of flat children objects to render
-      this.nodesToRender = Object.freeze(nodesToRender.map(uid => childrenMap[uid]));
+      this.setUnlessEqual('nodesToRender', nodesToRender.map(uid => childrenMap[uid]));
       // finally fetch any previously assigned filters or tags
       this.selectedTags = selectedTags;
       this.filter = filter;


### PR DESCRIPTION
Bug/issue #, if applicable: 105184773

## Summary

This PR fixes issues that rise form the virtual-scroller re-rendering when it doesnt need to.

## Dependencies

NA

## Testing

Navigate across sibling items and assert if focus is lost, or if there are slight scrolls up/down on the navigator, when near the bottom, but items are still fully visible.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
