### PR TITLE
Refactor: enablei18n centralized in App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,8 +16,8 @@
     <div :id="AppTopID" />
     <a href="#main" id="skip-nav">{{ $t('accessibility.skip-navigation') }}</a>
     <InitialLoadingPlaceholder />
-    <SuggestLang v-if="enablei18n" />
     <slot name="header" :isTargetIDE="isTargetIDE">
+      <SuggestLang v-if="enablei18n" />
       <!-- Render the custom header by default, if there is no content in the `header` slot -->
       <custom-header v-if="hasCustomHeader" :data-color-scheme="preferredColorScheme" />
     </slot>
@@ -26,7 +26,7 @@
     <slot :isTargetIDE="isTargetIDE">
       <router-view class="router-content" />
       <custom-footer v-if="hasCustomFooter" :data-color-scheme="preferredColorScheme" />
-      <Footer v-else-if="!isTargetIDE" />
+      <Footer v-else-if="!isTargetIDE" :enablei18n="enablei18n" />
     </slot>
     <slot name="footer" :isTargetIDE="isTargetIDE" />
   </div>
@@ -38,11 +38,10 @@ import ColorScheme from 'docc-render/constants/ColorScheme';
 import Footer from 'docc-render/components/Footer.vue';
 import InitialLoadingPlaceholder from 'docc-render/components/InitialLoadingPlaceholder.vue';
 import { baseNavStickyAnchorId } from 'docc-render/constants/nav';
-import { fetchThemeSettings, themeSettingsState } from 'docc-render/utils/theme-settings';
+import { fetchThemeSettings, themeSettingsState, getSetting } from 'docc-render/utils/theme-settings';
 import { objectToCustomProperties } from 'docc-render/utils/themes';
 import { AppTopID } from 'docc-render/constants/AppTopID';
 import SuggestLang from 'docc-render/components/SuggestLang.vue';
-import { enablei18n } from 'theme/lang/index.js';
 
 export default {
   name: 'CoreApp',
@@ -86,7 +85,7 @@ export default {
     ),
     hasCustomHeader: () => !!window.customElements.get('custom-header'),
     hasCustomFooter: () => !!window.customElements.get('custom-footer'),
-    enablei18n: () => enablei18n,
+    enablei18n: () => getSetting(['features', 'docs', 'i18n', 'enable'], false),
   },
   props: {
     enableThemeSettings: {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -22,13 +22,15 @@
 <script>
 import ColorSchemeToggle from 'docc-render/components/ColorSchemeToggle.vue';
 import LocaleSelector from 'docc-render/components/LocaleSelector.vue';
-import { enablei18n } from 'theme/lang/index.js';
 
 export default {
   name: 'Footer',
   components: { ColorSchemeToggle, LocaleSelector },
-  computed: {
-    enablei18n: () => enablei18n,
+  props: {
+    enablei18n: {
+      type: Boolean,
+      default: false,
+    },
   },
 };
 </script>

--- a/src/lang/index.js
+++ b/src/lang/index.js
@@ -8,7 +8,6 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { getSetting } from 'docc-render/utils/theme-settings';
 /* eslint-disable camelcase */
 import en_US from './locales/en-US.json';
 import zh_CN from './locales/zh-CN.json';
@@ -22,5 +21,3 @@ export const messages = {
   'zh-CN': zh_CN,
   'ja-JP': ja_JP,
 };
-// enable i18n feature flag
-export const enablei18n = getSetting(['features', 'docs', 'i18n', 'enable'], false);

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -25,18 +25,13 @@ jest.mock('docc-render/utils/theme-settings', () => ({
 
 let App;
 let fetchThemeSettings = jest.fn();
+let getSetting = jest.fn(() => {});
 
 const matchMedia = {
   matches: false,
   addListener: jest.fn(),
   removeListener: jest.fn(),
 };
-
-const mockEnablei18n = jest.fn().mockReturnValue(false);
-
-jest.mock('theme/lang/index.js', () => ({
-  get enablei18n() { return mockEnablei18n(); },
-}));
 
 const setPropertySpy = jest.spyOn(document.body.style, 'setProperty');
 const removePropertySpy = jest.spyOn(document.body.style, 'removeProperty');
@@ -138,7 +133,8 @@ describe('App', () => {
   });
 
   it('renders SuggestLang if enablei18n is true', async () => {
-    mockEnablei18n.mockReturnValueOnce(true);
+    ({ getSetting } = require('docc-render/utils/theme-settings'));
+    getSetting.mockReturnValue(true);
 
     const wrapper = createWrapper();
 

--- a/tests/unit/components/Footer.spec.js
+++ b/tests/unit/components/Footer.spec.js
@@ -11,12 +11,6 @@
 import { shallowMount } from '@vue/test-utils';
 import Footer from 'docc-render/components/Footer.vue';
 
-const mockEnablei18n = jest.fn().mockReturnValue(false);
-
-jest.mock('theme/lang/index.js', () => ({
-  get enablei18n() { return mockEnablei18n(); },
-}));
-
 const { ColorSchemeToggle, LocaleSelector } = Footer.components;
 
 describe('Footer', () => {
@@ -37,9 +31,11 @@ describe('Footer', () => {
   it('renders LocaleSelector if enablei18n is true', () => {
     expect(wrapper.find(LocaleSelector).exists()).toBe(false);
 
-    // set enablei18n to true
-    mockEnablei18n.mockReturnValueOnce(true);
-    wrapper = shallowMount(Footer);
+    wrapper = shallowMount(Footer, {
+      propsData: {
+        enablei18n: true,
+      },
+    });
 
     expect(wrapper.find(LocaleSelector).exists()).toBe(true);
   });


### PR DESCRIPTION
Bug/issue #107566850, if applicable: 

## Summary

Refactor: enablei18n centralized in App.vue

## Dependencies

NA

## Testing

Steps:
1. Check that enablei18n feature flag works as expected

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
