### PR TITLE
Ensure topicLinkCard items are always 16/9 aspect ratio

### DIFF
--- a/src/components/DocumentationTopic/TopicsLinkCardGridItem.vue
+++ b/src/components/DocumentationTopic/TopicsLinkCardGridItem.vue
@@ -79,6 +79,20 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .reference-card-grid-item {
+  // ensures card covers are always a 16/9 aspect ratio
+  --card-cover-height: auto;
+
+  &.card.large {
+    --card-cover-height: auto;
+    // .large and .small cards have min/max sizes
+    min-width: 0;
+    max-width: none;
+  }
+
+  /deep/ .card-cover {
+    aspect-ratio: 16/9;
+  }
+
   &__image {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Bug/issue #, if applicable: 106864428

## Summary

Set a hard aspect ratio size of 16/9 to the cards in LinksBlock grid sections.

## Dependencies

NA

## Testing

Load an archive that has LinkBlock of type `compactGrid` and `detailedGrid`, and ensure that the generated cards are always 16/9 size.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added tests~ - no, css only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
