### PR TITLE
Fix View more link when there's no Primary Content

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -454,11 +454,13 @@ export default {
       deprecationSummary,
       downloadNotAvailableSummary,
       primaryContentSectionsSanitized,
+      enableMinimized,
     }) => (
       isRequirement
       || (deprecationSummary && deprecationSummary.length)
       || (downloadNotAvailableSummary && downloadNotAvailableSummary.length)
       || (primaryContentSectionsSanitized.length)
+      || enableMinimized // minimized mode always renders `ViewMore`
     ),
     viewMoreLink: ({
       interfaceLanguage,

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -498,7 +498,6 @@ describe('DocumentationTopic', () => {
       deprecationSummary: null,
       downloadNotAvailableSummary: null,
     });
-    console.log(wrapper.html());
     const viewMore = wrapper.find(ViewMore);
     expect(viewMore.exists()).toBe(true);
     expect(viewMore.props('url')).toEqual('/documentation/swift'); // normalized path

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -491,7 +491,14 @@ describe('DocumentationTopic', () => {
   });
 
   it('renders `ViewMore` if `enableMinimized`', () => {
-    wrapper.setProps({ enableMinimized: true });
+    wrapper.setProps({
+      enableMinimized: true,
+      primaryContentSections: undefined,
+      isRequirement: false,
+      deprecationSummary: null,
+      downloadNotAvailableSummary: null,
+    });
+    console.log(wrapper.html());
     const viewMore = wrapper.find(ViewMore);
     expect(viewMore.exists()).toBe(true);
     expect(viewMore.props('url')).toEqual('/documentation/swift'); // normalized path
@@ -569,6 +576,7 @@ describe('DocumentationTopic', () => {
       isRequirement: false,
       deprecationSummary: null,
       downloadNotAvailableSummary: null,
+      enableMinimized: false,
     });
     expect(wrapper.find(PrimaryContent).exists()).toBe(false);
     expect(wrapper.find('.description').exists()).toBe(false);


### PR DESCRIPTION
Bug/issue #, if applicable: 106166386

## Summary
Fix the issue where view more link is not displayed when there's no Primary Content

## Dependencies
NA

## Testing
Steps:
1.  Turn on Navigation Preview feature
2. Test with a page with no primary content
