### PR TITLE
[5.9] ensure Links card items are always 16/9 aspect ratio

### DIFF
--- a/src/components/DocumentationTopic/TopicsLinkCardGridItem.vue
+++ b/src/components/DocumentationTopic/TopicsLinkCardGridItem.vue
@@ -79,6 +79,20 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .reference-card-grid-item {
+  // ensures card covers are always a 16/9 aspect ratio
+  --card-cover-height: auto;
+
+  &.card.large {
+    --card-cover-height: auto;
+    // .large and .small cards have min/max sizes
+    min-width: 0;
+    max-width: none;
+  }
+
+  /deep/ .card-cover {
+    aspect-ratio: 16/9;
+  }
+
   &__image {
     display: flex;
     align-items: center;


### PR DESCRIPTION
- Explanation: Sets the card items in Links component to 16/9 aspect ratio
- Scope: Doc pages with `@Links` component
- Issue: rdar://106864428
- Risk: Small, css only
- Testing: Test pages that have `@Links` components and the `grid` or `detailedGrid` type
- Reviewer: @mportiz08
- Original PR: https://github.com/apple/swift-docc-render/pull/553