### PR TITLE
Reduce `ViewMore` link font size

### DIFF
--- a/src/components/DocumentationTopic/ViewMore.vue
+++ b/src/components/DocumentationTopic/ViewMore.vue
@@ -35,6 +35,7 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .view-more-link {
+  @include font-styles(body-reduced-tight);
   display: flex;
   flex-flow: row-reverse;
   margin-bottom: 20px;


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://107077994

## Summary
Match the `ViewMore` link font size with the `Declared in` link.

## Testing
Steps:
1. Manually verify in minimized views
