### PR TITLE
Extract helper for establishing a new stacking context

### DIFF
--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -188,14 +188,9 @@ code {
   min-height: 100%;
   border-radius: var(--code-border-radius, $border-radius);
   overflow: hidden;
-  // this mask image is not actually used for any visual effect since there is
-  // no background being used on this element—however, we need this in order to
-  // establish a new stacking context, which resolves a Safari bug where the
-  // scrollbar is not clipped by this element depending on its border-radius.
-  // It's inside a screen query, because it causes issues with printing to PDF.
-  @media screen {
-    -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
-  }
+  // we need to establish a new stacking context to resolve a Safari bug where
+  // the scrollbar is not clipped by this element depending on its border-radius
+  @include new-stacking-context;
 
   &.single-line {
     border-radius: $large-border-radius;

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -200,13 +200,9 @@ $docs-declaration-source-border-width: 1px !default;
   padding: var(--code-block-style-elements-padding);
   speak: literal-punctuation;
   line-height: 25px;
-  // this mask image is not actually used for any visual effect since there is
-  // no background being used on this element—however, we need this in order to
-  // establish a new stacking context, which resolves a Safari bug where the
-  // scrollbar is not clipped by this element depending on its border-radius
-  @media screen {
-    -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
-  }
+  // we need to establish a new stacking context to resolve a Safari bug where
+  // the scrollbar is not clipped by this element depending on its border-radius
+  @include new-stacking-context;
 
   &.has-multiple-lines {
     border-radius: $border-radius;

--- a/src/components/Tutorial/Step.vue
+++ b/src/components/Tutorial/Step.vue
@@ -142,7 +142,7 @@ export default {
   background-color: var(--color-step-background);
   overflow: hidden;
   // To hide overflow on rounded corner divs in Safari
-  -webkit-mask-image: -webkit-radial-gradient(white, black);
+  @include new-stacking-context;
 
   &::before {
     content: "";

--- a/src/styles/core/_helpers.scss
+++ b/src/styles/core/_helpers.scss
@@ -299,3 +299,16 @@
     margin-top: $margin;
   }
 }
+
+// introduces a new "stacking context" by applying a filter that doesn't do
+// anything as a way of resolving issues related to the stacking context in
+// certain browsers without altering the visual appearance of the element
+//
+// a possible alternative would be to set a z-index but the exact value might
+// need to change depending on where this is used
+//
+// see also:
+// https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
+@mixin new-stacking-context() {
+  filter: blur(0px);
+}


### PR DESCRIPTION
Bug/issue #, if applicable: 104872474

## Summary

This extracts and modifies the existing functionality needed to establish a new [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) without altering any visuals, which is used in various places to work around browser specific issues related to overflow and border-radii.

The [previous method](https://github.com/apple/swift-docc-render/pull/514) has issues with the "Export as PDF" feature of Safari, possibly because of the way it handles transparent background images for that kind of rendering output, and it cannot be avoided with media queries the same way that it can when "printing" to PDF.

## Testing

Follow the same testing steps as https://github.com/apple/swift-docc-render/pull/514 but also verify that there are no issues with the "Export as PDF" functionality of Safari.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
