### PR TITLE
[5.9] Add a Pause state to the ReplayableVideoAsset

### DIFF
--- a/src/components/Icons/PauseIcon.vue
+++ b/src/components/Icons/PauseIcon.vue
@@ -1,0 +1,30 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2023 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <SVGIcon
+    class="pause-icon"
+    viewBox="0 0 14 14"
+    themeId="pause"
+  >
+    <path d="M5 4h1v6h-1z"></path>
+    <path d="M8 4h1v6h-1z"></path>
+    <path d="M7 0.5c-3.6 0-6.5 2.9-6.5 6.5s2.9 6.5 6.5 6.5 6.5-2.9 6.5-6.5-2.9-6.5-6.5-6.5zM7 12.5c-3 0-5.5-2.5-5.5-5.5s2.5-5.5 5.5-5.5 5.5 2.5 5.5 5.5-2.5 5.5-5.5 5.5z"></path>
+  </SVGIcon>
+</template>
+
+<script>
+import SVGIcon from 'docc-render/components/SVGIcon.vue';
+
+export default {
+  name: 'PauseIcon',
+  components: { SVGIcon },
+};
+</script>

--- a/src/components/ReplayableVideoAsset.vue
+++ b/src/components/ReplayableVideoAsset.vue
@@ -23,14 +23,15 @@
       @ended="onVideoEnd"
     />
     <a
-      class="replay-button"
+      v-if="!showsControls"
+      class="control-button"
       href="#"
-      :class="{ visible: showsReplayButton }"
-      @click.prevent="replay"
+      @click.prevent="togglePlayStatus"
     >
       {{ text }}
-      <InlineReplayIcon v-if="played" class="replay-icon icon-inline" />
-      <PlayIcon v-else class="replay-icon icon-inline" />
+      <InlineReplayIcon v-if="videoEnded" class="control-icon icon-inline" />
+      <PauseIcon v-else-if="isPlaying" class="control-icon icon-inline"></PauseIcon>
+      <PlayIcon v-else class="control-icon icon-inline" />
     </a>
   </div>
 </template>
@@ -39,10 +40,12 @@
 import VideoAsset from 'docc-render/components/VideoAsset.vue';
 import InlineReplayIcon from 'theme/components/Icons/InlineReplayIcon.vue';
 import PlayIcon from 'theme/components/Icons/PlayIcon.vue';
+import PauseIcon from 'theme/components/Icons/PauseIcon.vue';
 
 export default {
   name: 'ReplayableVideoAsset',
   components: {
+    PauseIcon,
     PlayIcon,
     InlineReplayIcon,
     VideoAsset,
@@ -75,35 +78,42 @@ export default {
   },
   computed: {
     text() {
-      return this.played ? this.$t('video.replay') : this.$t('video.play');
+      if (this.videoEnded) return this.$t('video.replay');
+      return this.isPlaying ? this.$t('video.pause') : this.$t('video.play');
     },
   },
   data() {
     return {
-      showsReplayButton: !(this.autoplays && this.muted),
-      played: false,
+      isPlaying: false,
+      videoEnded: false,
     };
   },
   methods: {
-    async replay() {
+    async togglePlayStatus() {
       const videoPlayer = this.$refs.asset.$refs.video;
-      if (videoPlayer) {
+      if (!videoPlayer) return;
+      if (this.isPlaying && !this.videoEnded) {
+        await videoPlayer.pause();
+      } else {
         await videoPlayer.play();
-        this.showsReplayButton = false;
       }
     },
     onVideoEnd() {
-      this.showsReplayButton = true;
-      this.played = true;
+      this.isPlaying = false;
+      this.videoEnded = true;
     },
     onVideoPlaying() {
-      this.showsReplayButton = false;
+      const { video } = this.$refs.asset.$refs;
+      this.isPlaying = !video.paused;
+      this.videoEnded = video.ended;
     },
     onPause() {
+      const { video } = this.$refs.asset.$refs;
       // if the video pauses, and we are hiding the controls, show the replay button
-      if (!this.showsControls && !this.showsReplayButton) {
-        this.showsReplayButton = true;
+      if (!this.showsControls && this.isPlaying) {
+        this.isPlaying = false;
       }
+      this.videoEnded = video.ended;
     },
   },
 };
@@ -112,20 +122,15 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-.video-replay-container .replay-button {
+.video-replay-container .control-button {
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  visibility: hidden;
   margin-top: .5rem;
   -webkit-tap-highlight-color: transparent;
 
-  &.visible {
-    visibility: visible;
-  }
-
-  svg.replay-icon {
+  svg.control-icon {
     height: 12px;
     width: 12px;
     margin-left: .3em;

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -5,6 +5,7 @@
   "video": {
     "replay": "Replay",
     "play": "Play",
+    "pause": "Pause",
     "watch": "Watch intro video"
   },
   "tutorials": {

--- a/tests/unit/components/ReplayableVideoAsset.spec.js
+++ b/tests/unit/components/ReplayableVideoAsset.spec.js
@@ -13,6 +13,7 @@ import ReplayableVideoAsset from 'docc-render/components/ReplayableVideoAsset.vu
 import VideoAsset from 'docc-render/components/VideoAsset.vue';
 import InlineReplayIcon from 'theme/components/Icons/InlineReplayIcon.vue';
 import PlayIcon from '@/components/Icons/PlayIcon.vue';
+import PauseIcon from '@/components/Icons/PauseIcon.vue';
 import { flushPromises } from '../../../test-utils';
 
 const variants = [{ traits: ['dark', '1x'], url: 'https://www.example.com/myvideo.mp4' }];
@@ -21,6 +22,7 @@ const posterVariants = [{ traits: ['dark', '1x'], url: 'https://www.example.com/
 const propsData = {
   variants,
   posterVariants,
+  showsControls: false,
 };
 describe('ReplayableVideoAsset', () => {
   const mountWithProps = props => shallowMount(ReplayableVideoAsset, {
@@ -35,10 +37,22 @@ describe('ReplayableVideoAsset', () => {
   });
 
   const playMock = jest.fn().mockResolvedValue(undefined);
+  const pauseMock = jest.fn().mockResolvedValue(undefined);
 
   beforeAll(() => {
     window.matchMedia = () => ({ matches: false });
     window.HTMLMediaElement.prototype.play = playMock;
+    window.HTMLMediaElement.prototype.pause = pauseMock;
+    Object.defineProperties(window.HTMLMediaElement.prototype, {
+      paused: {
+        value: false,
+        writable: true,
+      },
+      ended: {
+        value: false,
+        writable: true,
+      },
+    });
   });
   beforeEach(() => {
     jest.clearAllMocks();
@@ -50,88 +64,81 @@ describe('ReplayableVideoAsset', () => {
     const video = wrapper.find(VideoAsset);
     expect(video.props('variants')).toBe(variants);
     expect(video.props('posterVariants')).toBe(posterVariants);
-    expect(video.props('showsControls')).toBe(true);
+    expect(video.props('showsControls')).toBe(false);
     expect(video.props('autoplays')).toBe(true);
+    expect(wrapper.find('.control-button').exists()).toBe(true);
   });
 
-  it('displays the replay button when the video has ended', async () => {
+  it('does not show the `.control-button` if `showsControls` is `true`', () => {
+    const wrapper = mountWithProps({
+      showsControls: true,
+    });
+    const video = wrapper.find(VideoAsset);
+    expect(video.props('showsControls')).toBe(true);
+    expect(wrapper.find('.control-button').exists()).toBe(false);
+  });
+
+  it('changes the control button text, while the video is changing states', async () => {
     const wrapper = mountWithProps();
 
-    const replayButton = wrapper.find('.replay-button');
+    const replayButton = wrapper.find('.control-button');
 
-    // Initially, the replay button should not be displayed.
     expect(replayButton.exists()).toBe(true);
-    expect(replayButton.classes('visible')).toBe(false);
+    expect(replayButton.text()).toBe('video.play');
 
-    expect(replayButton.find('.replay-icon').is(PlayIcon)).toBe(true);
+    expect(replayButton.find('.control-icon').is(PlayIcon)).toBe(true);
     const video = wrapper.find(VideoAsset);
-    video.vm.$emit('ended');
+    await video.vm.$emit('ended');
 
-    expect(replayButton.classes('visible')).toBe(true);
-    expect(wrapper.find('.replay-icon').is(InlineReplayIcon)).toBe(true);
+    expect(wrapper.find('.control-icon').is(InlineReplayIcon)).toBe(true);
+    expect(replayButton.text()).toBe('video.replay');
 
-    // When the video is playing, the replay button should be hidden.
-    replayButton.trigger('click');
+    // start playing
+    await replayButton.trigger('click');
+    await video.vm.$emit('playing');
+    const videoEl = video.find('video').element;
+    videoEl.paused = false;
+    videoEl.ended = false;
     await flushPromises();
-    expect(replayButton.classes('visible')).toBe(false);
+    expect(replayButton.text()).toBe('video.pause');
+    expect(wrapper.find('.control-icon').is(PauseIcon)).toBe(true);
+    await replayButton.trigger('click');
+    videoEl.paused = true;
+    await video.vm.$emit('pause');
+    expect(replayButton.text()).toBe('video.play');
   });
 
   it('plays the video if replay button is clicked', async () => {
     const wrapper = mountWithProps();
 
     expect(playMock).toHaveBeenCalledTimes(0);
-    wrapper.find('.replay-button').trigger('click');
+    expect(pauseMock).toHaveBeenCalledTimes(0);
+    const button = wrapper.find('.control-button');
+    await button.trigger('click');
+    await wrapper.find(VideoAsset).vm.$emit('playing');
     await flushPromises();
+    expect(pauseMock).toHaveBeenCalledTimes(0);
     expect(playMock).toHaveBeenCalledTimes(1);
+    await button.trigger('click');
+    expect(pauseMock).toHaveBeenCalledTimes(1);
   });
 
-  it('shows the Replay on first mount, if not set to autoplay', async () => {
+  it('shows the play button on first mount, if not set to autoplay', async () => {
     const wrapper = mountWithProps({
       autoplays: false,
     });
-    const replay = wrapper.find('.replay-button');
-    expect(replay.text()).toBe('video.play');
-    expect(replay.classes()).toContain('visible');
-    replay.trigger('click');
+    const video = wrapper.find({ ref: 'asset' });
+    const control = wrapper.find('.control-button');
+    expect(control.text()).toBe('video.play');
+    control.trigger('click');
+    video.vm.$emit('playing');
     await flushPromises();
-    // text is not changed, but its invisible
-    expect(replay.text()).toBe('video.play');
-    expect(replay.classes()).not.toContain('visible');
+    // text is changed
+    expect(control.text()).toBe('video.pause');
     // now end the video
-    wrapper.find({ ref: 'asset' }).vm.$emit('ended');
+    video.vm.$emit('ended');
     // assert text changed and its visible
-    expect(replay.text()).toBe('video.replay');
-    expect(replay.classes()).toContain('visible');
-  });
-
-  it('shows the Replay on `pause` if no `showsControls` is false', async () => {
-    const wrapper = mountWithProps({
-      autoplays: false,
-      showsControls: false,
-    });
-    const replay = wrapper.find('.replay-button');
-    expect(replay.classes()).toContain('visible');
-    // play
-    replay.trigger('click');
-    await flushPromises();
-    // assert button is hidden
-    expect(replay.classes()).not.toContain('visible');
-    // pause
-    wrapper.find({ ref: 'asset' }).vm.$emit('pause');
-    // assert button is visible again
-    expect(replay.classes()).toContain('visible');
-  });
-
-  it('hides the button when @playing fired', () => {
-    const wrapper = mountWithProps({
-      autoplays: false,
-    });
-    const replay = wrapper.find('.replay-button');
-    expect(replay.classes()).toContain('visible');
-    // Simulate browser starts playing
-    wrapper.find({ ref: 'asset' }).vm.$emit('playing');
-    // assert button is hidden
-    expect(replay.classes()).not.toContain('visible');
+    expect(control.text()).toBe('video.replay');
   });
 
   it('provides the DeviceFrame down to the Video', () => {


### PR DESCRIPTION
- Explanation: Allow pausing a video while its playing
- Scope: All places the video tag is used (docs, tutorials)
- Issue: rdar://107269394
- Risk: Medium
- Testing: Assert videos can be paused and resumed. Assert there is no no regression in visuals and functionality 
- Reviewer: @marinaaisa 
- Original PR: https://github.com/apple/swift-docc-render/pull/559