### PR TITLE
[5.9] Remove breakpoint in Minimized mode & update padding

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -676,13 +676,15 @@ export default {
   @include font-styles(body);
 }
 
-.container {
+.container:not(.minimized-container) {
   outline-style: none;
   @include dynamic-content-container;
 }
 
 /deep/ {
   .minimized-container {
+    outline-style: none;
+
     --spacing-stacked-margin-large: 0.667em;
     --spacing-stacked-margin-xlarge: 1em;
     --declaration-code-listing-margin: 1em 0 0 0;
@@ -755,15 +757,8 @@ export default {
 }
 
 .full-width-container .doc-content .minimized-container {
-  padding-left: 20px;
-  padding-right: 20px;
-
-  @include inTargetIde {
-    @include breakpoint(xsmall) {
-      padding-left: 15px;
-      padding-right: 15px;
-    }
-  }
+  padding-left: 1.4rem;
+  padding-right: 1.4rem;
 }
 
 /deep/ {

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -195,7 +195,7 @@ $doc-hero-icon-dimension: 250px;
     }
   }
 
-  &__content {
+  &__content:not(.minimized-hero) {
     padding-top: rem(40px);
     padding-bottom: 40px;
     position: relative;
@@ -204,14 +204,9 @@ $doc-hero-icon-dimension: 250px;
   }
 
   .minimized-hero {
-    padding: 1.5em 20px;
-
-    @include inTargetIde {
-      @include breakpoint(xsmall) {
-        padding-left: 15px;
-        padding-right: 15px;
-      }
-    }
+    padding: 1.3em 1.4em;
+    position: relative;
+    z-index: 1;
   }
 
   &__above-content {

--- a/src/styles/base/_reset.scss
+++ b/src/styles/base/_reset.scss
@@ -184,10 +184,6 @@ button {
 body {
   $min-width: map-deep-get($breakpoint-attributes, ('default', small, 'min-width'), false);
 
-  @include inTargetIde() {
-    $min-width: map-deep-get($breakpoint-attributes, ('default', xsmall, 'min-width'), false);
-  }
-
   height: 100%;
 
   @if $min-width {

--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -30,11 +30,6 @@ $breakpoint-attributes: (
       max-width: 735px,
       content-width: 280px,
     ),
-    xsmall: (
-      min-width: 245px,
-      max-width: 320px,
-      content-width: 215px,
-    ),
   ),
   nav: (
     large: (
@@ -182,7 +177,7 @@ $breakpoint-attributes: (
 
         // Use a fixed percentage width value for the small breakpoint.
         // The percentage is the ratio of the content-width/min-width sizes.
-        @if ($breakpoint == small or $breakpoint == xsmall) and $min-width {
+        @if ($breakpoint == small) and $min-width {
           $width: percentage($content-width / $min-width);
         }
 


### PR DESCRIPTION
- Explanation: Remove breakpoint in Minimized mode & updated padding
- Scope: Minimized mode in Quick Nav
- Issue: rdar://108391432
- Risk: Low
- Testing: Ensure there's no regression in Quick Nav and the padding is updated.
- Reviewer: @mportiz08
- Original PR: https://github.com/apple/swift-docc-render/pull/610