### PR TITLE
Fix documentation page fails to load in minimized route for objc only pages

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -369,16 +369,16 @@ export default {
     };
   },
   computed: {
-    normalizedSwiftPath: ({ normalizePath, swiftPath }) => (
-      swiftPath ? normalizePath(swiftPath) : null
-    ),
+    normalizedSwiftPath: ({ normalizePath, swiftPath }) => (normalizePath(swiftPath)),
     normalizedObjcPath: ({
       normalizePath,
       objcPath,
+      swiftPath,
     }) => (
-      objcPath ? buildUrl(normalizePath(objcPath), {
+      // do not append language query parameter if no swiftPath exists
+      normalizePath((objcPath && swiftPath) ? buildUrl(objcPath, {
         language: Language.objectiveC.key.url,
-      }) : null
+      }) : objcPath)
     ),
     defaultImplementationsCount() {
       return (this.defaultImplementationsSections || []).reduce(
@@ -504,6 +504,7 @@ export default {
     normalizePath(path) {
       // Sometimes `paths` data from `variants` are prefixed with a leading
       // slash and sometimes they aren't
+      if (!path) return path;
       return path.startsWith('/') ? path : `/${path}`;
     },
     extractProps(json) {

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -369,7 +369,9 @@ export default {
     };
   },
   computed: {
-    normalizedSwiftPath: ({ normalizePath, swiftPath }) => (normalizePath(swiftPath)),
+    normalizedSwiftPath: ({ normalizePath, swiftPath }) => (
+      swiftPath ? normalizePath(swiftPath) : null
+    ),
     normalizedObjcPath: ({
       normalizePath,
       objcPath,

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -508,6 +508,7 @@ describe('DocumentationTopic', () => {
   });
 
   it('renders `ViewMore` with correct language path', () => {
+    // only objcPath
     wrapper.setProps({
       enableMinimized: true,
       swiftPath: null,
@@ -518,6 +519,7 @@ describe('DocumentationTopic', () => {
     expect(objcViewMore.exists()).toBe(true);
     expect(objcViewMore.props('url')).toEqual('/documentation/objc'); // normalized path
 
+    // only swiftPath
     wrapper.setProps({
       objcPath: null,
       swiftPath: 'documentation/swift',
@@ -526,6 +528,16 @@ describe('DocumentationTopic', () => {
     const swiftViewMore = wrapper.find(ViewMore);
     expect(swiftViewMore.exists()).toBe(true);
     expect(swiftViewMore.props('url')).toEqual('/documentation/swift'); // normalized path
+
+    // both paths exists, but on the objc variant
+    wrapper.setProps({
+      objcPath: 'documentation/objc',
+      swiftPath: 'documentation/swift',
+      interfaceLanguage: 'occ',
+    });
+    const viewMore = wrapper.find(ViewMore);
+    expect(viewMore.exists()).toBe(true);
+    expect(viewMore.props('url')).toEqual('/documentation/objc?language=objc'); // normalized path
   });
 
   describe('description column', () => {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -507,6 +507,27 @@ describe('DocumentationTopic', () => {
     expect(wrapper.find(ViewMore).exists()).toBe(false);
   });
 
+  it('renders `ViewMore` with correct language path', () => {
+    wrapper.setProps({
+      enableMinimized: true,
+      swiftPath: null,
+      objcPath: 'documentation/objc',
+      interfaceLanguage: 'occ',
+    });
+    const objcViewMore = wrapper.find(ViewMore);
+    expect(objcViewMore.exists()).toBe(true);
+    expect(objcViewMore.props('url')).toEqual('/documentation/objc'); // normalized path
+
+    wrapper.setProps({
+      objcPath: null,
+      swiftPath: 'documentation/swift',
+      interfaceLanguage: 'swift',
+    });
+    const swiftViewMore = wrapper.find(ViewMore);
+    expect(swiftViewMore.exists()).toBe(true);
+    expect(swiftViewMore.props('url')).toEqual('/documentation/swift'); // normalized path
+  });
+
   describe('description column', () => {
     it('renders the description section', () => {
       const description = wrapper.find('.description');


### PR DESCRIPTION
Bug/issue #, if applicable: 106383020 

## Summary
Fix documentation page fails to load in minimized route for objc only pages

## Testing
Load an objc only page in minimized mode
