### PR TITLE
[5.9] minor styling fixes to spacing and colors

### DIFF
--- a/src/components/ContentNode/Row.vue
+++ b/src/components/ContentNode/Row.vue
@@ -74,8 +74,6 @@ export default {
     }
   }
 
-  /deep/ + * {
-    margin-top: var(--spacing-stacked-margin-large);
-  }
+  @include space-out-between-siblings(var(--spacing-stacked-margin-xlarge));
 }
 </style>

--- a/src/components/DocumentationTopic/TopicsLinkCardGridItem.vue
+++ b/src/components/DocumentationTopic/TopicsLinkCardGridItem.vue
@@ -79,6 +79,10 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .reference-card-grid-item {
+  /deep/ .card-cover-wrap {
+    border: 1px solid var(--color-link-block-card-border);
+  }
+
   &__image {
     display: flex;
     align-items: center;

--- a/src/styles/core/colors/_dark.scss
+++ b/src/styles/core/colors/_dark.scss
@@ -88,4 +88,5 @@
   --color-navigator-item-hover: #{change-color(dark-color(fill-blue), $alpha: 0.5)};
 
   --color-card-shadow: #{change-color(light-color(fill), $alpha: 0.04)};
+  --color-link-block-card-border: #{change-color(light-color(fill), $alpha: 0.25)};
 }

--- a/src/styles/core/colors/_light.scss
+++ b/src/styles/core/colors/_light.scss
@@ -195,4 +195,5 @@
   --color-card-content-text: var(--color-figure-gray);
   --color-card-eyebrow: var(--color-figure-gray-secondary-alt);
   --color-card-shadow: #{change-color(dark-color(fill), $alpha: 0.04)};
+  --color-link-block-card-border: #{change-color(dark-color(fill), $alpha: 0.04)};
 }


### PR DESCRIPTION
- Explanation: Adds a very faint border to the cards in @links directive. Adds extra space around the Row component
- Scope: Doc pages
- Issue: rdar://107269619
- Risk: Small, css only
- Testing: Visually assert styling is applied.
- Reviewer: @hqhhuang 
- Original PR: https://github.com/apple/swift-docc-render/pull/558