### PR TITLE
[5.9] Reduce ViewMore Link font

### DIFF
--- a/src/components/DocumentationTopic/ViewMore.vue
+++ b/src/components/DocumentationTopic/ViewMore.vue
@@ -35,6 +35,7 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .view-more-link {
+  @include font-styles(body-reduced-tight);
   display: flex;
   flex-flow: row-reverse;
   margin-bottom: 20px;


### PR DESCRIPTION
- Explanation: Reduce font size for the “view more” link 
- Scope: minimized mode only, minor CSS change
- Issue: rdar://107077994
- Risk: Small
- Testing: Verify link font size in Quick Nav preview
- Reviewer: @mportiz08  
- Original PR: https://github.com/apple/swift-docc-render/pull/561