### PR TITLE
Fix quick nav preview references

### DIFF
--- a/src/components/Navigator/QuickNavigationPreview.vue
+++ b/src/components/Navigator/QuickNavigationPreview.vue
@@ -36,6 +36,8 @@
 
 <script>
 import DocumentationTopic from 'docc-render/components/DocumentationTopic.vue';
+import { clone } from 'docc-render/utils/data';
+import DocumentationTopicStore from 'docc-render/stores/DocumentationTopicStore';
 
 const { extractProps } = DocumentationTopic.methods;
 
@@ -47,10 +49,25 @@ const STATE = {
   success: 'success',
 };
 
+const PreviewStore = {
+  ...DocumentationTopicStore,
+  state: clone(DocumentationTopicStore.state),
+};
+
 export default {
   name: 'QuickNavigationPreview',
   components: { DocumentationTopic },
   constants: { PreviewState: STATE },
+  data() {
+    return {
+      store: PreviewStore,
+    };
+  },
+  provide() {
+    return {
+      store: this.store,
+    };
+  },
   props: {
     json: {
       type: Object,
@@ -89,6 +106,13 @@ export default {
         ...props,
         abstract,
       };
+    },
+  },
+  watch: {
+    async json(json) {
+      const { references = {} } = json || {};
+      await this.$nextTick();
+      PreviewStore.setReferences(references);
     },
   },
 };

--- a/src/components/Navigator/QuickNavigationPreview.vue
+++ b/src/components/Navigator/QuickNavigationPreview.vue
@@ -57,7 +57,7 @@ const PreviewStore = {
 export default {
   name: 'QuickNavigationPreview',
   components: { DocumentationTopic },
-  constants: { PreviewState: STATE },
+  constants: { PreviewState: STATE, PreviewStore },
   data() {
     return {
       store: PreviewStore,
@@ -109,10 +109,13 @@ export default {
     },
   },
   watch: {
-    async json(json) {
-      const { references = {} } = json || {};
-      await this.$nextTick();
-      PreviewStore.setReferences(references);
+    json: {
+      immediate: true,
+      async handler(json) {
+        const { references = {} } = json || {};
+        await this.$nextTick();
+        PreviewStore.setReferences(references);
+      },
     },
   },
 };


### PR DESCRIPTION
Bug/issue #, if applicable: 108479392

## Summary

Fixes the QuickNav preview references by providing its own clone of the DocTopic store.

## Dependencies

NA

## Testing

Assert the QuickNav Preview works as expected, and links + images are properly rendered.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
