### PR TITLE
[5.9] Remove unnecessary top padding in navigation bar

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -222,8 +222,6 @@ $sidenav-icon-padding-size: 5px;
 // overwrite the typography of menu items outside of breakpoint only
 /deep/ .nav-menu {
   @include font-styles(documentation-nav);
-  // vertically align the items
-  padding-top: 0;
 
   &-settings {
     @include font-styles(nav-toggles);
@@ -275,10 +273,6 @@ $sidenav-icon-padding-size: 5px;
     // normalize the Title font with menu items
     .nav-title {
       @include font-styles(documentation-nav);
-
-      @include breakpoint(medium, $scope: nav) {
-        padding-top: 0;
-      }
 
       .nav-title-link.inactive {
         height: auto;

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -615,14 +615,10 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   @include font-styles(nav-menu);
   flex: 1 1 auto;
   display: flex;
-  // padding centers it vertically for large resolutions
-  padding-top: 10px;
   min-width: 0;
 
   @include nav-in-breakpoint {
     @include font-styles(nav-menu-collapsible);
-    // it is collapsed, so we no longer need the offset
-    padding-top: 0;
     grid-area: menu;
   }
 }


### PR DESCRIPTION
- Explanation: Removes an unnecessary top padding from the nav bar that we are removing everywhere anyway.
- Scope: All pages
- Issue: rdar://107692636
- Risk: Small
- Testing: There should be no visual change in doc and tutorial pages
- Reviewer: @marinaaisa @SamLanier 
- Original PR: https://github.com/apple/swift-docc-render/pull/583