### PR TITLE
Remove the topicSectionsStyle limitation for the doc intro section

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -412,7 +412,6 @@ export default {
     enhanceBackground: ({
       symbolKind,
       disableHeroBackground,
-      topicSectionsStyle,
       enableMinimized,
     }) => {
       if (
@@ -420,9 +419,6 @@ export default {
         disableHeroBackground
         // or minimized view is enabled
         || enableMinimized
-        // or the topicSectionsStyle is a `grid` type
-        || topicSectionsStyle === TopicSectionsStyle.compactGrid
-        || topicSectionsStyle === TopicSectionsStyle.detailedGrid
       ) {
         return false;
       }

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -322,15 +322,6 @@ describe('DocumentationTopic', () => {
     expect(hero.props('enhanceBackground')).toBe(false);
   });
 
-  it('renders a `DocumentationHero`, disabled, if the `topicSectionsStyle` is a grid type', () => {
-    const hero = wrapper.find(DocumentationHero);
-    expect(hero.props('enhanceBackground')).toBe(true);
-    wrapper.setProps({ topicSectionsStyle: TopicSectionsStyle.detailedGrid });
-    expect(hero.props('enhanceBackground')).toBe(false);
-    wrapper.setProps({ topicSectionsStyle: TopicSectionsStyle.compactGrid });
-    expect(hero.props('enhanceBackground')).toBe(false);
-  });
-
   it('renders a `Title`', () => {
     const hero = wrapper.find(DocumentationHero);
 


### PR DESCRIPTION
Bug/issue #, if applicable: 107581728

## Summary

Stops removing the color from the intro section based on the topicSectionsStyle

## Dependencies

NA

## Testing

Steps:
1. Render a page using the topicSectionsStyle that is either a `grid` or `detailedGrid`
2. Assert the intro section is still colored for pages that support it.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
