### PR TITLE
[5.9] Refactor: Move References to Stores

### DIFF
--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -60,6 +60,7 @@ export default {
       default() {
         return {
           reset() {},
+          setReferences() {},
         };
       },
     },
@@ -164,13 +165,9 @@ export default {
       }[kind];
     },
   },
-  provide() {
-    return {
-      references: this.references,
-    };
-  },
   created() {
     this.store.reset();
+    this.store.setReferences(this.references);
   },
   SectionKind,
 };

--- a/src/components/Asset.vue
+++ b/src/components/Asset.vue
@@ -19,6 +19,8 @@ import ImageAsset from 'docc-render/components/ImageAsset.vue';
 import VideoAsset from 'docc-render/components/VideoAsset.vue';
 import ReplayableVideoAsset from 'docc-render/components/ReplayableVideoAsset.vue';
 
+import referencesProvider from 'docc-render/mixins/referencesProvider';
+
 const AssetTypes = {
   video: 'video',
   image: 'image',
@@ -33,7 +35,7 @@ export default {
   constants: {
     AssetTypes,
   },
-  inject: ['references'],
+  mixins: [referencesProvider],
   props: {
     identifier: {
       type: String,

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -61,6 +61,7 @@ import InlineChevronRightIcon from 'theme/components/Icons/InlineChevronRightIco
 import DiagonalArrowIcon from 'theme/components/Icons/DiagonalArrowIcon.vue';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
 import CardSize from 'docc-render/constants/CardSize';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 import CardCover from './CardCover.vue';
 
 export default {
@@ -75,9 +76,7 @@ export default {
   constants: {
     CardSize,
   },
-  inject: {
-    references: { default: () => ({}) },
-  },
+  mixins: [referencesProvider],
   computed: {
     titleId: ({ _uid }) => `card_title_${_uid}`,
     contentId: ({ _uid }) => `card_content_${_uid}`,

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -9,6 +9,7 @@
 -->
 
 <script>
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 import Aside from './ContentNode/Aside.vue';
 import CodeListing from './ContentNode/CodeListing.vue';
 import LinkableHeading from './ContentNode/LinkableHeading.vue';
@@ -464,19 +465,13 @@ function renderNode(createElement, references) {
 export default {
   name: 'ContentNode',
   constants: { TableHeaderStyle, TableColumnAlignments },
+  mixins: [referencesProvider],
   render: function render(createElement) {
     // Dynamically map each content item and any children to their
     // corresponding components, and wrap the whole tree in a <div>
     return createElement(this.tag, { class: 'content' }, (
       this.content.map(renderNode(createElement, this.references), this)
     ));
-  },
-  inject: {
-    references: {
-      default() {
-        return {};
-      },
-    },
   },
   props: {
     content: {

--- a/src/components/ContentNode/LinksBlock.vue
+++ b/src/components/ContentNode/LinksBlock.vue
@@ -27,10 +27,11 @@
 <script>
 import TopicsLinkCardGrid from 'docc-render/components/DocumentationTopic/TopicsLinkCardGrid.vue';
 import { TopicSectionsStyle } from 'docc-render/constants/TopicSectionsStyle';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 
 export default {
   name: 'LinksBlock',
-  inject: ['references'],
+  mixins: [referencesProvider],
   components: {
     // async import to overcome potential infinite loops from importing ContentNode inside.
     TopicsLinkBlock: () => import('docc-render/components/DocumentationTopic/TopicsLinkBlock.vue'),

--- a/src/components/DestinationDataProvider.vue
+++ b/src/components/DestinationDataProvider.vue
@@ -9,6 +9,8 @@
 -->
 
 <script>
+import referencesProvider from 'docc-render/mixins/referencesProvider';
+
 const DestinationType = {
   link: 'link',
   reference: 'reference',
@@ -22,6 +24,7 @@ const DestinationType = {
  */
 export default {
   name: 'DestinationDataProvider',
+  mixins: [referencesProvider],
   props: {
     destination: {
       type: Object,
@@ -30,9 +33,6 @@ export default {
     },
   },
   inject: {
-    references: {
-      default: () => ({}),
-    },
     isTargetIDE: {
       default: () => false,
     },
@@ -58,7 +58,6 @@ export default {
      * @returns {boolean}
      */
     shouldAppendOpensInBrowser: ({ isExternal, isTargetIDE }) => isExternal && isTargetIDE,
-
     reference: ({ references, destination }) => (references[destination.identifier] || {}),
 
     linkUrl: ({

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -363,10 +363,9 @@ export default {
     },
   },
   provide() {
-    // NOTE: this is not reactive: if this.references change, the provided value
+    // NOTE: this is not reactive: if this.identifier change, the provided value
     // to children will stay the same
     return {
-      references: this.references,
       identifier: this.identifier,
       languages: new Set(Object.keys(this.languagePaths)),
       interfaceLanguage: this.interfaceLanguage,

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/TypeIdentifierLink.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/TypeIdentifierLink.vue
@@ -11,16 +11,11 @@
 <script>
 // This component renders token text as a link to a given type.
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 
 export default {
   name: 'TypeIdentifierLink',
-  inject: {
-    references: {
-      default() {
-        return {};
-      },
-    },
-  },
+  mixins: [referencesProvider],
   render(createElement) {
     const klass = 'type-identifier-link';
     const reference = this.references[this.identifier];

--- a/src/components/DocumentationTopic/Relationships.vue
+++ b/src/components/DocumentationTopic/Relationships.vue
@@ -26,19 +26,14 @@
 
 <script>
 import { MainContentSectionAnchors } from 'docc-render/constants/ContentSectionAnchors';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 import ContentTable from './ContentTable.vue';
 import ContentTableSection from './ContentTableSection.vue';
 import RelationshipsList from './RelationshipsList.vue';
 
 export default {
   name: 'Relationships',
-  inject: {
-    references: {
-      default() {
-        return {};
-      },
-    },
-  },
+  mixins: [referencesProvider],
   components: {
     ContentTable,
     List: RelationshipsList,

--- a/src/components/DocumentationTopic/TopicsLinkBlock.vue
+++ b/src/components/DocumentationTopic/TopicsLinkBlock.vue
@@ -77,6 +77,7 @@ import RequirementMetadata
   from 'docc-render/components/DocumentationTopic/Description/RequirementMetadata.vue';
 
 import { getAPIChanges, APIChangesMultipleLines } from 'docc-render/mixins/apiChangesHelpers';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 
 const TopicKind = {
   article: 'article',
@@ -103,8 +104,7 @@ export default {
     RequirementMetadata,
     ConditionalConstraints,
   },
-  inject: ['store', 'references'],
-  mixins: [getAPIChanges, APIChangesMultipleLines],
+  mixins: [getAPIChanges, APIChangesMultipleLines, referencesProvider],
   constants: {
     ReferenceType,
     TopicKind,

--- a/src/components/DocumentationTopic/TopicsLinkCardGridItem.vue
+++ b/src/components/DocumentationTopic/TopicsLinkCardGridItem.vue
@@ -36,6 +36,7 @@ import Card from 'docc-render/components/Card.vue';
 import TopicTypeIcon from 'docc-render/components/TopicTypeIcon.vue';
 import { TopicRole } from 'docc-render/constants/roles';
 import CardSize from 'docc-render/constants/CardSize';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 
 export const ROLE_LINK_TEXT = {
   [TopicRole.article]: 'Read article',
@@ -52,7 +53,7 @@ export default {
     Card,
     ContentNode: () => import('docc-render/components/ContentNode.vue'),
   },
-  inject: ['references'],
+  mixins: [referencesProvider],
   props: {
     item: {
       type: Object,

--- a/src/components/DocumentationTopic/TopicsTable.vue
+++ b/src/components/DocumentationTopic/TopicsTable.vue
@@ -58,19 +58,14 @@ import WordBreak from 'docc-render/components/WordBreak.vue';
 import { TopicSectionsStyle } from 'docc-render/constants/TopicSectionsStyle';
 import TopicsLinkCardGrid from 'docc-render/components/DocumentationTopic/TopicsLinkCardGrid.vue';
 import LinkableHeading from 'docc-render/components/ContentNode/LinkableHeading.vue';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 import ContentTable from './ContentTable.vue';
 import ContentTableSection from './ContentTableSection.vue';
 import TopicsLinkBlock from './TopicsLinkBlock.vue';
 
 export default {
   name: 'TopicsTable',
-  inject: {
-    references: {
-      default() {
-        return {};
-      },
-    },
-  },
+  mixins: [referencesProvider],
   components: {
     TopicsLinkCardGrid,
     WordBreak,

--- a/src/components/ReferenceUrlProvider.vue
+++ b/src/components/ReferenceUrlProvider.vue
@@ -10,14 +10,11 @@
 
 <script>
 import { buildUrl } from 'docc-render/utils/url-helper';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 
 export default {
   name: 'ReferenceUrlProvider',
-  inject: {
-    references: {
-      default: () => ({}),
-    },
-  },
+  mixins: [referencesProvider],
   props: {
     reference: {
       type: String,

--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -136,6 +136,7 @@ export default {
   },
   created() {
     this.store.reset();
+    this.store.setReferences(this.references);
   },
   mounted() {
     this.$bridge.on('codeColors', this.handleCodeColorsChange);
@@ -143,7 +144,6 @@ export default {
   },
   provide() {
     return {
-      references: this.references,
       isClientMobile: this.isClientMobile,
     };
   },

--- a/src/components/Tutorial/CodePreview.vue
+++ b/src/components/Tutorial/CodePreview.vue
@@ -65,11 +65,20 @@ function scaledSize({ width, height }, scale = 1) {
 
 export default {
   name: 'CodePreview',
-  inject: [
-    'references',
-    'isTargetIDE',
-    'store',
-  ],
+  inject: {
+    isTargetIDE: {
+      default: false,
+    },
+    store: {
+      default() {
+        return {
+          state: {
+            references: {},
+          },
+        };
+      },
+    },
+  },
   components: {
     DiagonalArrowIcon,
     CodeListing,
@@ -95,6 +104,7 @@ export default {
     };
   },
   computed: {
+    references: ({ tutorialState }) => tutorialState.references,
     currentBreakpoint() {
       return this.tutorialState.breakpoint;
     },

--- a/src/components/Tutorial/Hero.vue
+++ b/src/components/Tutorial/Hero.vue
@@ -74,6 +74,7 @@ import LinkableElement from 'docc-render/components/LinkableElement.vue';
 import GenericModal from 'docc-render/components/GenericModal.vue';
 import PlayIcon from 'theme/components/Icons/PlayIcon.vue';
 import { normalizeAssetUrl, toCSSUrl } from 'docc-render/utils/assets';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 import HeroMetadata from './HeroMetadata.vue';
 
 export default {
@@ -103,7 +104,7 @@ export default {
     Asset,
     LinkableSection: LinkableElement,
   },
-  inject: ['references'],
+  mixins: [referencesProvider],
   props: {
     title: {
       type: String,

--- a/src/components/Tutorial/MobileCodePreview.vue
+++ b/src/components/Tutorial/MobileCodePreview.vue
@@ -54,17 +54,15 @@
 import CodeListing from 'docc-render/components/ContentNode/CodeListing.vue';
 import MobileCodeListing from 'docc-render/components/ContentNode/MobileCodeListing.vue';
 import GenericModal from 'docc-render/components/GenericModal.vue';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 import MobileCodePreviewToggle from './MobileCodePreviewToggle.vue';
 import BackgroundTheme from './BackgroundTheme.vue';
 import CodeTheme from './CodeTheme.vue';
 
 export default {
   name: 'MobileCodePreview',
-  inject: [
-    'references',
-    'isTargetIDE',
-    'store',
-  ],
+  inject: ['isTargetIDE'],
+  mixins: [referencesProvider],
   components: {
     GenericModal,
     CodeListing,

--- a/src/components/Tutorial/NavigationBar.vue
+++ b/src/components/Tutorial/NavigationBar.vue
@@ -61,6 +61,7 @@
 <script>
 import ChevronIcon from 'theme/components/Icons/ChevronIcon.vue';
 import ReferenceUrlProvider from 'docc-render/components/ReferenceUrlProvider.vue';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
 import scrollToElement from 'docc-render/mixins/scrollToElement';
 import NavBase from 'docc-render/components/NavBase.vue';
 import NavTitleContainer from 'docc-render/components/NavTitleContainer.vue';
@@ -87,8 +88,7 @@ export default {
     MobileDropdown,
     ChevronIcon,
   },
-  mixins: [scrollToElement],
-  inject: ['store', 'references'],
+  mixins: [scrollToElement, referencesProvider],
   props: {
     chapters: {
       type: Array,

--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -36,7 +36,6 @@
 
 <script>
 import TutorialsOverviewStore from 'docc-render/stores/TutorialsOverviewStore';
-
 import Nav from 'theme/components/TutorialsOverview/Nav.vue';
 import metadata from 'theme/mixins/metadata.js';
 import Hero from './TutorialsOverview/Hero.vue';
@@ -97,12 +96,12 @@ export default {
   },
   provide() {
     return {
-      references: this.references,
       store: this.store,
     };
   },
   created() {
     this.store.reset();
+    this.store.setReferences(this.references);
   },
 };
 </script>

--- a/src/components/TutorialsOverview/Volume.vue
+++ b/src/components/TutorialsOverview/Volume.vue
@@ -39,13 +39,16 @@ export default {
     Chapter,
   },
   computed: {
+    references: ({ store }) => store.state.references,
     intersectionRootMargin: () => intersectionMargins.topOneThird,
   },
   inject: {
-    references: { default: () => ({}) },
     store: {
       default: () => ({
         setActiveVolume() {},
+        state: {
+          references: {},
+        },
       }),
     },
   },

--- a/src/mixins/referencesProvider.js
+++ b/src/mixins/referencesProvider.js
@@ -1,0 +1,28 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2023 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+export default {
+  // inject the `store`
+  inject: {
+    store: {
+      default: () => ({
+        state: {
+          references: {},
+        },
+        setReferences() {},
+        reset() {},
+      }),
+    },
+  },
+  computed: {
+    // exposes the references for the current page
+    references: ({ store }) => store.state.references,
+  },
+};

--- a/src/stores/DocumentationTopicStore.js
+++ b/src/stores/DocumentationTopicStore.js
@@ -21,9 +21,11 @@ export default {
     contentWidth: 0,
     ...changesState,
     ...pageSectionsState,
+    references: {},
   },
   reset() {
     this.state.preferredLanguage = Settings.preferredLanguage;
+    this.state.references = {};
     this.resetApiChanges();
   },
   setPreferredLanguage(language) {
@@ -32,6 +34,9 @@ export default {
   },
   setContentWidth(width) {
     this.state.contentWidth = width;
+  },
+  setReferences(references) {
+    this.state.references = references;
   },
   ...changesActions,
   ...pageSectionsActions,

--- a/src/stores/TopicStore.js
+++ b/src/stores/TopicStore.js
@@ -16,6 +16,7 @@ export default {
   state: {
     linkableSections: [],
     breakpoint: BreakpointName.large,
+    references: {},
   },
   addLinkableSection(section) {
     const newLinkableSection = {
@@ -28,6 +29,7 @@ export default {
   reset() {
     this.state.linkableSections = [];
     this.state.breakpoint = BreakpointName.large;
+    this.state.references = {};
   },
   updateLinkableSection(section) {
     this.state.linkableSections = this.state.linkableSections.map(oldSection => (
@@ -41,5 +43,8 @@ export default {
   },
   updateBreakpoint(value) {
     this.state.breakpoint = value;
+  },
+  setReferences(references) {
+    this.state.references = references;
   },
 };

--- a/src/stores/TutorialsOverviewStore.js
+++ b/src/stores/TutorialsOverviewStore.js
@@ -12,15 +12,20 @@ export default {
   state: {
     activeTutorialLink: null,
     activeVolume: null,
+    references: {},
   },
   reset() {
     this.state.activeTutorialLink = null;
     this.state.activeVolume = null;
+    this.state.references = {};
   },
   setActiveSidebarLink(link) {
     this.state.activeTutorialLink = link;
   },
   setActiveVolume(name) {
     this.state.activeVolume = name;
+  },
+  setReferences(references) {
+    this.state.references = references;
   },
 };

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -384,6 +384,7 @@ export default {
       this.$nextTick(() => {
         // Send a 'rendered' message to the host when new data has been patched onto the DOM.
         this.newContentMounted();
+        this.store.setReferences(this.topicProps.references);
       });
     },
   },

--- a/tests/unit/components/Asset.spec.js
+++ b/tests/unit/components/Asset.spec.js
@@ -42,7 +42,11 @@ describe('Asset', () => {
   const mountAsset = (identifier, references = {}) => (
     shallowMount(Asset, {
       propsData: { identifier },
-      provide: { references },
+      provide: {
+        store: {
+          state: { references },
+        },
+      },
     })
   );
 
@@ -121,7 +125,11 @@ describe('Asset', () => {
         showsReplayButton: true,
         showsVideoControls: true,
       },
-      provide: { references: { video } },
+      provide: {
+        store: {
+          state: { references: { video } },
+        },
+      },
     });
 
     const videoAsset = wrapper.find(ReplayableVideoAsset);
@@ -138,7 +146,11 @@ describe('Asset', () => {
         showsVideoControls: true,
         deviceFrame: 'phone',
       },
-      provide: { references: { video } },
+      provide: {
+        store: {
+          state: { references: { video } },
+        },
+      },
     });
 
     const videoAsset = wrapper.find(ReplayableVideoAsset);
@@ -160,7 +172,11 @@ describe('Asset', () => {
         videoAutoplays: true,
         videoMuted: false,
       },
-      provide: { references: { video } },
+      provide: {
+        store: {
+          state: { references: { video } },
+        },
+      },
     });
 
     expect(wrapper.find(ReplayableVideoAsset).exists()).toBe(false);
@@ -179,7 +195,11 @@ describe('Asset', () => {
         showsVideoControls: true,
         videoMuted: false,
       },
-      provide: { references: { video } },
+      provide: {
+        store: {
+          state: { references: { video } },
+        },
+      },
     });
 
     const videoAsset = wrapper.find(ReplayableVideoAsset);

--- a/tests/unit/components/CallToActionButton.spec.js
+++ b/tests/unit/components/CallToActionButton.spec.js
@@ -26,10 +26,14 @@ describe('CallToActionButton', () => {
   let wrapper;
 
   const provide = {
-    references: {
-      [propsData.action.identifier]: {
-        title: 'Foo Bar',
-        url: '/foo/bar',
+    store: {
+      state: {
+        references: {
+          [propsData.action.identifier]: {
+            title: 'Foo Bar',
+            url: '/foo/bar',
+          },
+        },
       },
     },
   };
@@ -45,7 +49,8 @@ describe('CallToActionButton', () => {
   it('renders a `ButtonLink`', () => {
     const btn = wrapper.find(ButtonLink);
     expect(btn.exists()).toBe(true);
-    expect(btn.props('url')).toBe(provide.references[propsData.action.identifier].url);
+    expect(btn.props('url'))
+      .toBe(provide.store.state.references[propsData.action.identifier].url);
     expect(btn.props('isDark')).toBe(propsData.isDark);
     expect(btn.text()).toBe(propsData.action.overridingTitle);
   });

--- a/tests/unit/components/Card.spec.js
+++ b/tests/unit/components/Card.spec.js
@@ -39,7 +39,11 @@ describe('Card', () => {
     hasButton: false,
   };
 
-  const provide = { references };
+  const provide = {
+    store: {
+      state: { references },
+    },
+  };
 
   const mountCard = options => shallowMount(Card, {
     propsData,

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -34,14 +34,27 @@ import DeviceFrame from '@/components/ContentNode/DeviceFrame.vue';
 
 const { TableHeaderStyle, TableColumnAlignments } = ContentNode.constants;
 
-const mountWithContent = (content = [], provide = { references: {} }) => (
-  shallowMount(ContentNode, {
-    propsData: { content },
-    provide,
-  })
-);
+const mountWithContent = (
+  content = [],
+  provide = {
+    store: {
+      state: {
+        references: {},
+      },
+    },
+  },
+) => shallowMount(ContentNode, {
+  propsData: { content },
+  provide,
+});
 
-const mountWithItem = (item, references) => mountWithContent([item], { references });
+const mountWithItem = (item, references) => mountWithContent([item], {
+  store: {
+    state: {
+      references,
+    },
+  },
+});
 
 describe('ContentNode', () => {
   it('renders a div.content wrapper', () => {
@@ -70,7 +83,6 @@ describe('ContentNode', () => {
           },
         ],
       });
-
       const aside = wrapper.find('.content').find(Aside);
       expect(aside.exists()).toBe(true);
       expect(aside.props('kind')).toBe('note');

--- a/tests/unit/components/ContentNode/LinksBlock.spec.js
+++ b/tests/unit/components/ContentNode/LinksBlock.spec.js
@@ -30,7 +30,11 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(LinksBlock
     ...propsData,
   },
   stubs: { TopicsLinkBlock: { props: ['topic'], template: '<div/>' } },
-  provide: { references },
+  provide: {
+    store: {
+      state: { references },
+    },
+  },
   ...others,
 });
 

--- a/tests/unit/components/DestinationDataProvider.spec.js
+++ b/tests/unit/components/DestinationDataProvider.spec.js
@@ -60,7 +60,9 @@ const createWrapper = (overrides) => {
       destination: Destinations.link,
     },
     provide: {
-      references,
+      store: {
+        state: { references },
+      },
     },
     scopedSlots: {
       default(params) {
@@ -146,7 +148,9 @@ describe('DestinationDataProvider', () => {
           destination: Destinations.referenceLink,
         },
         provide: {
-          references,
+          store: {
+            state: { references },
+          },
           isTargetIDE: true,
         },
       });

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -166,8 +166,8 @@ describe('DocumentationTopic', () => {
       propsData,
       provide: {
         store: {
-          state: { onThisPageSections: [] },
-          reset() {},
+          state: { onThisPageSections: [], references: {} },
+          reset: jest.fn(),
         },
       },
     });
@@ -193,11 +193,6 @@ describe('DocumentationTopic', () => {
   it('provides the interface languages', () => {
     // eslint-disable-next-line no-underscore-dangle
     expect(wrapper.vm._provided.interfaceLanguage).toEqual(propsData.interfaceLanguage);
-  });
-
-  it('provides `references', () => {
-    // eslint-disable-next-line no-underscore-dangle
-    expect(wrapper.vm._provided.references).toEqual(propsData.references);
   });
 
   it('provides the languages', () => {
@@ -627,7 +622,15 @@ describe('DocumentationTopic', () => {
   });
 
   it('renders a `LanguageSwitcher` if TargetIDE', () => {
-    const provide = { isTargetIDE: true };
+    const provide = {
+      isTargetIDE: true,
+      store: {
+        state: {
+          references: {},
+        },
+        reset: jest.fn(),
+      },
+    };
     wrapper = shallowMount(DocumentationTopic, { propsData, provide });
     const switcher = wrapper.find(LanguageSwitcher);
     expect(switcher.exists()).toBe(true);
@@ -760,6 +763,12 @@ describe('DocumentationTopic', () => {
         Relationships: stubSection('relationships'),
         SeeAlso: stubSection('see-also'),
       },
+      provide: {
+        store: {
+          state: { onThisPageSections: [], references: {} },
+          reset: jest.fn(),
+        },
+      },
     });
     const sections = wrapper.findAll('.section-stub');
     expect(sections.at(0).classes('relationships')).toBe(true);
@@ -839,6 +848,12 @@ describe('DocumentationTopic', () => {
       slots: {
         'above-title': '<div class="above-title">Above Title Content</div>',
       },
+      provide: {
+        store: {
+          state: { onThisPageSections: [], references: {} },
+          reset: jest.fn(),
+        },
+      },
     });
     expect(wrapper.find(DocumentationHero).contains('.above-title')).toBe(true);
   });
@@ -851,6 +866,12 @@ describe('DocumentationTopic', () => {
       },
       stubs: {
         DocumentationHero,
+      },
+      provide: {
+        store: {
+          state: { onThisPageSections: [], references: {} },
+          reset: jest.fn(),
+        },
       },
     });
     expect(wrapper.contains('.above-hero-content')).toBe(true);
@@ -903,7 +924,7 @@ describe('DocumentationTopic', () => {
     it('calls `store.reset()`', () => {
       const store = {
         reset: jest.fn(),
-        state: { onThisPageSections: [], apiChanges: null },
+        state: { onThisPageSections: [], apiChanges: null, references: {} },
       };
       wrapper = shallowMount(DocumentationTopic, {
         propsData,
@@ -921,6 +942,7 @@ describe('DocumentationTopic', () => {
           apiChanges: null,
           onThisPageSections: [],
           preferredLanguage: Language.objectiveC.key.url,
+          references: {},
         },
       };
       wrapper = shallowMount(DocumentationTopic, {

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/TypeIdentifierLink.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/TypeIdentifierLink.spec.js
@@ -36,6 +36,13 @@ describe('TypeIdentifierLink', () => {
         query: {},
       },
     },
+    provide: {
+      store: {
+        state: {
+          references: {},
+        },
+      },
+    },
   };
 
   it('renders a span for unresolved references', () => {
@@ -48,8 +55,12 @@ describe('TypeIdentifierLink', () => {
     const wrapper = shallowMount(TypeIdentifierLink, {
       ...defaultOpts,
       provide: {
-        references: {
-          [foo.identifier]: foo,
+        store: {
+          state: {
+            references: {
+              [foo.identifier]: foo,
+            },
+          },
         },
       },
     });

--- a/tests/unit/components/DocumentationTopic/Relationships.spec.js
+++ b/tests/unit/components/DocumentationTopic/Relationships.spec.js
@@ -58,10 +58,14 @@ describe('Relationships', () => {
   };
 
   const provide = {
-    references: {
-      [foo.identifier]: foo,
-      [bar.identifier]: bar,
-      [baz.identifier]: baz,
+    store: {
+      state: {
+        references: {
+          [foo.identifier]: foo,
+          [bar.identifier]: bar,
+          [baz.identifier]: baz,
+        },
+      },
     },
   };
 

--- a/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
@@ -33,15 +33,6 @@ describe('TopicsLinkBlock', () => {
   /** @type {import('@vue/test-utils').Wrapper} */
   let wrapper;
 
-  const store = {
-    reset: jest.fn(),
-    setAPIChanges: jest.fn(),
-    state: {
-      onThisPageSections: [],
-      apiChanges: null,
-    },
-  };
-
   const iconOverride = {
     type: 'icon',
     identifier: 'icon-override',
@@ -51,9 +42,18 @@ describe('TopicsLinkBlock', () => {
     [iconOverride.identifier]: { foo: 'bar' },
   };
 
+  const store = {
+    reset: jest.fn(),
+    setAPIChanges: jest.fn(),
+    state: {
+      onThisPageSections: [],
+      apiChanges: null,
+      references,
+    },
+  };
+
   const provide = {
     store,
-    references,
   };
 
   const propsData = {

--- a/tests/unit/components/DocumentationTopic/TopicsLinkCardGridItem.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkCardGridItem.spec.js
@@ -58,7 +58,11 @@ const createWrapper = ({ propsData, ...others } = {}) => mount(TopicsLinkCardGri
     ...defaultProps,
     ...propsData,
   },
-  provide: { references },
+  provide: {
+    store: {
+      state: { references },
+    },
+  },
   ...others,
 });
 

--- a/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
@@ -56,9 +56,13 @@ describe('TopicsTable', () => {
   };
 
   const provide = {
-    references: {
-      foo,
-      baz,
+    store: {
+      state: {
+        references: {
+          foo,
+          baz,
+        },
+      },
     },
   };
 

--- a/tests/unit/components/ReferenceUrlProvider.spec.js
+++ b/tests/unit/components/ReferenceUrlProvider.spec.js
@@ -35,7 +35,11 @@ describe('ReferenceUrlProvider', () => {
 
     shallowMount(ReferenceUrlProvider, {
       propsData,
-      provide: { references },
+      provide: {
+        store: {
+          state: { references },
+        },
+      },
       scopedSlots: {
         default: (props) => {
           assertProps = props;

--- a/tests/unit/components/Tutorial.spec.js
+++ b/tests/unit/components/Tutorial.spec.js
@@ -185,11 +185,6 @@ describe('Tutorial', () => {
     });
   });
 
-  it('provides `references`', () => {
-    // eslint-disable-next-line no-underscore-dangle
-    expect(wrapper.vm._provided.references).toEqual(propsData.references);
-  });
-
   it('renders a div.tutorial', () => {
     expect(wrapper.is('div.tutorial')).toBe(true);
   });

--- a/tests/unit/components/Tutorial/CodePreview.spec.js
+++ b/tests/unit/components/Tutorial/CodePreview.spec.js
@@ -27,53 +27,46 @@ describe('CodePreview', () => {
     preview: 'mypreview',
     isRuntimePreviewVisible: true,
   };
-  const provide = {
-    isTargetIDE: false,
-    references: {
-      [propsData.code]: {
-        content,
-        fileName,
-        highlights,
-        syntax,
-      },
-      [propsData.preview]: {
-        variants: [
-          {
-            size: {
-              width: 600,
-              height: 1200,
-            },
-          },
-        ],
-      },
+
+  const references = {
+    [propsData.code]: {
+      content,
+      fileName,
+      highlights,
+      syntax,
     },
-    store: TopicStore,
+    [propsData.preview]: {
+      variants: [
+        {
+          size: {
+            width: 600,
+            height: 1200,
+          },
+        },
+      ],
+    },
   };
+
+  const referencesWithVariant = variants => ({
+    ...references,
+    [propsData.preview]: {
+      variants,
+    },
+  });
+
+  const provide = topicStore => ({
+    isTargetIDE: false,
+    store: topicStore,
+  });
   const slots = {
     default: '<p>foo</p>',
   };
 
-  const mountWithVariant = variants => (
-    shallowMount(CodePreview, {
-      propsData,
-      provide: {
-        ...provide,
-        references: {
-          ...provide.references,
-          [propsData.preview]: {
-            variants,
-          },
-        },
-      },
-      slots,
-    })
-  );
-
   beforeEach(() => {
-    TopicStore.reset();
+    TopicStore.setReferences(references);
     wrapper = shallowMount(CodePreview, {
       propsData,
-      provide,
+      provide: provide(TopicStore),
       slots,
     });
   });
@@ -148,7 +141,13 @@ describe('CodePreview', () => {
       },
     ];
 
-    wrapper = mountWithVariant(variantSizeEmpty);
+    TopicStore.updateBreakpoint('large');
+    TopicStore.setReferences(referencesWithVariant(variantSizeEmpty));
+    wrapper = shallowMount(CodePreview, {
+      propsData,
+      provide: provide(TopicStore),
+      slots,
+    });
 
     let runtimePreview = wrapper.find('.runtime-preview');
     expect(runtimePreview.attributes('style')).toBe('width: 300px;');
@@ -163,7 +162,12 @@ describe('CodePreview', () => {
       },
     ];
 
-    wrapper = mountWithVariant(variantNoSize);
+    TopicStore.setReferences(referencesWithVariant(variantNoSize));
+    wrapper = shallowMount(CodePreview, {
+      propsData,
+      provide: provide(TopicStore),
+      slots,
+    });
 
     runtimePreview = wrapper.find('.runtime-preview');
     expect(runtimePreview.attributes('style')).toBe('width: 300px;');
@@ -178,7 +182,12 @@ describe('CodePreview', () => {
       },
     ];
 
-    wrapper = mountWithVariant(variantWithOnlyWidth);
+    TopicStore.setReferences(referencesWithVariant(variantWithOnlyWidth));
+    wrapper = shallowMount(CodePreview, {
+      propsData,
+      provide: provide(TopicStore),
+      slots,
+    });
 
     const runtimePreview = wrapper.find('.runtime-preview');
     expect(runtimePreview.attributes('style')).toBe('width: 400px;');
@@ -193,7 +202,12 @@ describe('CodePreview', () => {
       },
     ];
 
-    wrapper = mountWithVariant(variantWithOnlyHeight);
+    TopicStore.setReferences(referencesWithVariant(variantWithOnlyHeight));
+    wrapper = shallowMount(CodePreview, {
+      propsData,
+      provide: provide(TopicStore),
+      slots,
+    });
 
     const runtimePreview = wrapper.find('.runtime-preview');
     // no height is defined at all
@@ -208,7 +222,7 @@ describe('CodePreview', () => {
           isRuntimePreviewVisible,
           preview: hasRuntimePreview ? propsData.preview : undefined,
         },
-        provide,
+        provide: provide(TopicStore),
         slots,
       })
     );
@@ -258,7 +272,12 @@ describe('CodePreview', () => {
         },
       ];
 
-      wrapper = mountWithVariant(variantSmallImage);
+      TopicStore.setReferences(referencesWithVariant(variantSmallImage));
+      wrapper = shallowMount(CodePreview, {
+        propsData,
+        provide: provide(TopicStore),
+        slots,
+      });
     });
 
     describe('in breakpoint other than "medium"', () => {
@@ -284,10 +303,11 @@ describe('CodePreview', () => {
 
   describe('with `isTargetIDE`', () => {
     beforeEach(() => {
+      TopicStore.setReferences(references);
       wrapper = shallowMount(CodePreview, {
         propsData,
         provide: {
-          ...provide,
+          ...provide(TopicStore),
           isTargetIDE: true,
         },
         slots,

--- a/tests/unit/components/Tutorial/Hero.spec.js
+++ b/tests/unit/components/Tutorial/Hero.spec.js
@@ -49,9 +49,13 @@ const mountWithProps = (props, references = {}, others) => {
       ...props,
     },
     provide: {
-      references: {
-        ...defaultReferences,
-        ...references,
+      store: {
+        state: {
+          references: {
+            ...defaultReferences,
+            ...references,
+          },
+        },
       },
     },
     ...others,

--- a/tests/unit/components/Tutorial/MobileCodePreview.spec.js
+++ b/tests/unit/components/Tutorial/MobileCodePreview.spec.js
@@ -13,7 +13,9 @@ import MobileCodePreview from 'docc-render/components/Tutorial/MobileCodePreview
 import CodeListing from 'docc-render/components/ContentNode/CodeListing.vue';
 import MobileCodeListing from 'docc-render/components/ContentNode/MobileCodeListing.vue';
 import GenericModal from 'docc-render/components/GenericModal.vue';
-import TopicStore from 'docc-render/stores/TopicStore';
+import BreakpointEmitter from 'docc-render/components/BreakpointEmitter.vue';
+
+const { BreakpointName } = BreakpointEmitter.constants;
 
 describe('MobileCodePreview', () => {
   const { PreviewToggle } = MobileCodePreview.components;
@@ -38,7 +40,13 @@ describe('MobileCodePreview', () => {
     default: '<img src="media.jpg" />',
   };
 
-  const store = TopicStore;
+  const store = {
+    state: {
+      linkableSections: [],
+      breakpoint: BreakpointName.large,
+      references,
+    },
+  };
 
   beforeEach(() => {
     wrapper = shallowMount(MobileCodePreview, {
@@ -46,7 +54,6 @@ describe('MobileCodePreview', () => {
         code: 'mycode',
       },
       provide: {
-        references,
         isTargetIDE: false,
         store,
       },
@@ -93,7 +100,6 @@ describe('MobileCodePreview', () => {
           code: 'mycode',
         },
         provide: {
-          references,
           isTargetIDE: false,
           store,
         },
@@ -137,7 +143,7 @@ describe('MobileCodePreview', () => {
     const mountWithIDETarget = isTargetIDE => (
       shallowMount(MobileCodePreview, {
         propsData: { code: 'mycode' },
-        provide: { references, isTargetIDE, store },
+        provide: { isTargetIDE, store },
         slots: defaultSlots,
       })
     );

--- a/tests/unit/components/Tutorial/NavigationBar.spec.js
+++ b/tests/unit/components/Tutorial/NavigationBar.spec.js
@@ -92,7 +92,7 @@ describe('NavigationBar', () => {
     },
   };
 
-  const mountOptions = {
+  const mountOptions = topicStore => ({
     propsData: {
       technology,
       chapters,
@@ -102,8 +102,7 @@ describe('NavigationBar', () => {
       identifierUrl: 'topic://com.example.ARKit.Building-Interactive-AR-Experiences.Basic-Augmented-Reality-App',
     },
     provide: {
-      store: TopicStore,
-      references,
+      store: topicStore,
     },
     mocks,
     stubs: {
@@ -111,14 +110,19 @@ describe('NavigationBar', () => {
       ReferenceUrlProvider,
       NavBase,
     },
-  };
+  });
 
   beforeEach(() => {
+    TopicStore.setReferences(references);
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    wrapper.destroy();
+  });
+
   it('renders the NavBase', () => {
-    wrapper = shallowMount(NavigationBar, mountOptions);
+    wrapper = shallowMount(NavigationBar, mountOptions(TopicStore));
 
     const container = wrapper.find(NavBase);
     expect(container.attributes()).toHaveProperty('aria-label', technology);
@@ -129,7 +133,7 @@ describe('NavigationBar', () => {
   it('renders a tray scoped slot', () => {
     let slotProps = {};
     wrapper = shallowMount(NavigationBar, {
-      ...mountOptions,
+      ...mountOptions(TopicStore),
       scopedSlots: {
         tray(props) {
           slotProps = props;
@@ -146,6 +150,8 @@ describe('NavigationBar', () => {
   describe('with a current section', () => {
     beforeEach(() => {
       TopicStore.reset();
+      TopicStore.updateBreakpoint('large');
+      TopicStore.setReferences(references);
       TopicStore.addLinkableSection({
         anchor: 'introduction',
         title: 'Introduction',
@@ -167,7 +173,7 @@ describe('NavigationBar', () => {
         depth: 0,
       });
 
-      wrapper = shallowMount(NavigationBar, mountOptions);
+      wrapper = shallowMount(NavigationBar, mountOptions(TopicStore));
     });
 
     it('renders a .nav-title-content with technology title', () => {
@@ -183,8 +189,9 @@ describe('NavigationBar', () => {
     });
 
     it('appends already existing query params to the url', () => {
+      wrapper.destroy();
       wrapper = shallowMount(NavigationBar, {
-        ...mountOptions,
+        ...mountOptions(TopicStore),
         mocks: {
           ...mocks,
           $route: {
@@ -313,9 +320,11 @@ describe('NavigationBar', () => {
     });
 
     it('renders a tray scoped slot', () => {
+      wrapper.destroy();
+
       let slotProps = {};
       wrapper = shallowMount(NavigationBar, {
-        ...mountOptions,
+        ...mountOptions(TopicStore),
         scopedSlots: {
           tray(props) {
             slotProps = props;

--- a/tests/unit/components/Tutorial/NavigationBar/MobileDropdown.spec.js
+++ b/tests/unit/components/Tutorial/NavigationBar/MobileDropdown.spec.js
@@ -95,7 +95,9 @@ describe('MobileDropdown', () => {
       },
       stubs: { 'router-link': RouterLinkStub, ReferenceUrlProvider },
       provide: {
-        references,
+        store: {
+          state: { references },
+        },
       },
     });
   });

--- a/tests/unit/components/Tutorial/NavigationBar/PrimaryDropdown.spec.js
+++ b/tests/unit/components/Tutorial/NavigationBar/PrimaryDropdown.spec.js
@@ -128,7 +128,9 @@ describe('Primary Dropdown', () => {
         ReferenceUrlProvider,
       },
       provide: {
-        references,
+        store: {
+          state: { references },
+        },
       },
     });
 

--- a/tests/unit/components/TutorialsOverview/ResourcesTile.spec.js
+++ b/tests/unit/components/TutorialsOverview/ResourcesTile.spec.js
@@ -59,7 +59,11 @@ describe('ResourcesTile', () => {
     wrapper = shallowMount(ResourcesTile, {
       propsData,
       stubs,
-      provide: { references },
+      provide: {
+        store: {
+          state: { references },
+        },
+      },
     });
   });
 

--- a/tests/unit/components/TutorialsOverview/Volume.spec.js
+++ b/tests/unit/components/TutorialsOverview/Volume.spec.js
@@ -41,12 +41,14 @@ describe('Volume', () => {
   };
 
   const provide = {
-    references: {
-      [topics.a.identifier]: topics.a,
-      [topics.b.identifier]: topics.b,
-      [topics.c.identifier]: topics.c,
-    },
     store: {
+      state: {
+        references: {
+          [topics.a.identifier]: topics.a,
+          [topics.b.identifier]: topics.b,
+          [topics.c.identifier]: topics.c,
+        },
+      },
       setActiveVolume: jest.fn(),
     },
   };

--- a/tests/unit/stores/DocumentationTopicStore.spec.js
+++ b/tests/unit/stores/DocumentationTopicStore.spec.js
@@ -12,12 +12,18 @@ import DocumentationTopicStore from 'docc-render/stores/DocumentationTopicStore'
 import ApiChangesStoreBase from 'docc-render/stores/ApiChangesStoreBase';
 import OnThisPageSectionsStoreBase from 'docc-render/stores/OnThisPageSectionsStoreBase';
 
+const references = {
+  foo: { identifier: 'foo' },
+  bar: { identifier: 'bar' },
+};
+
 describe('DocumentationTopicStore', () => {
   const defaultState = {
     preferredLanguage: null,
     contentWidth: 0,
     ...ApiChangesStoreBase.state,
     ...OnThisPageSectionsStoreBase.state,
+    references: {},
   };
 
   beforeEach(() => {
@@ -35,6 +41,7 @@ describe('DocumentationTopicStore', () => {
   describe('reset', () => {
     it('restores the default state', () => {
       DocumentationTopicStore.state.apiChanges = {};
+      DocumentationTopicStore.state.references = references;
       expect(DocumentationTopicStore.state).not.toEqual(defaultState);
       DocumentationTopicStore.reset();
       // assert all the state is reset
@@ -90,6 +97,11 @@ describe('DocumentationTopicStore', () => {
   it('sets the content width', () => {
     DocumentationTopicStore.setContentWidth(99);
     expect(DocumentationTopicStore.state.contentWidth).toBe(99);
+  });
+
+  it('sets `references`', () => {
+    DocumentationTopicStore.setReferences(references);
+    expect(DocumentationTopicStore.state.references).toBe(references);
   });
 
   describe('APIChanges', () => {

--- a/tests/unit/stores/TopicStore.spec.js
+++ b/tests/unit/stores/TopicStore.spec.js
@@ -13,6 +13,11 @@ import BreakpointEmitter from 'docc-render/components/BreakpointEmitter.vue';
 
 const { BreakpointName } = BreakpointEmitter.constants;
 
+const references = {
+  foo: { identifier: 'foo' },
+  bar: { identifier: 'bar' },
+};
+
 describe('TopicStore', () => {
   beforeEach(() => {
     TopicStore.reset();
@@ -22,6 +27,7 @@ describe('TopicStore', () => {
     expect(TopicStore.state).toEqual({
       linkableSections: [],
       breakpoint: BreakpointName.large,
+      references: {},
     });
   });
 
@@ -32,12 +38,13 @@ describe('TopicStore', () => {
     });
 
     TopicStore.updateBreakpoint('my breakpoint');
-
+    TopicStore.setReferences(references);
     TopicStore.reset();
 
     expect(TopicStore.state).toEqual({
       linkableSections: [],
       breakpoint: BreakpointName.large,
+      references: {},
     });
   });
 
@@ -110,6 +117,13 @@ describe('TopicStore', () => {
           },
         ]);
       });
+    });
+  });
+
+  describe('setReferences', () => {
+    it('sets the `references` state', () => {
+      TopicStore.setReferences(references);
+      expect(TopicStore.state.references).toBe(references);
     });
   });
 });

--- a/tests/unit/stores/TutorialsOverviewStore.spec.js
+++ b/tests/unit/stores/TutorialsOverviewStore.spec.js
@@ -10,11 +10,17 @@
 
 import TutorialsOverviewStore from 'docc-render/stores/TutorialsOverviewStore';
 
+const references = {
+  foo: { identifier: 'foo' },
+  bar: { identifier: 'bar' },
+};
+
 describe('TutorialsOverviewStore', () => {
   it('has a default state', () => {
     expect(TutorialsOverviewStore.state).toEqual({
       activeTutorialLink: null,
       activeVolume: null,
+      references: {},
     });
   });
 
@@ -22,10 +28,12 @@ describe('TutorialsOverviewStore', () => {
     it('restores the default state', () => {
       TutorialsOverviewStore.state.activeTutorialLink = 'foobar';
       TutorialsOverviewStore.state.activeVolume = 'foobar';
+      TutorialsOverviewStore.state.references = references;
       TutorialsOverviewStore.reset();
       expect(TutorialsOverviewStore.state).toEqual({
         activeTutorialLink: null,
         activeVolume: null,
+        references: {},
       });
     });
   });
@@ -41,6 +49,13 @@ describe('TutorialsOverviewStore', () => {
     it('sets the `activeVolume` state', () => {
       TutorialsOverviewStore.setActiveVolume('foobar');
       expect(TutorialsOverviewStore.state.activeVolume).toBe('foobar');
+    });
+  });
+
+  describe('setReferences', () => {
+    it('sets the `references` state', () => {
+      TutorialsOverviewStore.setReferences(references);
+      expect(TutorialsOverviewStore.state.references).toBe(references);
     });
   });
 });


### PR DESCRIPTION
- Explanation: Refactor: Move References to Stores
- Scope: All pages/components using references
- Issue: rdar://107635892
- Risk: Medium
- Testing:
1. All unit tests should still pass.
2. Make sure this change doesn’t introduce regressions for all pages
- Reviewer: @mportiz08 @dobromir-hristov @marinaaisa 
- Original PR: https://github.com/apple/swift-docc-render/pull/594