### PR TITLE
Use `WordBreak` based on the page `role`, inside the OnThisPageNav

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -129,7 +129,7 @@
         </div>
         <template v-if="enableOnThisPageNav">
           <OnThisPageStickyContainer v-show="isOnThisPageNavVisible">
-            <OnThisPageNav v-if="topicState.onThisPageSections.length > 2" />
+            <OnThisPageNav v-if="topicState.onThisPageSections.length > 2" :role="role" />
           </OnThisPageStickyContainer>
         </template>
       </div>

--- a/src/components/OnThisPageNav.vue
+++ b/src/components/OnThisPageNav.vue
@@ -35,7 +35,7 @@ import { waitFrames } from 'docc-render/utils/loading';
 import ScrollToElement from 'docc-render/mixins/scrollToElement';
 import { buildUrl } from 'docc-render/utils/url-helper';
 import WordBreak from 'docc-render/components/WordBreak.vue';
-import { TopicRole } from '@/constants/roles';
+import { TopicRole } from 'docc-render/constants/roles';
 
 export default {
   name: 'OnThisPageNav',

--- a/src/components/OnThisPageNav.vue
+++ b/src/components/OnThisPageNav.vue
@@ -20,8 +20,9 @@
           class="base-link"
           @click.native="handleFocusAndScroll(item.anchor)"
         >
-          <WordBreak v-if="item.i18n">{{ $t(item.title) }}</WordBreak>
-          <WordBreak v-else>{{ item.title }}</WordBreak>
+          <component :is="wordWrapComponent">
+            {{ item.i18n ? $t(item.title) : item.title }}
+          </component>
         </router-link>
       </li>
     </ul>
@@ -34,11 +35,18 @@ import { waitFrames } from 'docc-render/utils/loading';
 import ScrollToElement from 'docc-render/mixins/scrollToElement';
 import { buildUrl } from 'docc-render/utils/url-helper';
 import WordBreak from 'docc-render/components/WordBreak.vue';
+import { TopicRole } from '@/constants/roles';
 
 export default {
   name: 'OnThisPageNav',
   components: { WordBreak },
   mixins: [ScrollToElement],
+  props: {
+    role: {
+      type: String,
+      required: false,
+    },
+  },
   inject: {
     store: {
       default() {
@@ -54,6 +62,13 @@ export default {
       url: buildUrl(`#${item.anchor}`, $route.query),
     })),
     currentPageAnchor: ({ store }) => store.state.currentPageAnchor,
+    wordWrapComponent({ role }) {
+      // Articles and Collection pages normally dont need special wrapping for their titles.
+      if (role === TopicRole.collection || role === TopicRole.article) {
+        return 'span';
+      }
+      return 'WordBreak';
+    },
   },
   async mounted() {
     window.addEventListener('scroll', this.onScroll, false);

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -870,7 +870,9 @@ describe('DocumentationTopic', () => {
         onThisPageSections: [{ anchor: 'foo' }, { anchor: 'bar' }, { anchor: 'baz' }],
       },
     });
-    expect(wrapper.find(OnThisPageNav).exists()).toBe(true);
+    expect(wrapper.find(OnThisPageNav).props()).toEqual({
+      role: propsData.role,
+    });
   });
 
   it('hides the `OnThisPageStickyContainer`, if the store.contentWidth is below a threshold', () => {

--- a/tests/unit/components/OnThisPageNav.spec.js
+++ b/tests/unit/components/OnThisPageNav.spec.js
@@ -6,13 +6,14 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import Vue from 'vue';
 import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import OnThisPageNav from '@/components/OnThisPageNav.vue';
 import { AppTopID } from '@/constants/AppTopID';
 import WordBreak from '@/components/WordBreak.vue';
+import { TopicRole } from '@/constants/roles';
 import { createEvent, flushPromises } from '../../../test-utils';
 
 jest.mock('docc-render/utils/throttle', () => jest.fn(v => v));
@@ -75,8 +76,9 @@ const $route = {
   },
 };
 
-const createWrapper = () => {
+const createWrapper = (propsData = {}) => {
   wrapper = shallowMount(OnThisPageNav, {
+    propsData,
     provide: {
       store,
     },
@@ -114,7 +116,8 @@ describe('OnThisPageNav', () => {
     // assert second parent
     const secondParent = parents.at(1);
     expect(secondParent.classes()).toContain('active');
-    expect(secondParent.find(RouterLinkStub).props('to')).toEqual(`?language=objc#${sections[1].anchor}`);
+    expect(secondParent.find(RouterLinkStub).props('to'))
+      .toEqual(`?language=objc#${sections[1].anchor}`);
     expect(secondParent.find(WordBreak).text()).toBe(sections[1].title);
     // assert "children" items
     const children = wrapper.findAll('.child-item');
@@ -127,8 +130,20 @@ describe('OnThisPageNav', () => {
     // assert third parent
     const thirdParent = parents.at(2);
     expect(thirdParent.classes()).not.toContain('active');
-    expect(thirdParent.find(RouterLinkStub).props('to')).toEqual(`?language=objc#${sections[3].anchor}`);
+    expect(thirdParent.find(RouterLinkStub).props('to'))
+      .toEqual(`?language=objc#${sections[3].anchor}`);
     expect(thirdParent.find('.children').exists()).toBe(false);
+  });
+
+  it('uses a `span` instead of a `WordBreak`, if an `article` or `collection`', () => {
+    createWrapper({
+      role: TopicRole.article,
+    });
+    expect(wrapper.find('.base-link span').text()).toEqual(sections[0].title);
+    expect(wrapper.find(WordBreak).exists()).toBe(false);
+    wrapper.setProps({ role: TopicRole.collection });
+    expect(wrapper.find(WordBreak).exists()).toBe(false);
+    expect(wrapper.find('.base-link span').text()).toEqual(sections[0].title);
   });
 
   it('sets the first item as active, if at the top', async () => {

--- a/tests/unit/components/OnThisPageNav.spec.js
+++ b/tests/unit/components/OnThisPageNav.spec.js
@@ -6,7 +6,7 @@
  *
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import Vue from 'vue';
 import { shallowMount, RouterLinkStub } from '@vue/test-utils';


### PR DESCRIPTION
Bug/issue #, if applicable: 107193315

## Summary

Refactors the OnThisPageNav to use the page `Role` in order to determine if using the WordBreak is necessary or not.

Article and Collection pages most often dont need the WordBreak

## Dependencies

NA

## Testing

Steps:
1. Use a docc archive that has both code and articles in order to test this out, like the DocC docs

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
