### PR TITLE
Make highlight.js languages user-configurable

### DIFF
--- a/SwiftDocCRender.docc/contributing/Internals.md
+++ b/SwiftDocCRender.docc/contributing/Internals.md
@@ -177,6 +177,7 @@ DocC-Render has a few build-time environment flags, that allow you to set config
 
 * **VUE_APP_DEV_SERVER_PROXY** - The HTTP endpoint or  local filepath to read render JSON from when using the development server
 * **VUE_APP_TITLE** - An optional default page title to apply to pages
+* **VUE_APP_HLJS_LANGUAGES** - An optional comma-separated list of highlight.js languages to include in the build
 
 #### Available Scripts
 

--- a/src/setup-utils/vue-config-utils.js
+++ b/src/setup-utils/vue-config-utils.js
@@ -12,6 +12,8 @@ const fs = require('fs');
 const path = require('path');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const ThemeResolverPlugin = require('webpack-theme-resolver-plugin');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const webpack = require('webpack');
 const themeUtils = require('./theme-build-utils');
 const { BannerPlugin, LICENSE_HEADER } = require('./license-header-built-files');
 
@@ -70,6 +72,16 @@ function baseChainWebpack(config) {
     .use(BannerPlugin, [{
       banner: LICENSE_HEADER,
     }]);
+
+  // Limit highlight.js to only the necessary languages
+  const builtinLanguages = 'bash|c|s?css|cpp|diff|http|java|llvm|perl|php|python|ruby|xml|javascript|json|markdown|objectivec|shell|swift';
+  const envLanguages = (process.env.VUE_APP_HLJS_LANGUAGES ?? '').split(',').join('|');
+  config
+    .plugin('LanguagesPlugin')
+    .use(webpack.ContextReplacementPlugin, [
+      /highlight\.js\/lib\/languages$/,
+      new RegExp(`/(${[builtinLanguages, envLanguages].join('|')})$`),
+    ]);
 }
 
 function baseDevServer({ defaultDevServerProxy = 'http://localhost:8000' } = {}) {

--- a/src/utils/syntax-highlight.js
+++ b/src/utils/syntax-highlight.js
@@ -37,6 +37,12 @@ const Languages = {
   shell: ['console', 'shellsession'],
   swift: [],
   xml: ['html', 'xhtml', 'rss', 'atom', 'xjb', 'xsd', 'xsl', 'plist', 'wsf', 'svg'],
+  // load more languages from the environment
+  ...(
+    process.env.VUE_APP_HLJS_LANGUAGES
+      ? Object.fromEntries(process.env.VUE_APP_HLJS_LANGUAGES.split(',').map(l => [l, []]))
+      : undefined
+  ),
 };
 
 export const CustomLanguagesSet = new Set([
@@ -83,8 +89,6 @@ async function importHighlightFileForLanguage(language) {
       } else {
         languageFile = await import(
           /* webpackChunkName: "highlight-js-[request]" */
-          // eslint-disable-next-line max-len
-          /* webpackInclude: /\/(bash|c|s?css|cpp|diff|http|java|llvm|perl|php|python|ruby|xml|javascript|json|markdown|objectivec|shell|swift)\.js$/ */
           `highlight.js/lib/languages/${file}`
         );
       }


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

In some cases, documentation may use codeblocks with languages other than those enabled by default in `swift-docc-render`. In our case, we want to include Elixir codeblocks in the [LiveViewNative](https://github.com/liveview-native/liveview-client-swiftui) docs.

This PR makes it possible to build with a custom set of supported languages which are added to the default set with an environment variable:

```sh
VUE_APP_HLJS_LANGUAGES=elixir npm run build
```

Multiple languages can be added with a comma-separated list:

```sh
VUE_APP_HLJS_LANGUAGES=elixir,haskell npm run build
```

Now codeblocks for Elixir are properly highlighted!

<img width="464" alt="Screenshot 2023-03-15 at 1 27 08 PM" src="https://user-images.githubusercontent.com/13581484/225395177-f714201c-12cd-4cfd-92af-3e15ca3d118c.png">

I used webpack's `ContextReplacementPlugin` to ensure only the necessary languages are included in the bundle. This replaces the `webpackInclude` magic comment in `src/utils/syntax-highlight.js`.

## Dependencies

N/A

## Testing

Steps:
1. Write documentation with a codeblock in an unsupported language, such as Elixir.

```markdown
    ```elixir
    def hello do
        :world
    end
    ```
```

2. Build `swift-docc-render` with the `VUE_APP_HLJS_LANGUAGES` variable.

```sh
VUE_APP_HLJS_LANGUAGES=elixir npm run build
```

3. Preview the documentation and confirm the codeblock is properly highlighted.

```sh
DOCC_HTML_DIR=dist xcrun docc preview SwiftDocCRender.docc
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - I am unsure how to test environment variables, I'd be happy to add tests if needed.
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary