### PR TITLE
Add explicit font-styles for h1/h2 in doc content

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -767,6 +767,14 @@ export default {
 }
 
 /deep/ {
+  h1 {
+    @include font-styles(headline-reduced);
+  }
+
+  h2 {
+    @include font-styles(heading-2-reduced);
+  }
+
   @each $heading in (h3, h4, h5, h6) {
     #{$heading} {
       @include font-styles(documentation-#{$heading});

--- a/src/components/DocumentationTopic/PrimaryContent.vue
+++ b/src/components/DocumentationTopic/PrimaryContent.vue
@@ -121,12 +121,6 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-/deep/ {
-  h2 {
-    @include font-styles(heading-2-reduced);
-  }
-}
-
 .primary-content {
   &.with-border::before {
     border-top-color: var(--colors-grid, var(--color-grid));


### PR DESCRIPTION
Bug/issue #, if applicable: 105804332

## Summary

For historical reasons, we never needed to bother with explicit font-styles for h1 and h2 headings in authored content. This updates h1 and h2 headings in article/symbol content to use the same font-style that we use elsewhere on the same page for these elements instead of relying on the browser default styles.

## Testing

Test content with custom h1 and h2 headings in an article or symbol page. Verify that the h1 font style matches the page title style and that the h2 font style matches the overview font style.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~ (CSS only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
