### PR TITLE
Set tabnav to the tab with latest title update

### DIFF
--- a/src/components/ContentNode/TabNavigator.vue
+++ b/src/components/ContentNode/TabNavigator.vue
@@ -75,8 +75,7 @@ export default {
     titles(newVal, oldVal) {
       if (newVal.length < oldVal.length) {
         // set to the first tab if selected tab was removed
-        const removedTab = oldVal.find((tab, i) => newVal[i] !== tab);
-        if (removedTab === this.currentTitle) {
+        if (!newVal.includes(this.currentTitle)) {
           // eslint-disable-next-line prefer-destructuring
           this.currentTitle = newVal[0];
         }

--- a/src/components/ContentNode/TabNavigator.vue
+++ b/src/components/ContentNode/TabNavigator.vue
@@ -71,6 +71,28 @@ export default {
       currentTitle: this.titles[0],
     };
   },
+  watch: {
+    titles(newVal, oldVal) {
+      if (newVal.length === oldVal.length) {
+        // set to the tab with updated title
+        newVal.forEach((tab, index) => {
+          if (tab !== oldVal[index]) {
+            this.currentTitle = tab;
+          }
+        });
+      } else if (newVal.length > oldVal.length) {
+        // set to newly added tab, may not be the last tab
+        this.currentTitle = newVal.find(tab => !oldVal.includes(tab));
+      } else {
+        // set to the tab before the removed one
+        const removedTab = oldVal.find(tab => !newVal.includes(tab));
+        const removedTabIdx = oldVal.indexOf(removedTab);
+        const newTabIdx = (removedTabIdx === oldVal.length - 1)
+          ? (newVal.length - 1) : removedTabIdx;
+        this.currentTitle = newVal[newTabIdx];
+      }
+    },
+  },
 };
 </script>
 

--- a/src/components/ContentNode/TabNavigator.vue
+++ b/src/components/ContentNode/TabNavigator.vue
@@ -73,23 +73,17 @@ export default {
   },
   watch: {
     titles(newVal, oldVal) {
-      if (newVal.length === oldVal.length) {
-        // set to the tab with updated title
-        newVal.forEach((tab, index) => {
-          if (tab !== oldVal[index]) {
-            this.currentTitle = tab;
-          }
-        });
-      } else if (newVal.length > oldVal.length) {
-        // set to newly added tab, may not be the last tab
-        this.currentTitle = newVal.find(tab => !oldVal.includes(tab));
-      } else {
-        // set to the tab before the removed one
+      if (newVal.length < oldVal.length) {
+        // set to the first tab if selected tab was removed
         const removedTab = oldVal.find(tab => !newVal.includes(tab));
-        const removedTabIdx = oldVal.indexOf(removedTab);
-        const newTabIdx = (removedTabIdx === oldVal.length - 1)
-          ? (newVal.length - 1) : removedTabIdx;
-        this.currentTitle = newVal[newTabIdx];
+        if (removedTab === this.currentTitle) {
+          // eslint-disable-next-line prefer-destructuring
+          this.currentTitle = newVal[0];
+        }
+      } else {
+        // set to newly added/changed tab
+        const newTab = newVal.find(tab => !oldVal.includes(tab));
+        this.currentTitle = newTab || this.currentTitle;
       }
     },
   },

--- a/src/components/ContentNode/TabNavigator.vue
+++ b/src/components/ContentNode/TabNavigator.vue
@@ -76,8 +76,8 @@ export default {
       if (newVal.length < oldVal.length) {
         // set to the first tab if selected tab was removed
         if (!newVal.includes(this.currentTitle)) {
-          // eslint-disable-next-line prefer-destructuring
-          this.currentTitle = newVal[0];
+          const [firstTitle] = newVal;
+          this.currentTitle = firstTitle;
         }
       } else {
         // set to newly added/changed tab

--- a/src/components/ContentNode/TabNavigator.vue
+++ b/src/components/ContentNode/TabNavigator.vue
@@ -75,7 +75,7 @@ export default {
     titles(newVal, oldVal) {
       if (newVal.length < oldVal.length) {
         // set to the first tab if selected tab was removed
-        const removedTab = oldVal.find(tab => !newVal.includes(tab));
+        const removedTab = oldVal.find((tab, i) => newVal[i] !== tab);
         if (removedTab === this.currentTitle) {
           // eslint-disable-next-line prefer-destructuring
           this.currentTitle = newVal[0];

--- a/tests/unit/components/ContentNode/TabNavigator.spec.js
+++ b/tests/unit/components/ContentNode/TabNavigator.spec.js
@@ -16,6 +16,8 @@ import ImageLoadingStrategy from '@/constants/ImageLoadingStrategy';
 import { flushPromises } from '../../../../test-utils';
 
 const titles = ['Long tab title', 'A Longer tab title', 'The Longest tab title'];
+const longerTitles = titles.concat('added title');
+
 const scopedSlots = {
   [titles[0]]: '<div>First</div>',
   [titles[1]]: '<div>Second</div>',
@@ -70,20 +72,14 @@ describe('TabNavigator.spec', () => {
     expect(tabnav.props('value')).toEqual(titles[1]);
   });
 
-  it('selects correct tab when adding a tab', async () => {
-    const longerTitles = ['Long tab title',
-      'A Longer tab title', 'The Longest tab title', 'added title'];
-
+  it('selects correct tab when adding a tab', () => {
     const wrapper = createWrapper();
     wrapper.setProps({ titles: longerTitles });
 
     expect(wrapper.vm.currentTitle).toEqual('added title');
   });
 
-  it('selects first tab when deleting current tab', async () => {
-    const longerTitles = ['Long tab title',
-      'A Longer tab title', 'The Longest tab title', 'added title'];
-
+  it('selects first tab when deleting current tab', () => {
     const wrapper = createWrapper();
     // current tab is on 'added title'
     wrapper.setProps({ titles: longerTitles });
@@ -92,26 +88,32 @@ describe('TabNavigator.spec', () => {
     expect(wrapper.vm.currentTitle).toEqual('Long tab title');
   });
 
-  it('selects first tab when deleting current tab', async () => {
-    const longerTitles = ['Long tab title',
-      'A Longer tab title', 'The Longest tab title', 'added title'];
-    const removedTitles = ['Long tab title',
-      'A Longer tab title', 'added title'];
+  it('keep currently selected tab when deleting a tab', () => {
     const wrapper = createWrapper();
     // current tab is on 'added title'
     wrapper.setProps({ titles: longerTitles });
+    const removedTitles = ['Long tab title',
+      'A Longer tab title', 'added title'];
     wrapper.setProps({ titles: removedTitles });
 
     expect(wrapper.vm.currentTitle).toEqual('added title');
   });
 
-  it('selects correct tab when changing a tab', async () => {
-    const changedTitle = ['Long tab title',
-      'A Longer tab title', 'changed tab title'];
-
+  it('selects correct tab when changing a tab', () => {
+    const changedLastTab = ['Long tab title',
+      'A Longer tab title', 'changed last tab'];
     const wrapper = createWrapper();
-    wrapper.setProps({ titles: changedTitle });
+    wrapper.setProps({ titles: changedLastTab });
+    expect(wrapper.vm.currentTitle).toEqual('changed last tab');
 
-    expect(wrapper.vm.currentTitle).toEqual('changed tab title');
+    const changedFirstTab = ['changed first tab',
+      'A Longer tab title', 'changed last tab'];
+    wrapper.setProps({ titles: changedFirstTab });
+    expect(wrapper.vm.currentTitle).toEqual('changed first tab');
+
+    const changedMidTab = ['changed first tab',
+      'changed middle tab', 'changed last tab'];
+    wrapper.setProps({ titles: changedMidTab });
+    expect(wrapper.vm.currentTitle).toEqual('changed middle tab');
   });
 });

--- a/tests/unit/components/ContentNode/TabNavigator.spec.js
+++ b/tests/unit/components/ContentNode/TabNavigator.spec.js
@@ -17,10 +17,17 @@ import { flushPromises } from '../../../../test-utils';
 
 const titles = ['Long tab title', 'A Longer tab title', 'The Longest tab title'];
 const longerTitles = titles.concat('added title');
+const changedTitles = ['changed first tab',
+  'changed middle tab', 'changed last tab'];
 
 const scopedSlots = {
   [titles[0]]: '<div>First</div>',
   [titles[1]]: '<div>Second</div>',
+  [titles[2]]: '<div>Third</div>',
+  [longerTitles[3]]: '<div>Fourth</div>',
+  [changedTitles[0]]: '<div>First</div>',
+  [changedTitles[1]]: '<div>Middle</div>',
+  [changedTitles[2]]: '<div>Last</div>',
 };
 const defaultProps = {
   titles,
@@ -72,48 +79,62 @@ describe('TabNavigator.spec', () => {
     expect(tabnav.props('value')).toEqual(titles[1]);
   });
 
-  it('selects correct tab when adding a tab', () => {
+  it('selects the added tab when adding a tab', () => {
     const wrapper = createWrapper();
-    wrapper.setProps({ titles: longerTitles });
+    expect(wrapper.find('.tabs-content').text()).toBe('First');
 
-    expect(wrapper.vm.currentTitle).toEqual('added title');
+    wrapper.setProps({ titles: longerTitles });
+    expect(wrapper.find('.tabs-content').text()).toBe('Fourth');
+    const tabnav = wrapper.find(Tabnav);
+    expect(tabnav.props('value')).toEqual(longerTitles[3]);
   });
 
   it('selects first tab when deleting current tab', () => {
     const wrapper = createWrapper();
-    // current tab is on 'added title'
     wrapper.setProps({ titles: longerTitles });
-    wrapper.setProps({ titles });
+    expect(wrapper.find('.tabs-content').text()).toBe('Fourth');
 
-    expect(wrapper.vm.currentTitle).toEqual('Long tab title');
+    wrapper.setProps({ titles });
+    expect(wrapper.find('.tabs-content').text()).toBe('First');
+    const tabnav = wrapper.find(Tabnav);
+    expect(tabnav.props('value')).toEqual(titles[0]);
   });
 
   it('keep currently selected tab when deleting a tab', () => {
     const wrapper = createWrapper();
-    // current tab is on 'added title'
     wrapper.setProps({ titles: longerTitles });
+    expect(wrapper.find('.tabs-content').text()).toBe('Fourth'); // Current tab
+
     const removedTitles = ['Long tab title',
       'A Longer tab title', 'added title'];
     wrapper.setProps({ titles: removedTitles });
-
-    expect(wrapper.vm.currentTitle).toEqual('added title');
+    expect(wrapper.find('.tabs-content').text()).toBe('Fourth'); // Keeps current tab
+    const tabnav = wrapper.find(Tabnav);
+    expect(tabnav.props('value')).toEqual(longerTitles[3]);
   });
 
   it('selects correct tab when changing a tab', () => {
     const changedLastTab = ['Long tab title',
       'A Longer tab title', 'changed last tab'];
     const wrapper = createWrapper();
+    expect(wrapper.find('.tabs-content').text()).toBe('First');
     wrapper.setProps({ titles: changedLastTab });
-    expect(wrapper.vm.currentTitle).toEqual('changed last tab');
+    expect(wrapper.find('.tabs-content').text()).toBe('Last');
+    let tabnav = wrapper.find(Tabnav);
+    expect(tabnav.props('value')).toEqual(changedLastTab[2]);
 
     const changedFirstTab = ['changed first tab',
       'A Longer tab title', 'changed last tab'];
     wrapper.setProps({ titles: changedFirstTab });
-    expect(wrapper.vm.currentTitle).toEqual('changed first tab');
+    expect(wrapper.find('.tabs-content').text()).toBe('First');
+    tabnav = wrapper.find(Tabnav);
+    expect(tabnav.props('value')).toEqual(changedFirstTab[0]);
 
     const changedMidTab = ['changed first tab',
       'changed middle tab', 'changed last tab'];
     wrapper.setProps({ titles: changedMidTab });
-    expect(wrapper.vm.currentTitle).toEqual('changed middle tab');
+    expect(wrapper.find('.tabs-content').text()).toBe('Middle');
+    tabnav = wrapper.find(Tabnav);
+    expect(tabnav.props('value')).toEqual(changedMidTab[1]);
   });
 });

--- a/tests/unit/components/ContentNode/TabNavigator.spec.js
+++ b/tests/unit/components/ContentNode/TabNavigator.spec.js
@@ -15,7 +15,7 @@ import TabnavItem from '@/components/TabnavItem.vue';
 import ImageLoadingStrategy from '@/constants/ImageLoadingStrategy';
 import { flushPromises } from '../../../../test-utils';
 
-const titles = ['Long tab title', 'A Longer tab title'];
+const titles = ['Long tab title', 'A Longer tab title', 'The Longest tab title'];
 const scopedSlots = {
   [titles[0]]: '<div>First</div>',
   [titles[1]]: '<div>Second</div>',
@@ -44,7 +44,7 @@ describe('TabNavigator.spec', () => {
       vertical: false,
       value: titles[0],
     });
-    expect(wrapper.findAll(TabnavItem)).toHaveLength(2);
+    expect(wrapper.findAll(TabnavItem)).toHaveLength(3);
     expect(wrapper.find('.tabs-content').text()).toEqual('First');
     // eslint-disable-next-line no-underscore-dangle
     expect(wrapper.vm._provided).toHaveProperty('imageLoadingStrategy', ImageLoadingStrategy.eager);
@@ -68,5 +68,35 @@ describe('TabNavigator.spec', () => {
     tabnav.vm.$emit('input', titles[1]);
     expect(wrapper.find('.tabs-content').text()).toBe('Second');
     expect(tabnav.props('value')).toEqual(titles[1]);
+  });
+
+  it('selects correct tab when adding a tab', async () => {
+    const longerTitles = ['Long tab title',
+      'A Longer tab title', 'The Longest tab title', 'added title'];
+
+    const wrapper = createWrapper();
+    wrapper.setProps({ titles: longerTitles });
+
+    expect(wrapper.vm.currentTitle).toEqual('added title');
+  });
+
+  it('selects correct tab when deleting a tab', async () => {
+    const shorterTitles = ['Long tab title',
+      'A Longer tab title'];
+
+    const wrapper = createWrapper();
+    wrapper.setProps({ titles: shorterTitles });
+
+    expect(wrapper.vm.currentTitle).toEqual('A Longer tab title');
+  });
+
+  it('selects correct tab when changing a tab', async () => {
+    const changedTitle = ['Long tab title',
+      'A Longer tab title', 'changed tab title'];
+
+    const wrapper = createWrapper();
+    wrapper.setProps({ titles: changedTitle });
+
+    expect(wrapper.vm.currentTitle).toEqual('changed tab title');
   });
 });

--- a/tests/unit/components/ContentNode/TabNavigator.spec.js
+++ b/tests/unit/components/ContentNode/TabNavigator.spec.js
@@ -80,14 +80,29 @@ describe('TabNavigator.spec', () => {
     expect(wrapper.vm.currentTitle).toEqual('added title');
   });
 
-  it('selects correct tab when deleting a tab', async () => {
-    const shorterTitles = ['Long tab title',
-      'A Longer tab title'];
+  it('selects first tab when deleting current tab', async () => {
+    const longerTitles = ['Long tab title',
+      'A Longer tab title', 'The Longest tab title', 'added title'];
 
     const wrapper = createWrapper();
-    wrapper.setProps({ titles: shorterTitles });
+    // current tab is on 'added title'
+    wrapper.setProps({ titles: longerTitles });
+    wrapper.setProps({ titles });
 
-    expect(wrapper.vm.currentTitle).toEqual('A Longer tab title');
+    expect(wrapper.vm.currentTitle).toEqual('Long tab title');
+  });
+
+  it('selects first tab when deleting current tab', async () => {
+    const longerTitles = ['Long tab title',
+      'A Longer tab title', 'The Longest tab title', 'added title'];
+    const removedTitles = ['Long tab title',
+      'A Longer tab title', 'added title'];
+    const wrapper = createWrapper();
+    // current tab is on 'added title'
+    wrapper.setProps({ titles: longerTitles });
+    wrapper.setProps({ titles: removedTitles });
+
+    expect(wrapper.vm.currentTitle).toEqual('added title');
   });
 
   it('selects correct tab when changing a tab', async () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 108013117

## Summary
We should set the current tab of TabNav to the tab that just got added or just had its title updated.


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
