### PR TITLE
Remove feature flag for quicknav preview

### DIFF
--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -116,7 +116,7 @@
               </Reference>
             </div>
             <Preview
-              v-if="previewEnabled && previewState"
+              v-if="previewState"
               class="quick-navigation__preview"
               :json="previewJSON"
               :state="previewState"
@@ -184,10 +184,6 @@ export default {
     showQuickNavigationModal: {
       type: Boolean,
       required: true,
-    },
-    previewEnabled: {
-      type: Boolean,
-      default: false,
     },
     technology: {
       type: String,

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -31,7 +31,6 @@
                   v-if="enableQuickNavigation"
                   :children="slotProps.flatChildren"
                   :showQuickNavigationModal.sync="showQuickNavigationModal"
-                  :previewEnabled="enableQuickNavigationPreview"
                   :technology="technology.title"
                 />
                 <transition name="delay-hiding">
@@ -173,7 +172,6 @@ export default {
     enableQuickNavigation: ({ isTargetIDE }) => (
       !isTargetIDE && getSetting(['features', 'docs', 'quickNavigation', 'enable'], true)
     ),
-    enableQuickNavigationPreview: () => getSetting(['features', 'docs', 'quickNavigationPreview', 'enable'], false),
     topicData: {
       get() {
         return this.topicDataObjc ? this.topicDataObjc : this.topicDataDefault;

--- a/tests/unit/components/Navigator/QuickNavigationModal.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationModal.spec.js
@@ -366,20 +366,10 @@ describe('QuickNavigationModal', () => {
     expect(wrapper.vm.filteredSymbols.length).toBe(2);
   });
 
-  it('does not render a preview by default', () => {
-    expect(wrapper.contains(QuickNavigationPreview)).toBe(false);
-    wrapper.setData({ debouncedInput: inputValue });
-    expect(wrapper.contains(QuickNavigationPreview)).toBe(false);
-  });
-
-  describe('with preview enabled', () => {
+  describe('preview', () => {
     const { PreviewState } = QuickNavigationPreview.constants;
 
-    beforeEach(() => {
-      wrapper.setProps({ previewEnabled: true });
-    });
-
-    it('renders with a default loading sate when enabled', () => {
+    it('renders with a default loading state', () => {
       wrapper.setData({ debouncedInput: inputValue });
 
       const preview = wrapper.find(QuickNavigationPreview);


### PR DESCRIPTION
Bug/issue #, if applicable: NA

## Summary

Removes the feature flag for the quicknav preview functionality and enables it by default.

## Testing

Verify that the quicknav preview features, even without theme-settings file.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
