### PR TITLE
[5.9] hide view more link if no expanded documentation (#562)

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -101,7 +101,7 @@
               :source="remoteSource"
               :sections="primaryContentSectionsSanitized"
             />
-            <ViewMore v-if="enableMinimized" :url="viewMoreLink" />
+            <ViewMore v-if="shouldShowViewMoreLink" :url="viewMoreLink" />
           </div>
           <Topics
             v-if="shouldRenderTopicSection"
@@ -240,6 +240,10 @@ export default {
     },
     modules: {
       type: Array,
+      required: false,
+    },
+    hasNoExpandedDocumentation: {
+      type: Boolean,
       required: false,
     },
     hierarchy: {
@@ -456,13 +460,13 @@ export default {
       deprecationSummary,
       downloadNotAvailableSummary,
       primaryContentSectionsSanitized,
-      enableMinimized,
+      shouldShowViewMoreLink,
     }) => (
       isRequirement
       || (deprecationSummary && deprecationSummary.length)
       || (downloadNotAvailableSummary && downloadNotAvailableSummary.length)
       || (primaryContentSectionsSanitized.length)
-      || enableMinimized // minimized mode always renders `ViewMore`
+      || shouldShowViewMoreLink
     ),
     viewMoreLink: ({
       interfaceLanguage,
@@ -471,6 +475,13 @@ export default {
     }) => (
       interfaceLanguage === Language.objectiveC.key.api
         ? normalizedObjcPath : normalizedSwiftPath
+    ),
+    shouldShowViewMoreLink: ({
+      enableMinimized,
+      hasNoExpandedDocumentation,
+      viewMoreLink,
+    }) => (
+      enableMinimized && !hasNoExpandedDocumentation && viewMoreLink
     ),
     tagName() {
       return this.isSymbolDeprecated ? this.$t('aside-kind.deprecated') : this.$t('aside-kind.beta');
@@ -521,6 +532,7 @@ export default {
         },
         metadata: {
           conformance,
+          hasNoExpandedDocumentation,
           modules,
           platforms,
           required: isRequirement = false,
@@ -559,6 +571,7 @@ export default {
         deprecationSummary,
         downloadNotAvailableSummary,
         diffAvailability,
+        hasNoExpandedDocumentation,
         hierarchy,
         role,
         identifier,

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -490,6 +490,18 @@ describe('DocumentationTopic', () => {
     expect(wrapper.contains(PrimaryContent)).toBe(false);
   });
 
+  it('does not render a `PrimaryContent` column when passed empty an PrimaryContent & no `ViewMore` link', () => {
+    wrapper.setProps({ primaryContentSections: [], enableMinimized: true });
+    expect(wrapper.contains(PrimaryContent)).toBe(true); // ViewMore link is present
+
+    wrapper.setProps({
+      primaryContentSections: [],
+      enableMinimized: true,
+      hasNoExpandedDocumentation: true,
+    });
+    expect(wrapper.contains(PrimaryContent)).toBe(false); // no ViewMore link
+  });
+
   it('renders `ViewMore` if `enableMinimized`', () => {
     wrapper.setProps({
       enableMinimized: true,
@@ -504,6 +516,10 @@ describe('DocumentationTopic', () => {
 
     // should not render `ViewMore` in non-minimized mode
     wrapper.setProps({ enableMinimized: false });
+    expect(wrapper.find(ViewMore).exists()).toBe(false);
+
+    // should not render `ViewMore` if `hasNoExpandedDocumentation`
+    wrapper.setProps({ enableMinimized: true, hasNoExpandedDocumentation: true });
     expect(wrapper.find(ViewMore).exists()).toBe(false);
   });
 
@@ -609,6 +625,7 @@ describe('DocumentationTopic', () => {
       deprecationSummary: null,
       downloadNotAvailableSummary: null,
       enableMinimized: false,
+      hasNoExpandedDocumentation: true,
     });
     expect(wrapper.find(PrimaryContent).exists()).toBe(false);
     expect(wrapper.find('.description').exists()).toBe(false);


### PR DESCRIPTION
- Explanation:  Conditionally hide the “ViewMore” link
- Scope: Minimized mode only
- Issue: rdar://106860554
- Risk: Small
- Testing: 
1. Manually add hasNoExpandedDocumentation to the metadata field of a renderJSON, and set it to true.
2. Test in Quick Nav that the link is hidden.
- Reviewer: @dobromir-hristov 
- Original PR: https://github.com/apple/swift-docc-render/pull/562