### PR TITLE
refactor: remove unnecessary top padding

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -222,8 +222,6 @@ $sidenav-icon-padding-size: 5px;
 // overwrite the typography of menu items outside of breakpoint only
 /deep/ .nav-menu {
   @include font-styles(documentation-nav);
-  // vertically align the items
-  padding-top: 0;
 
   &-settings {
     @include font-styles(nav-toggles);
@@ -275,10 +273,6 @@ $sidenav-icon-padding-size: 5px;
     // normalize the Title font with menu items
     .nav-title {
       @include font-styles(documentation-nav);
-
-      @include breakpoint(medium, $scope: nav) {
-        padding-top: 0;
-      }
 
       .nav-title-link.inactive {
         height: auto;

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -615,14 +615,10 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   @include font-styles(nav-menu);
   flex: 1 1 auto;
   display: flex;
-  // padding centers it vertically for large resolutions
-  padding-top: 10px;
   min-width: 0;
 
   @include nav-in-breakpoint {
     @include font-styles(nav-menu-collapsible);
-    // it is collapsed, so we no longer need the offset
-    padding-top: 0;
     grid-area: menu;
   }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 107692636

## Summary

Removes a top-padding from the nav that we are only conditionally removing anyway.

It was probably left from one of the recent refactors @marinaaisa did to clean the nav up.

## Dependencies

NA

## Testing

Assert there are no visual regressions in the nav on any of our page types.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added tests~ - css only
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
