### PR TITLE
[5.9] Prevent scrolling if router `meta` field `preventScrolling` is `true`

### DIFF
--- a/src/utils/router-utils.js
+++ b/src/utils/router-utils.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -48,6 +48,10 @@ export async function scrollBehavior(to, from, savedPosition) {
     await this.app.$nextTick();
     return savedPosition;
   }
+  if (to.meta && to.meta.preventScrolling) {
+    // Do not change the scroll position if disabled from router meta field
+    return false;
+  }
   if (to.hash) {
     const { name, query, hash } = to;
     const isDocumentation = name.includes(documentationTopicName);
@@ -62,7 +66,8 @@ export async function scrollBehavior(to, from, savedPosition) {
     return { selector: cssEscapeTopicIdHash(hash), offset: { x: 0, y } };
   }
   if (areEquivalentLocations(to, from)) {
-    // Do not change the scroll position if the location hasn't changed.
+    // Do not change the scroll position if the location hasn't changed
+    // Note: `areEquivalentLocations` doesn't detect hash differences
     return false;
   }
   return { x: 0, y: 0 };

--- a/tests/unit/utils/router-utils.spec.js
+++ b/tests/unit/utils/router-utils.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -52,7 +52,9 @@ describe('router-utils', () => {
     const mockApp = { app: { $nextTick: jest.fn().mockResolvedValue({}) } };
     const scrollBehavior = originalScrollBehavior.bind(mockApp);
 
-    const createRoute = (name, query, hash) => ({ name, query, hash });
+    const createRoute = (name, query, hash, meta) => ({
+      name, query, hash, meta,
+    });
     const routeFoo = createRoute('foo', {}, 'foo');
     const routeBar = createRoute('bar', {}, 'bar');
 
@@ -64,6 +66,18 @@ describe('router-utils', () => {
       const savedPosition = { foo: 'foo' };
       const resolved = await scrollBehavior(routeFoo, routeBar, savedPosition);
       expect(resolved).toEqual(savedPosition);
+    });
+
+    it('resolves as false if two urls are the same and have no `hash`', async () => {
+      const noHashUrl = createRoute('foo', {});
+      const resolved = await scrollBehavior(noHashUrl, noHashUrl);
+      expect(resolved).toEqual(false);
+    });
+
+    it('resolves with pageOffset if `meta.preventScrolling` is `true`', async () => {
+      const routeNoScroll = createRoute('foo', {}, 'foo', { preventScrolling: true });
+      const resolved = await scrollBehavior(routeNoScroll, routeBar);
+      expect(resolved).toEqual(false);
     });
 
     it('resolves with a selector and `y:0` offset if passed `hash` but in IDE target', async () => {
@@ -104,12 +118,6 @@ describe('router-utils', () => {
         selector: routeDocsNoChanges.hash,
         offset: { x: 0, y: baseNavHeight * 2 + EXTRA_DOCUMENTATION_OFFSET },
       });
-    });
-
-    it('resolves as false if two urls are the same and have no `hash`', async () => {
-      const noHashUrl = createRoute('foo', {});
-      const resolved = await scrollBehavior(noHashUrl, noHashUrl);
-      expect(resolved).toEqual(false);
     });
 
     it('resolves with `{ x: 0, y: 0 }` if new url without hash', async () => {


### PR DESCRIPTION
- Explanation: Prevent scroller from scrolling during the navigation event if setting is turned on
- Scope: routes with the `preventScrolling` set to `true`
- Issue: rdar://103146273
- Risk: Small
- Testing: add `preventScrolling` to the `meta` field for routes, set it to `true` and test with emitting `navigation` event.
- Reviewer: @dobromir-hristov 
- Original PR: https://github.com/apple/swift-docc-render/pull/563