### PR TITLE
[5.9] Provide alt text to overridable assets

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -18,6 +18,7 @@
     <CardCover
       :variants="imageVariants"
       :rounded="floatingStyle"
+      :alt="imageReference.alt"
       aria-hidden="true"
       #default="coverProps"
     >

--- a/src/components/CardCover.vue
+++ b/src/components/CardCover.vue
@@ -11,7 +11,7 @@
 <template>
   <div class="card-cover-wrap" :class="{ rounded }">
     <slot classes="card-cover">
-      <ImageAsset :variants="variants" class="card-cover" />
+      <ImageAsset :variants="variants" :alt="alt" class="card-cover" />
     </slot>
   </div>
 </template>
@@ -30,6 +30,10 @@ export default {
     rounded: {
       type: Boolean,
       default: false,
+    },
+    alt: {
+      type: String,
+      default: null,
     },
   },
 };
@@ -57,6 +61,7 @@ export default {
     display: block;
     margin: 0;
   }
+
   // make sure we dont override the height for the fallback
   /deep/ img {
     height: 100%;

--- a/src/components/OverridableAsset.vue
+++ b/src/components/OverridableAsset.vue
@@ -10,7 +10,7 @@
 <template>
   <ImageAsset
     v-if="shouldUseAsset"
-    v-bind="{ variants, loading: null, shouldCalculateOptimalWidth }"
+    v-bind="{ variants, loading: null, shouldCalculateOptimalWidth, alt }"
   />
   <SVGIcon v-else :icon-url="iconUrl" :themeId="themeId" />
 </template>
@@ -36,6 +36,7 @@ export default {
   },
   computed: {
     variants: ({ imageOverride }) => (imageOverride ? imageOverride.variants : []),
+    alt: ({ imageOverride }) => imageOverride.alt,
     firstVariant: ({ variants }) => (variants[0]),
     iconUrl: ({ firstVariant }) => firstVariant && firstVariant.url,
     themeId: ({ firstVariant }) => firstVariant && firstVariant.svgID,

--- a/tests/unit/components/Card.spec.js
+++ b/tests/unit/components/Card.spec.js
@@ -26,6 +26,7 @@ describe('Card', () => {
   const references = {
     [image.identifier]: {
       variants: [{ url: 'image.com', traits: ['1x'] }],
+      alt: 'some Alt',
     },
   };
 
@@ -170,7 +171,11 @@ describe('Card', () => {
     });
     const cardCover = wrapper.find(CardCover);
     expect(cardCover.exists()).toBe(true);
-    expect(cardCover.props()).toHaveProperty('variants', references[propsData.image].variants);
+    expect(cardCover.props()).toEqual({
+      variants: references[propsData.image].variants,
+      rounded: false,
+      alt: 'some Alt',
+    });
   });
 
   it('renders a `.link` with appropriate classes and aria label in WEB', () => {

--- a/tests/unit/components/CardCover.spec.js
+++ b/tests/unit/components/CardCover.spec.js
@@ -26,6 +26,7 @@ const variants = [lightVariant, darkVariant];
 
 const defaultProps = {
   variants,
+  alt: 'alt text',
 };
 
 const mountCover = ({ propsData, ...rest } = {}) => {
@@ -45,6 +46,7 @@ describe('CardCover', () => {
     const asset = wrapper.find(ImageAsset);
     expect(asset.classes()).toContain('card-cover');
     expect(asset.props('variants')).toEqual(defaultProps.variants);
+    expect(asset.props('alt')).toEqual(defaultProps.alt);
   });
 
   it('exposes a default slot', () => {

--- a/tests/unit/components/OverridableAsset.spec.js
+++ b/tests/unit/components/OverridableAsset.spec.js
@@ -42,13 +42,14 @@ describe('OverridableAsset', () => {
     const wrapper = createWrapper({
       propsData: {
         imageOverride: {
+          alt: 'someAlt',
           variants: [localVariantNoID],
         },
       },
     });
     expect(wrapper.find(ImageAsset).props()).toEqual({
       variants: [localVariantNoID],
-      alt: '',
+      alt: 'someAlt',
       shouldCalculateOptimalWidth: true,
     });
   });
@@ -57,11 +58,16 @@ describe('OverridableAsset', () => {
     const wrapper = createWrapper({
       propsData: {
         imageOverride: {
+          alt: 'someAlt',
           variants: [remoteDifferentVariant],
         },
       },
     });
-    expect(wrapper.find(ImageAsset).props('variants')).toEqual([remoteDifferentVariant]);
+    expect(wrapper.find(ImageAsset).props()).toEqual({
+      variants: [remoteDifferentVariant],
+      alt: 'someAlt',
+      shouldCalculateOptimalWidth: true,
+    });
   });
 
   it('renders an `SVGIcon` component, if icon has `svgID` and is from a local path', () => {


### PR DESCRIPTION
- Explanation: Renders the `alt` text on overridden assets
- Scope: Doc pages with asset overrides in the Navigator or `@Links` via `@PageImage`
- Issue: rdar://106633366
- Risk: Small
- Testing: Assert `alt` text provided to `@PageImage` tag is rendered where necessary.
- Reviewer: @marinaaisa 
- Original PR: https://github.com/apple/swift-docc-render/pull/548