### PR TITLE
[5.9] fix spacing issue with api changes and ParametersTable

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/ParametersTable.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/ParametersTable.vue
@@ -105,10 +105,14 @@ export default {
     @include change-highlight-target();
     // Move the responsibility of the left padding to the first element instead.
     // This is only for Large screens
-    padding-left: 0;
+
+    &.changed {
+      padding-left: 0;
+      padding-right: 0;
+    }
 
     & + & {
-      margin-top: calc(var(--spacing-param)/2);
+      margin-top: calc(var(--spacing-param) / 2);
     }
   }
 }
@@ -162,6 +166,10 @@ export default {
 .param-content {
   padding-left: 1rem;
   @include change-highlight-end-spacing();
+
+  .changed & {
+    padding-right: $change-highlight-horizontal-space-rem;
+  }
 
   @include breakpoint(small) {
     padding-left: 0;


### PR DESCRIPTION
- Explanation: Fix a spacing issue with ParametersTable and API changes
- Scope: Doc pages
- Issue: rdar://103421001
- Risk: Small
- Testing: Test doc pages that have Parameter Table sections and API changes in them.
- Reviewer: @mportiz08
- Original PR: https://github.com/apple/swift-docc-render/pull/540