### PR TITLE
Remove the WordBreak component from the OnThisPageNav items

### DIFF
--- a/src/components/OnThisPageNav.vue
+++ b/src/components/OnThisPageNav.vue
@@ -20,8 +20,7 @@
           class="base-link"
           @click.native="handleFocusAndScroll(item.anchor)"
         >
-          <WordBreak v-if="item.i18n">{{ $t(item.title) }}</WordBreak>
-          <WordBreak v-else>{{ item.title }}</WordBreak>
+          <span>{{ item.i18n ? $t(item.title): item.title }}</span>
         </router-link>
       </li>
     </ul>
@@ -33,11 +32,9 @@ import throttle from 'docc-render/utils/throttle';
 import { waitFrames } from 'docc-render/utils/loading';
 import ScrollToElement from 'docc-render/mixins/scrollToElement';
 import { buildUrl } from 'docc-render/utils/url-helper';
-import WordBreak from 'docc-render/components/WordBreak.vue';
 
 export default {
   name: 'OnThisPageNav',
-  components: { WordBreak },
   mixins: [ScrollToElement],
   inject: {
     store: {

--- a/tests/unit/components/OnThisPageNav.spec.js
+++ b/tests/unit/components/OnThisPageNav.spec.js
@@ -12,7 +12,6 @@ import Vue from 'vue';
 import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import OnThisPageNav from '@/components/OnThisPageNav.vue';
 import { AppTopID } from '@/constants/AppTopID';
-import WordBreak from '@/components/WordBreak.vue';
 import { createEvent, flushPromises } from '../../../test-utils';
 
 jest.mock('docc-render/utils/throttle', () => jest.fn(v => v));
@@ -110,12 +109,12 @@ describe('OnThisPageNav', () => {
     // assert first parent is active
     expect(firstParent.classes()).not.toContain('active');
     expect(parentLink1.props('to')).toEqual(`?language=objc#${sections[0].anchor}`);
-    expect(parentLink1.find(WordBreak).text()).toBe(sections[0].title);
+    expect(parentLink1.find('span').text()).toBe(sections[0].title);
     // assert second parent
     const secondParent = parents.at(1);
     expect(secondParent.classes()).toContain('active');
     expect(secondParent.find(RouterLinkStub).props('to')).toEqual(`?language=objc#${sections[1].anchor}`);
-    expect(secondParent.find(WordBreak).text()).toBe(sections[1].title);
+    expect(secondParent.find('span').text()).toBe(sections[1].title);
     // assert "children" items
     const children = wrapper.findAll('.child-item');
     expect(children).toHaveLength(1);


### PR DESCRIPTION
Bug/issue #, if applicable: 107193315

## Summary

Removes the WordBreak component from the OnThisPage as it was breaking `camelCaseText` in weird ways sometimes.

## Note

H1 items, aka the page titles are often code-like strings, when considering code documentation, removing the WordBreak may cause regressions on those cases. 

## Dependencies

NA

## Testing

Open pages that have camelCaseWords in the sections headings and assert it does not break them up.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
