### PR TITLE
Add VUE_APP_HLJS_LANGUAGES environment variable (#551)

### DIFF
--- a/SwiftDocCRender.docc/contributing/Internals.md
+++ b/SwiftDocCRender.docc/contributing/Internals.md
@@ -177,6 +177,7 @@ DocC-Render has a few build-time environment flags, that allow you to set config
 
 * **VUE_APP_DEV_SERVER_PROXY** - The HTTP endpoint or  local filepath to read render JSON from when using the development server
 * **VUE_APP_TITLE** - An optional default page title to apply to pages
+* **VUE_APP_HLJS_LANGUAGES** - An optional comma-separated list of highlight.js languages to include in the build
 
 #### Available Scripts
 

--- a/src/setup-utils/vue-config-utils.js
+++ b/src/setup-utils/vue-config-utils.js
@@ -12,6 +12,8 @@ const fs = require('fs');
 const path = require('path');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const ThemeResolverPlugin = require('webpack-theme-resolver-plugin');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const webpack = require('webpack');
 const themeUtils = require('./theme-build-utils');
 const { BannerPlugin, LICENSE_HEADER } = require('./license-header-built-files');
 
@@ -70,6 +72,16 @@ function baseChainWebpack(config) {
     .use(BannerPlugin, [{
       banner: LICENSE_HEADER,
     }]);
+
+  // Limit highlight.js to only the necessary languages
+  const builtinLanguages = 'bash|c|s?css|cpp|diff|http|java|llvm|perl|php|python|ruby|xml|javascript|json|markdown|objectivec|shell|swift';
+  const envLanguages = (process.env.VUE_APP_HLJS_LANGUAGES ?? '').split(',').join('|');
+  config
+    .plugin('LanguagesPlugin')
+    .use(webpack.ContextReplacementPlugin, [
+      /highlight\.js\/lib\/languages$/,
+      new RegExp(`/(${[builtinLanguages, envLanguages].join('|')})$`),
+    ]);
 }
 
 function baseDevServer({ defaultDevServerProxy = 'http://localhost:8000' } = {}) {

--- a/src/utils/syntax-highlight.js
+++ b/src/utils/syntax-highlight.js
@@ -37,6 +37,12 @@ const Languages = {
   shell: ['console', 'shellsession'],
   swift: [],
   xml: ['html', 'xhtml', 'rss', 'atom', 'xjb', 'xsd', 'xsl', 'plist', 'wsf', 'svg'],
+  // load more languages from the environment
+  ...(
+    process.env.VUE_APP_HLJS_LANGUAGES
+      ? Object.fromEntries(process.env.VUE_APP_HLJS_LANGUAGES.split(',').map(l => [l, []]))
+      : undefined
+  ),
 };
 
 export const CustomLanguagesSet = new Set([
@@ -83,8 +89,6 @@ async function importHighlightFileForLanguage(language) {
       } else {
         languageFile = await import(
           /* webpackChunkName: "highlight-js-[request]" */
-          // eslint-disable-next-line max-len
-          /* webpackInclude: /\/(bash|c|s?css|cpp|diff|http|java|llvm|perl|php|python|ruby|xml|javascript|json|markdown|objectivec|shell|swift)\.js$/ */
           `highlight.js/lib/languages/${file}`
         );
       }


### PR DESCRIPTION
- Explanation: Allow adding extra languages to highlight.js via ENV config at build time
- Scope: OSS users who build the app themselves
- Issue: rdar://107325271
- Risk: Small
- Testing: There should be no regression in default provided languages for highlighting
- Reviewer: @mportiz08 @dobromir-hristov
- Original PR: https://github.com/apple/swift-docc-render/pull/551