### PR TITLE
[5.9] Remove the topicSectionsStyle limitation for the doc intro section

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -412,7 +412,6 @@ export default {
     enhanceBackground: ({
       symbolKind,
       disableHeroBackground,
-      topicSectionsStyle,
       enableMinimized,
     }) => {
       if (
@@ -420,9 +419,6 @@ export default {
         disableHeroBackground
         // or minimized view is enabled
         || enableMinimized
-        // or the topicSectionsStyle is a `grid` type
-        || topicSectionsStyle === TopicSectionsStyle.compactGrid
-        || topicSectionsStyle === TopicSectionsStyle.detailedGrid
       ) {
         return false;
       }

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -322,15 +322,6 @@ describe('DocumentationTopic', () => {
     expect(hero.props('enhanceBackground')).toBe(false);
   });
 
-  it('renders a `DocumentationHero`, disabled, if the `topicSectionsStyle` is a grid type', () => {
-    const hero = wrapper.find(DocumentationHero);
-    expect(hero.props('enhanceBackground')).toBe(true);
-    wrapper.setProps({ topicSectionsStyle: TopicSectionsStyle.detailedGrid });
-    expect(hero.props('enhanceBackground')).toBe(false);
-    wrapper.setProps({ topicSectionsStyle: TopicSectionsStyle.compactGrid });
-    expect(hero.props('enhanceBackground')).toBe(false);
-  });
-
   it('renders a `Title`', () => {
     const hero = wrapper.find(DocumentationHero);
 


### PR DESCRIPTION
- Explanation: Stops removing the color from the intro section based on the `@TopicsVisualStyle`
- Scope: Doc hero section
- Issue: rdar://107581728
- Risk: Small
- Testing: Assert pages that use `@TopicsVisualStyle` directive still can render a colored Intro section.
- Reviewer: @SamLanier @hqhhuang 
- Original PR: https://github.com/apple/swift-docc-render/pull/581