### PR TITLE
Refactor for i18n utils and LocaleSelector

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -14,7 +14,7 @@
       <ColorSchemeToggle />
     </div>
     <div v-if="enablei18n" class="row">
-      <LocaleSelector @change="updateRouter"/>
+      <LocaleSelector/>
     </div>
   </footer>
 </template>
@@ -22,25 +22,13 @@
 <script>
 import ColorSchemeToggle from 'docc-render/components/ColorSchemeToggle.vue';
 import LocaleSelector from 'docc-render/components/LocaleSelector.vue';
-import { enablei18n, defaultLocale } from 'theme/lang/index.js';
-import { updateLangTag } from 'docc-render/utils/metadata';
+import { enablei18n } from 'theme/lang/index.js';
 
 export default {
   name: 'Footer',
   components: { ColorSchemeToggle, LocaleSelector },
   computed: {
     enablei18n: () => enablei18n,
-  },
-  methods: {
-    updateRouter({ target: { value: currentLocale } }) {
-      this.$i18n.locale = currentLocale;
-      this.$router.push({
-        params: {
-          locale: currentLocale === defaultLocale ? null : currentLocale,
-        },
-      });
-      updateLangTag(currentLocale);
-    },
   },
 };
 </script>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -14,7 +14,7 @@
       <ColorSchemeToggle />
     </div>
     <div v-if="enablei18n" class="row">
-      <LocaleSelector />
+      <LocaleSelector @change="updateRouter"/>
     </div>
   </footer>
 </template>
@@ -22,13 +22,25 @@
 <script>
 import ColorSchemeToggle from 'docc-render/components/ColorSchemeToggle.vue';
 import LocaleSelector from 'docc-render/components/LocaleSelector.vue';
-import { enablei18n } from 'theme/lang/index.js';
+import { enablei18n, defaultLocale } from 'theme/lang/index.js';
+import { updateLangTag } from 'docc-render/utils/metadata';
 
 export default {
   name: 'Footer',
   components: { ColorSchemeToggle, LocaleSelector },
   computed: {
     enablei18n: () => enablei18n,
+  },
+  methods: {
+    updateRouter({ target: { value: currentLocale } }) {
+      this.$i18n.locale = currentLocale;
+      this.$router.push({
+        params: {
+          locale: currentLocale === defaultLocale ? null : currentLocale,
+        },
+      });
+      updateLangTag(currentLocale);
+    },
   },
 };
 </script>

--- a/src/components/LocaleSelector.vue
+++ b/src/components/LocaleSelector.vue
@@ -13,7 +13,7 @@
     <select
       :value="$i18n.locale"
       :aria-label="$t('select-language')"
-      @change="updateRouter"
+      @change="$emit('change', $event)"
     >
       <option
         v-for="{ code, name } in locales"
@@ -30,8 +30,6 @@
 <script>
 import ChevronThickIcon from 'theme/components/Icons/ChevronThickIcon.vue';
 import locales from 'theme/lang/locales.json';
-import { defaultLocale } from 'theme/lang/index.js';
-import { updateLangTag } from 'docc-render/utils/metadata';
 
 export default {
   name: 'LocaleSelector',
@@ -42,17 +40,6 @@ export default {
     return {
       locales,
     };
-  },
-  methods: {
-    updateRouter({ target: { value: currentLocale } }) {
-      this.$i18n.locale = currentLocale;
-      this.$router.push({
-        params: {
-          locale: currentLocale === defaultLocale ? null : currentLocale,
-        },
-      });
-      updateLangTag(currentLocale);
-    },
   },
 };
 

--- a/src/components/LocaleSelector.vue
+++ b/src/components/LocaleSelector.vue
@@ -13,7 +13,7 @@
     <select
       :value="$i18n.locale"
       :aria-label="$t('select-language')"
-      @change="$emit('change', $event)"
+      @change="updateRouter"
     >
       <option
         v-for="{ code, name } in locales"
@@ -30,6 +30,8 @@
 <script>
 import ChevronThickIcon from 'theme/components/Icons/ChevronThickIcon.vue';
 import locales from 'theme/lang/locales.json';
+import { defaultLocale } from 'theme/lang/index.js';
+import { updateLangTag } from 'docc-render/utils/metadata';
 
 export default {
   name: 'LocaleSelector',
@@ -40,6 +42,18 @@ export default {
     return {
       locales,
     };
+  },
+  methods: {
+    updateRouter({ target: { value: currentLocale } }) {
+      const { slug } = locales.find(locale => locale.code === currentLocale);
+      this.$i18n.locale = currentLocale;
+      this.$router.push({
+        params: {
+          locale: currentLocale === defaultLocale ? null : slug,
+        },
+      });
+      updateLangTag(currentLocale);
+    },
   },
 };
 

--- a/src/components/LocaleSelector.vue
+++ b/src/components/LocaleSelector.vue
@@ -16,9 +16,10 @@
       @change="updateRouter"
     >
       <option
-        v-for="{ code, name } in locales"
-        :key="code"
-        :value="code"
+        v-for="{ slug, name, code } in locales"
+        :key="slug"
+        :value="slug"
+        :lang="code"
       >
         {{ name }}
       </option>
@@ -31,8 +32,7 @@
 import ChevronThickIcon from 'theme/components/Icons/ChevronThickIcon.vue';
 import locales from 'theme/lang/locales.json';
 import { defaultLocale } from 'theme/lang/index.js';
-import { updateLangTag } from 'docc-render/utils/metadata';
-import { getSlug } from 'docc-render/utils/i18n-utils';
+import { updateLocale } from 'docc-render/utils/i18n-utils';
 
 export default {
   name: 'LocaleSelector',
@@ -45,15 +45,13 @@ export default {
     };
   },
   methods: {
-    updateRouter({ target: { value: currentLocale } }) {
-      const slug = getSlug(currentLocale);
-      this.$i18n.locale = currentLocale;
+    updateRouter({ target: { value: slug } }) {
       this.$router.push({
         params: {
-          locale: currentLocale === defaultLocale ? null : slug,
+          locale: slug === defaultLocale ? null : slug,
         },
       });
-      updateLangTag(currentLocale);
+      updateLocale(slug, this);
     },
   },
 };

--- a/src/components/LocaleSelector.vue
+++ b/src/components/LocaleSelector.vue
@@ -32,6 +32,7 @@ import ChevronThickIcon from 'theme/components/Icons/ChevronThickIcon.vue';
 import locales from 'theme/lang/locales.json';
 import { defaultLocale } from 'theme/lang/index.js';
 import { updateLangTag } from 'docc-render/utils/metadata';
+import { getSlug } from 'docc-render/utils/i18n-utils';
 
 export default {
   name: 'LocaleSelector',
@@ -45,7 +46,7 @@ export default {
   },
   methods: {
     updateRouter({ target: { value: currentLocale } }) {
-      const { slug } = locales.find(locale => locale.code === currentLocale);
+      const slug = getSlug(currentLocale);
       this.$i18n.locale = currentLocale;
       this.$router.push({
         params: {

--- a/src/components/Navigator/NavigatorDataProvider.vue
+++ b/src/components/Navigator/NavigatorDataProvider.vue
@@ -33,10 +33,6 @@ export default {
       type: String,
       required: true,
     },
-    currentLocale: {
-      type: String,
-      required: true,
-    },
     apiChangesVersion: {
       type: String,
       default: '',
@@ -93,7 +89,7 @@ export default {
       try {
         this.isFetching = true;
         const { interfaceLanguages, references } = await fetchIndexPathsData(
-          { currentLocale: this.currentLocale },
+          { locale: this.$route.params.locale || '' },
         );
         this.navigationIndex = Object.freeze(interfaceLanguages);
         this.navigationReferences = Object.freeze(references);
@@ -105,9 +101,10 @@ export default {
     },
   },
   watch: {
-    currentLocale: {
-      immediate: true,
+    '$route.params.locale': {
       handler: 'fetchIndexData',
+      deep: true,
+      immediate: true,
     },
   },
   render() {

--- a/src/components/Navigator/NavigatorDataProvider.vue
+++ b/src/components/Navigator/NavigatorDataProvider.vue
@@ -89,7 +89,7 @@ export default {
       try {
         this.isFetching = true;
         const { interfaceLanguages, references } = await fetchIndexPathsData(
-          { locale: this.$route.params.locale || '' },
+          { slug: this.$route.params.locale || '' },
         );
         this.navigationIndex = Object.freeze(interfaceLanguages);
         this.navigationReferences = Object.freeze(references);
@@ -103,7 +103,6 @@ export default {
   watch: {
     '$route.params.locale': {
       handler: 'fetchIndexData',
-      deep: true,
       immediate: true,
     },
   },

--- a/src/lang/locales.json
+++ b/src/lang/locales.json
@@ -1,14 +1,17 @@
 [
   {
     "code": "en-US",
-    "name": "English"
+    "name": "English",
+    "slug": "en-US"
   },
   {
     "code": "zh-CN",
-    "name": "简体中文"
+    "name": "简体中文",
+    "slug": "zh-CN"
   },
   {
     "code": "ja-JP",
-    "name": "日本語"
+    "name": "日本語",
+    "slug": "ja-JP"
   }
 ]

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -15,7 +15,6 @@ import { baseUrl } from 'docc-render/utils/theme-settings';
 import RedirectError from 'docc-render/errors/RedirectError';
 import FetchError from 'docc-render/errors/FetchError';
 import { defaultLocale } from 'theme/lang/index.js';
-import { getSlug } from 'docc-render/utils/i18n-utils';
 
 export async function fetchData(path, params = {}, options = {}) {
   function isBadResponse(response) {
@@ -138,8 +137,8 @@ export function clone(jsonObject) {
   return JSON.parse(JSON.stringify(jsonObject));
 }
 
-export async function fetchIndexPathsData({ currentLocale }) {
-  const slug = currentLocale === defaultLocale ? '' : getSlug(currentLocale);
+export async function fetchIndexPathsData({ locale }) {
+  const slug = locale === defaultLocale ? '' : locale;
   const path = new URL(`${pathJoin([baseUrl, 'index/', slug, 'index.json'])}`, window.location.href);
   return fetchData(path);
 }

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -15,6 +15,7 @@ import { baseUrl } from 'docc-render/utils/theme-settings';
 import RedirectError from 'docc-render/errors/RedirectError';
 import FetchError from 'docc-render/errors/FetchError';
 import { defaultLocale } from 'theme/lang/index.js';
+import { getSlug } from 'docc-render/utils/i18n-utils';
 
 export async function fetchData(path, params = {}, options = {}) {
   function isBadResponse(response) {
@@ -138,7 +139,7 @@ export function clone(jsonObject) {
 }
 
 export async function fetchIndexPathsData({ currentLocale }) {
-  const locale = currentLocale === defaultLocale ? '' : currentLocale;
-  const path = new URL(`${pathJoin([baseUrl, 'index/', locale, 'index.json'])}`, window.location.href);
+  const slug = currentLocale === defaultLocale ? '' : getSlug(currentLocale);
+  const path = new URL(`${pathJoin([baseUrl, 'index/', slug, 'index.json'])}`, window.location.href);
   return fetchData(path);
 }

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -14,7 +14,6 @@ import emitWarningForSchemaVersionMismatch from 'docc-render/utils/schema-versio
 import { baseUrl } from 'docc-render/utils/theme-settings';
 import RedirectError from 'docc-render/errors/RedirectError';
 import FetchError from 'docc-render/errors/FetchError';
-import { defaultLocale } from 'theme/lang/index.js';
 
 export async function fetchData(path, params = {}, options = {}) {
   function isBadResponse(response) {
@@ -137,8 +136,7 @@ export function clone(jsonObject) {
   return JSON.parse(JSON.stringify(jsonObject));
 }
 
-export async function fetchIndexPathsData({ locale }) {
-  const slug = locale === defaultLocale ? '' : locale;
+export async function fetchIndexPathsData({ slug }) {
   const path = new URL(`${pathJoin([baseUrl, 'index/', slug, 'index.json'])}`, window.location.href);
   return fetchData(path);
 }

--- a/src/utils/i18n-utils.js
+++ b/src/utils/i18n-utils.js
@@ -8,11 +8,11 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import appLocales from 'theme/lang/locales.json';
+import locales from 'theme/lang/locales.json';
 import { defaultLocale } from 'theme/lang/index.js';
 import { updateLangTag } from 'docc-render/utils/metadata';
 
-const localeCodes = new Set(appLocales.map(appLocale => appLocale.code));
+const localeCodes = new Set(locales.map(appLocale => appLocale.code));
 
 /**
  * Check if locale is valid
@@ -45,4 +45,14 @@ export function updateLocale(locale = defaultLocale, env) {
 export function updateCurrentLocale(to, env) {
   const currentLocale = to.params.locale;
   updateLocale(currentLocale, env);
+}
+
+/**
+ * Get locale slug from locale code
+ * @param {String} localeCode - locale code
+ * @return {String}
+ */
+export function getSlug(localeCode) {
+  const locale = locales.find(({ code }) => code === localeCode);
+  return locale ? locale.slug : '';
 }

--- a/src/utils/i18n-utils.js
+++ b/src/utils/i18n-utils.js
@@ -25,16 +25,24 @@ export function localeIsValid(localeCode) {
 
 /**
  * Updates i18n global var and html lang
+ * @param {String} locale - locale used
+ * @param {Object{}} env - context
+ */
+export function updateLocale(locale = defaultLocale, env) {
+  // exist if current locale is not supported
+  if (!localeIsValid(locale)) return;
+  // update locale global var
+  env.$i18n.locale = locale; // eslint-disable-line no-param-reassign
+  // update html lang
+  updateLangTag(locale);
+}
+
+/**
+ * Updates i18n global var and html lang
  * @param {{ params: { locale: String } }} to - where the route navigates to
  * @param {Object{}} env - context
- * @param {{ code: String, name: String }[]} locales
  */
 export function updateCurrentLocale(to, env) {
-  const currentLocale = to.params.locale || defaultLocale;
-  // exist if current locale is not supported
-  if (!localeIsValid(currentLocale)) return;
-  // update locale global var
-  env.$i18n.locale = currentLocale; // eslint-disable-line no-param-reassign
-  // update html lang
-  updateLangTag(currentLocale);
+  const currentLocale = to.params.locale;
+  updateLocale(currentLocale, env);
 }

--- a/src/utils/i18n-utils.js
+++ b/src/utils/i18n-utils.js
@@ -12,15 +12,29 @@ import locales from 'theme/lang/locales.json';
 import { defaultLocale } from 'theme/lang/index.js';
 import { updateLangTag } from 'docc-render/utils/metadata';
 
-const localeCodes = new Set(locales.map(appLocale => appLocale.code));
+const localeSlug = new Set(locales.map(appLocale => appLocale.slug));
 
 /**
  * Check if locale is valid
  * @param {String} localeCode - locale code
  * @param {{ code: String }[]} locales - locales available
  */
-export function localeIsValid(localeCode) {
-  return localeCodes.has(localeCode);
+export function localeIsValid(slug) {
+  return localeSlug.has(slug);
+}
+
+const slugsForLocale = locales.reduce((map, locale) => ({
+  ...map,
+  [locale.slug]: locale.code,
+}), {});
+
+/**
+ * Get locale code from slug
+ * @param {String} slug
+ * @return {String}
+ */
+export function getCodeForSlug(slug) {
+  return slugsForLocale[slug];
 }
 
 /**
@@ -28,31 +42,13 @@ export function localeIsValid(localeCode) {
  * @param {String} locale - locale used
  * @param {Object{}} env - context
  */
-export function updateLocale(locale = defaultLocale, env) {
+export function updateLocale(slug = defaultLocale, env) {
   // exist if current locale is not supported
-  if (!localeIsValid(locale)) return;
+  if (!localeIsValid(slug)) return;
   // update locale global var
-  env.$i18n.locale = locale; // eslint-disable-line no-param-reassign
+  env.$i18n.locale = slug; // eslint-disable-line no-param-reassign
+  // get code
+  const code = getCodeForSlug(slug);
   // update html lang
-  updateLangTag(locale);
-}
-
-/**
- * Updates i18n global var and html lang
- * @param {{ params: { locale: String } }} to - where the route navigates to
- * @param {Object{}} env - context
- */
-export function updateCurrentLocale(to, env) {
-  const currentLocale = to.params.locale;
-  updateLocale(currentLocale, env);
-}
-
-/**
- * Get locale slug from locale code
- * @param {String} localeCode - locale code
- * @return {String}
- */
-export function getSlug(localeCode) {
-  const locale = locales.find(({ code }) => code === localeCode);
-  return locale ? locale.slug : '';
+  updateLangTag(code);
 }

--- a/src/utils/i18n-utils.js
+++ b/src/utils/i18n-utils.js
@@ -12,7 +12,7 @@ import locales from 'theme/lang/locales.json';
 import { defaultLocale } from 'theme/lang/index.js';
 import { updateLangTag } from 'docc-render/utils/metadata';
 
-const slugsForLocale = locales.reduce((map, locale) => ({
+const codeForSlug = locales.reduce((map, locale) => ({
   ...map,
   [locale.slug]: locale.code,
 }), {});
@@ -23,7 +23,7 @@ const slugsForLocale = locales.reduce((map, locale) => ({
  * @return {String}
  */
 export function getCodeForSlug(slug) {
-  return slugsForLocale[slug];
+  return codeForSlug[slug];
 }
 
 /**
@@ -31,7 +31,7 @@ export function getCodeForSlug(slug) {
  * @param {String} slug - locale code
  */
 export function localeIsValid(slug) {
-  return !!slugsForLocale[slug];
+  return !!codeForSlug[slug];
 }
 
 /**

--- a/src/utils/i18n-utils.js
+++ b/src/utils/i18n-utils.js
@@ -12,17 +12,6 @@ import locales from 'theme/lang/locales.json';
 import { defaultLocale } from 'theme/lang/index.js';
 import { updateLangTag } from 'docc-render/utils/metadata';
 
-const localeSlug = new Set(locales.map(appLocale => appLocale.slug));
-
-/**
- * Check if locale is valid
- * @param {String} localeCode - locale code
- * @param {{ code: String }[]} locales - locales available
- */
-export function localeIsValid(slug) {
-  return localeSlug.has(slug);
-}
-
 const slugsForLocale = locales.reduce((map, locale) => ({
   ...map,
   [locale.slug]: locale.code,
@@ -38,9 +27,17 @@ export function getCodeForSlug(slug) {
 }
 
 /**
+ * Check if locale is valid
+ * @param {String} slug - locale code
+ */
+export function localeIsValid(slug) {
+  return !!slugsForLocale[slug];
+}
+
+/**
  * Updates i18n global var and html lang
  * @param {String} locale - locale used
- * @param {Object{}} env - context
+ * @param {Object} env - context
  */
 export function updateLocale(slug = defaultLocale, env) {
   // exist if current locale is not supported

--- a/src/utils/metadata.js
+++ b/src/utils/metadata.js
@@ -9,7 +9,6 @@
 */
 import { getSetting } from 'docc-render/utils/theme-settings';
 import { resolveAbsoluteUrl } from 'docc-render/utils/url-helper';
-import locales from 'theme/lang/locales.json';
 
 const themeTitle = getSetting(['meta', 'title'], process.env.VUE_APP_TITLE);
 
@@ -124,17 +123,9 @@ export function addOrUpdateMetadata({
 }
 
 /**
- * It returns the iso code of a language in case it exists
- * @param {String} code
- */
-export function getISO(code) {
-  return locales.find(locale => locale.code === code).iso;
-}
-
-/**
  * It updates the document setting a new lang attribute with the iso code or fallback on the locale
  * @param {String} locale
  */
 export function updateLangTag(locale) {
-  document.querySelector('html').setAttribute('lang', getISO(locale) || locale);
+  document.querySelector('html').setAttribute('lang', locale);
 }

--- a/src/utils/metadata.js
+++ b/src/utils/metadata.js
@@ -9,6 +9,7 @@
 */
 import { getSetting } from 'docc-render/utils/theme-settings';
 import { resolveAbsoluteUrl } from 'docc-render/utils/url-helper';
+import locales from 'theme/lang/locales.json';
 
 const themeTitle = getSetting(['meta', 'title'], process.env.VUE_APP_TITLE);
 
@@ -122,6 +123,18 @@ export function addOrUpdateMetadata({
   );
 }
 
+/**
+ * It returns the iso code of a language in case it exists
+ * @param {String} code
+ */
+export function getISO(code) {
+  return locales.find(locale => locale.code === code).iso;
+}
+
+/**
+ * It updates the document setting a new lang attribute with the iso code or fallback on the locale
+ * @param {String} locale
+ */
 export function updateLangTag(locale) {
-  return document.querySelector('html').setAttribute('lang', locale);
+  document.querySelector('html').setAttribute('lang', getISO(locale) || locale);
 }

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -23,7 +23,6 @@
             :interface-language="topicProps.interfaceLanguage"
             :technologyUrl="technology.url"
             :api-changes-version="store.state.selectedAPIChangesVersion"
-            :currentLocale="enablei18n ? $i18n.locale : ''"
             ref="NavigatorDataProvider"
           >
             <template #default="slotProps">
@@ -125,7 +124,7 @@ import { BreakpointName } from 'docc-render/utils/breakpoints';
 import { storage } from 'docc-render/utils/storage';
 import { getSetting } from 'docc-render/utils/theme-settings';
 import OnThisPageRegistrator from 'docc-render/mixins/onThisPageRegistrator';
-import { updateCurrentLocale } from 'theme/utils/i18n-utils.js';
+import { updateLocale } from 'theme/utils/i18n-utils.js';
 import { enablei18n } from 'theme/lang/index.js';
 
 const MIN_RENDER_JSON_VERSION_WITH_INDEX = '0.3.0';
@@ -358,7 +357,7 @@ export default {
     }
 
     fetchDataForRouteEnter(to, from, next).then(data => next((vm) => {
-      updateCurrentLocale(to, vm);
+      updateLocale(to.params.locale, vm);
 
       vm.topicData = data; // eslint-disable-line no-param-reassign
       if (to.query.language === Language.objectiveC.key.url && vm.objcOverrides) {
@@ -378,7 +377,7 @@ export default {
         if (to.query.language === Language.objectiveC.key.url && this.objcOverrides) {
           this.applyObjcOverrides();
         }
-        updateCurrentLocale(to, this);
+        updateLocale(to.params.locale, this);
         next();
       }).catch(next);
     } else {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -125,7 +125,7 @@ import { BreakpointName } from 'docc-render/utils/breakpoints';
 import { storage } from 'docc-render/utils/storage';
 import { getSetting } from 'docc-render/utils/theme-settings';
 import OnThisPageRegistrator from 'docc-render/mixins/onThisPageRegistrator';
-import { updateCurrentLocale } from 'docc-render/utils/i18n-utils';
+import { updateCurrentLocale } from 'theme/utils/i18n-utils.js';
 import { enablei18n } from 'theme/lang/index.js';
 
 const MIN_RENDER_JSON_VERSION_WITH_INDEX = '0.3.0';

--- a/tests/unit/components/LocaleSelector.spec.js
+++ b/tests/unit/components/LocaleSelector.spec.js
@@ -16,12 +16,12 @@ jest.mock('theme/lang/locales.json', () => (
     {
       code: 'en-US',
       name: 'English',
-      slug: 'en-US',
+      slug: 'en',
     },
     {
       code: 'zh-CN',
       name: '简体中文',
-      slug: 'zh-CN',
+      slug: 'cn',
     },
   ]
 ));
@@ -48,11 +48,11 @@ describe('LocaleSelector', () => {
     const options = wrapper.findAll('option');
     expect(options).toHaveLength(2);
     expect(options.at(0).text()).toBe('English');
-    expect(options.at(0).attributes('value')).toBe('en-US');
+    expect(options.at(0).attributes('value')).toBe('en');
     expect(options.at(0).attributes('lang')).toBe('en-US');
 
     expect(options.at(1).text()).toBe('简体中文');
-    expect(options.at(1).attributes('value')).toBe('zh-CN');
+    expect(options.at(1).attributes('value')).toBe('cn');
     expect(options.at(1).attributes('lang')).toBe('zh-CN');
   });
 });

--- a/tests/unit/components/LocaleSelector.spec.js
+++ b/tests/unit/components/LocaleSelector.spec.js
@@ -16,10 +16,12 @@ jest.mock('theme/lang/locales.json', () => (
     {
       code: 'en-US',
       name: 'English',
+      slug: 'en-US',
     },
     {
       code: 'zh-CN',
       name: '简体中文',
+      slug: 'zh-CN',
     },
   ]
 ));
@@ -47,8 +49,10 @@ describe('LocaleSelector', () => {
     expect(options).toHaveLength(2);
     expect(options.at(0).text()).toBe('English');
     expect(options.at(0).attributes('value')).toBe('en-US');
+    expect(options.at(0).attributes('lang')).toBe('en-US');
 
     expect(options.at(1).text()).toBe('简体中文');
     expect(options.at(1).attributes('value')).toBe('zh-CN');
+    expect(options.at(1).attributes('lang')).toBe('zh-CN');
   });
 });

--- a/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
+++ b/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
@@ -11,7 +11,6 @@
 import NavigatorDataProvider from '@/components/Navigator/NavigatorDataProvider.vue';
 import { shallowMount } from '@vue/test-utils';
 import Language from 'docc-render/constants/Language';
-import { defaultLocale } from 'theme/lang/index.js';
 import { TopicTypes } from '@/constants/TopicTypes';
 import { fetchIndexPathsData } from '@/utils/data';
 import { INDEX_ROOT_KEY } from '@/constants/sidebar';
@@ -145,7 +144,6 @@ fetchIndexPathsData.mockResolvedValue(response);
 
 const defaultProps = {
   technologyUrl,
-  currentLocale: defaultLocale,
 };
 
 let props = {};
@@ -159,6 +157,13 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(NavigatorD
     default: (p) => {
       props = p;
       return 'Text';
+    },
+  },
+  mocks: {
+    $route: {
+      params: {
+        locale: 'en-US',
+      },
     },
   },
   ...others,

--- a/tests/unit/utils/data.spec.js
+++ b/tests/unit/utils/data.spec.js
@@ -373,7 +373,7 @@ describe('fetchIndexPathsData', () => {
     expect(data).toEqual({ foobar: 'foobar' });
     // fetch data with another locale
     const locale = 'zh-CN';
-    await fetchIndexPathsData({ currentLocale: locale });
+    await fetchIndexPathsData({ locale });
     expect(fetch).toHaveBeenLastCalledWith(`http://localhost/index/${locale}/index.json`, {});
   });
 });

--- a/tests/unit/utils/data.spec.js
+++ b/tests/unit/utils/data.spec.js
@@ -22,6 +22,10 @@ import { defaultLocale } from 'theme/lang/index.js';
 
 jest.mock('docc-render/utils/schema-version-check', () => jest.fn());
 
+jest.mock('docc-render/utils/metadata', () => ({
+  updateLangTag: jest.fn(),
+}));
+
 const mockBaseUrl = jest.fn().mockReturnValue('/');
 
 jest.mock('docc-render/utils/theme-settings', () => ({

--- a/tests/unit/utils/data.spec.js
+++ b/tests/unit/utils/data.spec.js
@@ -372,8 +372,8 @@ describe('fetchIndexPathsData', () => {
     expect(fetch).toHaveBeenLastCalledWith('http://localhost/index/index.json', {});
     expect(data).toEqual({ foobar: 'foobar' });
     // fetch data with another locale
-    const locale = 'zh-CN';
-    await fetchIndexPathsData({ locale });
-    expect(fetch).toHaveBeenLastCalledWith(`http://localhost/index/${locale}/index.json`, {});
+    const slug = 'zh-CN';
+    await fetchIndexPathsData({ slug });
+    expect(fetch).toHaveBeenLastCalledWith(`http://localhost/index/${slug}/index.json`, {});
   });
 });

--- a/tests/unit/utils/i18n-utils.spec.js
+++ b/tests/unit/utils/i18n-utils.spec.js
@@ -8,7 +8,7 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { localeIsValid, updateCurrentLocale } from '@/utils/i18n-utils';
+import { localeIsValid, updateLocale } from '@/utils/i18n-utils';
 import { updateLangTag } from 'docc-render/utils/metadata';
 
 jest.mock('theme/lang/locales.json', () => (
@@ -16,10 +16,12 @@ jest.mock('theme/lang/locales.json', () => (
     {
       code: 'en-US',
       name: 'English',
+      slug: 'en-US',
     },
     {
       code: 'zh-CN',
       name: '简体中文',
+      slug: 'zh-CN',
     },
   ]
 ));
@@ -47,9 +49,9 @@ describe('localeIsValid', () => {
   });
 });
 
-describe('updateCurrentLocale', () => {
+describe('updateLocale', () => {
   it('updates current global var for locale', () => {
-    updateCurrentLocale(to, env);
+    updateLocale(to.params.locale, env);
     expect(env.$i18n.locale).toBe('zh-CN');
     expect(updateLangTag).toHaveBeenCalledTimes(1);
   });

--- a/tests/unit/utils/i18n-utils.spec.js
+++ b/tests/unit/utils/i18n-utils.spec.js
@@ -16,12 +16,12 @@ jest.mock('theme/lang/locales.json', () => (
     {
       code: 'en-US',
       name: 'English',
-      slug: 'en-US',
+      slug: 'en',
     },
     {
       code: 'zh-CN',
       name: '简体中文',
-      slug: 'zh-CN',
+      slug: 'cn',
     },
   ]
 ));
@@ -32,19 +32,19 @@ jest.mock('docc-render/utils/metadata', () => ({
 
 const to = {
   params: {
-    locale: 'zh-CN',
+    locale: 'cn',
   },
 };
 
 const env = {
   $i18n: {
-    locale: 'en-US',
+    locale: 'en',
   },
 };
 
 describe('localeIsValid', () => {
   it('checks that locale is inside locales', () => {
-    expect(localeIsValid('en-US')).toBe(true);
+    expect(localeIsValid('en')).toBe(true);
     expect(localeIsValid('es-ES')).toBe(false);
   });
 });
@@ -52,7 +52,7 @@ describe('localeIsValid', () => {
 describe('updateLocale', () => {
   it('updates current global var for locale', () => {
     updateLocale(to.params.locale, env);
-    expect(env.$i18n.locale).toBe('zh-CN');
+    expect(env.$i18n.locale).toBe('cn');
     expect(updateLangTag).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/utils/metadata.spec.js
+++ b/tests/unit/utils/metadata.spec.js
@@ -16,12 +16,12 @@ jest.mock('theme/lang/locales.json', () => (
     {
       code: 'en-US',
       name: 'English',
-      slug: 'en-US',
+      slug: 'en',
     },
     {
       code: 'zh-CN',
       name: '简体中文',
-      slug: 'zh-CN',
+      slug: 'cn',
     },
   ]
 ));

--- a/tests/unit/utils/metadata.spec.js
+++ b/tests/unit/utils/metadata.spec.js
@@ -16,10 +16,12 @@ jest.mock('theme/lang/locales.json', () => (
     {
       code: 'en-US',
       name: 'English',
+      slug: 'en-US',
     },
     {
       code: 'zh-CN',
       name: '简体中文',
+      slug: 'zh-CN',
     },
   ]
 ));

--- a/tests/unit/utils/metadata.spec.js
+++ b/tests/unit/utils/metadata.spec.js
@@ -8,15 +8,14 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { addOrUpdateMetadata, getISO, updateLangTag } from 'docc-render/utils/metadata';
+import { addOrUpdateMetadata, updateLangTag } from 'docc-render/utils/metadata';
 import { defaultLocale } from 'theme/lang/index.js';
 
 jest.mock('theme/lang/locales.json', () => (
   [
     {
-      code: 'en',
+      code: 'en-US',
       name: 'English',
-      iso: 'en-US',
     },
     {
       code: 'zh-CN',
@@ -121,19 +120,8 @@ describe('Metadata', () => {
   });
 });
 
-describe('getISO', () => {
-  it('returns ISO code', () => {
-    expect(getISO('en')).toBe('en-US');
-  });
-});
-
 describe('updateLangTag', () => {
-  it('updates the lang tag on the HTML with ISO code if exist', () => {
-    updateLangTag('en');
-    expect(document.querySelector('html').getAttribute('lang')).toBe('en-US');
-  });
-
-  it('updates the lang tag on the HTML with code if ISO code does not exist', () => {
+  it('updates the lang tag on the HTML with code', () => {
     updateLangTag('zh-CN');
     expect(document.querySelector('html').getAttribute('lang')).toBe('zh-CN');
   });

--- a/tests/unit/utils/metadata.spec.js
+++ b/tests/unit/utils/metadata.spec.js
@@ -8,8 +8,22 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { addOrUpdateMetadata } from 'docc-render/utils/metadata';
+import { addOrUpdateMetadata, getISO, updateLangTag } from 'docc-render/utils/metadata';
 import { defaultLocale } from 'theme/lang/index.js';
+
+jest.mock('theme/lang/locales.json', () => (
+  [
+    {
+      code: 'en',
+      name: 'English',
+      iso: 'en-US',
+    },
+    {
+      code: 'zh-CN',
+      name: '简体中文',
+    },
+  ]
+));
 
 const fs = require('fs');
 const path = require('path');
@@ -104,5 +118,23 @@ describe('Metadata', () => {
     addOrUpdateMetadata({ description: differentDescription });
     expect(document.querySelector('meta[name="description"]').content).toBe(differentDescription);
     expect(document.querySelectorAll('meta[name="description"]')).toHaveLength(1);
+  });
+});
+
+describe('getISO', () => {
+  it('returns ISO code', () => {
+    expect(getISO('en')).toBe('en-US');
+  });
+});
+
+describe('updateLangTag', () => {
+  it('updates the lang tag on the HTML with ISO code if exist', () => {
+    updateLangTag('en');
+    expect(document.querySelector('html').getAttribute('lang')).toBe('en-US');
+  });
+
+  it('updates the lang tag on the HTML with code if ISO code does not exist', () => {
+    updateLangTag('zh-CN');
+    expect(document.querySelector('html').getAttribute('lang')).toBe('zh-CN');
   });
 });

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -75,6 +75,9 @@ const mocks = {
   },
   $route: {
     path: '/documentation/somepath',
+    params: {
+      locale: 'en-US',
+    },
   },
 };
 
@@ -217,7 +220,6 @@ describe('DocumentationTopic', () => {
     expect(wrapper.find(NavigatorDataProvider).props()).toEqual({
       interfaceLanguage: Language.swift.key.url,
       technologyUrl: technology.url,
-      currentLocale: '',
       apiChangesVersion: null,
     });
     // its rendered by default
@@ -319,7 +321,6 @@ describe('DocumentationTopic', () => {
     expect(wrapper.find(NavigatorDataProvider).props()).toEqual({
       interfaceLanguage: Language.swift.key.url,
       technologyUrl: technology.url,
-      currentLocale: defaultLocale,
       apiChangesVersion: null,
     });
   });


### PR DESCRIPTION
Bug/issue #106158283, if applicable: 

## Summary

Refactor for i18n utils and LocaleSelector

## Dependencies

NA

## Testing

Steps:
1. Add the following to `theme-settings.json` file at public folder
```json
{
  "features": {
    "docs": {
      "i18n": {
        "enable": true
      }
    }
  }
}
```
3. Run `npm run serve`
2. Go to the bottom of the page and change the language in the locale selector
3. Assert that everything works properly

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
