### PR TITLE
Images can eagerly load in IDE mode

### DIFF
--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -22,7 +22,8 @@ const defaultColorScheme = supportsAutoColorScheme ? ColorScheme.auto : ColorSch
 
 export default {
   state: {
-    imageLoadingStrategy: ImageLoadingStrategy.lazy,
+    imageLoadingStrategy: process.env.VUE_APP_TARGET === 'ide'
+      ? ImageLoadingStrategy.eager : ImageLoadingStrategy.lazy,
     preferredColorScheme: Settings.preferredColorScheme || defaultColorScheme,
     supportsAutoColorScheme,
     systemColorScheme: ColorScheme.light,

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -28,6 +28,13 @@ export default {
     supportsAutoColorScheme,
     systemColorScheme: ColorScheme.light,
   },
+  reset() {
+    this.state.imageLoadingStrategy = process.env.VUE_APP_TARGET === 'ide'
+      ? ImageLoadingStrategy.eager : ImageLoadingStrategy.lazy;
+    this.state.preferredColorScheme = Settings.preferredColorScheme || defaultColorScheme;
+    this.state.supportsAutoColorScheme = supportsAutoColorScheme;
+    this.state.systemColorScheme = ColorScheme.light;
+  },
   setImageLoadingStrategy(strategy) {
     this.state.imageLoadingStrategy = strategy;
   },

--- a/tests/unit/stores/AppStore.spec.js
+++ b/tests/unit/stores/AppStore.spec.js
@@ -1,0 +1,85 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2023 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import AppStore from 'docc-render/stores/AppStore';
+import ColorScheme from 'docc-render/constants/ColorScheme';
+import ImageLoadingStrategy from 'docc-render/constants/ImageLoadingStrategy';
+import Settings from 'docc-render/utils/settings';
+
+describe('AppStore', () => {
+  it('has a default state', () => {
+    expect(AppStore.state).toEqual({
+      imageLoadingStrategy: ImageLoadingStrategy.lazy,
+      preferredColorScheme: ColorScheme.light,
+      supportsAutoColorScheme: false,
+      systemColorScheme: ColorScheme.light,
+    });
+  });
+
+  it('has correct state in IDE mode', () => {
+    const originalTarget = process.env.VUE_APP_TARGET;
+    process.env.VUE_APP_TARGET = 'ide';
+    AppStore.reset();
+
+    expect(AppStore.state).toEqual({
+      imageLoadingStrategy: ImageLoadingStrategy.eager,
+      preferredColorScheme: ColorScheme.light,
+      supportsAutoColorScheme: false,
+      systemColorScheme: ColorScheme.light,
+    });
+
+    // restore target
+    process.env.VUE_APP_TARGET = originalTarget;
+  });
+
+  describe('setImageLoadingStrategy', () => {
+    it('sets the `imageLoadingStrategy` state', () => {
+      AppStore.setImageLoadingStrategy(ImageLoadingStrategy.eager);
+      expect(AppStore.state.imageLoadingStrategy).toBe(ImageLoadingStrategy.eager);
+    });
+  });
+
+  describe('setPreferredColorScheme', () => {
+    it('sets the `preferredColorScheme` state', () => {
+      AppStore.setPreferredColorScheme(ColorScheme.auto);
+      expect(AppStore.state.preferredColorScheme).toBe(ColorScheme.auto);
+      expect(Settings.preferredColorScheme).toBe(ColorScheme.auto);
+    });
+  });
+
+  describe('setSystemColorScheme', () => {
+    it('sets the `systemColorScheme` state', () => {
+      AppStore.setSystemColorScheme(ColorScheme.dark);
+      expect(AppStore.state.systemColorScheme).toBe(ColorScheme.dark);
+    });
+  });
+
+  describe('syncPreferredColorScheme', () => {
+    it('sets the `syncPreferredColorScheme` state', () => {
+      AppStore.syncPreferredColorScheme();
+      expect(AppStore.state.preferredColorScheme).toBe(Settings.preferredColorScheme);
+    });
+  });
+
+  it('resets the state', () => {
+    AppStore.setImageLoadingStrategy(ImageLoadingStrategy.eager);
+    AppStore.setPreferredColorScheme(ColorScheme.auto);
+    AppStore.setSystemColorScheme(ColorScheme.dark);
+    AppStore.syncPreferredColorScheme();
+    AppStore.reset();
+
+    expect(AppStore.state).toEqual({
+      imageLoadingStrategy: ImageLoadingStrategy.lazy,
+      preferredColorScheme: ColorScheme.auto,
+      supportsAutoColorScheme: false,
+      systemColorScheme: ColorScheme.light,
+    });
+  });
+});


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://107320467

## Summary
Images should be allowed to eagerly load by default in IDE mode.