### PR TITLE
Use technology icon for collections in Topics section

### DIFF
--- a/src/components/DocumentationTopic/TopicLinkBlockIcon.vue
+++ b/src/components/DocumentationTopic/TopicLinkBlockIcon.vue
@@ -21,6 +21,7 @@ import CurlyBracketsIcon from 'theme/components/Icons/CurlyBracketsIcon.vue';
 import ApiCollectionIcon from 'theme/components/Icons/APIReferenceIcon.vue';
 import EndpointIcon from 'theme/components/Icons/EndpointIcon.vue';
 import PathIcon from 'theme/components/Icons/PathIcon.vue';
+import TechnologyIcon from 'theme/components/Icons/TechnologyIcon.vue';
 import TutorialIcon from 'theme/components/Icons/TutorialIcon.vue';
 import SVGIcon from 'docc-render/components/SVGIcon.vue';
 import { TopicRole } from 'docc-render/constants/roles';
@@ -28,6 +29,7 @@ import OverridableAsset from 'docc-render/components/OverridableAsset.vue';
 
 const TopicRoleIcons = {
   [TopicRole.article]: ArticleIcon,
+  [TopicRole.collection]: TechnologyIcon,
   [TopicRole.collectionGroup]: ApiCollectionIcon,
   [TopicRole.learn]: PathIcon,
   [TopicRole.overview]: PathIcon,

--- a/tests/unit/components/DocumentationTopic/TopicLinkBlockIcon.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicLinkBlockIcon.spec.js
@@ -12,6 +12,7 @@ import TopicLinkBlockIcon from '@/components/DocumentationTopic/TopicLinkBlockIc
 import { mount } from '@vue/test-utils';
 import { TopicRole } from '@/constants/roles';
 import ArticleIcon from '@/components/Icons/ArticleIcon.vue';
+import TechnologyIcon from '@/components/Icons/TechnologyIcon.vue';
 import OverridableAsset from '@/components/OverridableAsset.vue';
 
 const defaultProps = {
@@ -60,5 +61,11 @@ describe('TopicLinkBlockIcon', () => {
       },
     });
     expect(wrapper.html()).toBeFalsy();
+  });
+
+  it('uses the technology icon for collections', () => {
+    const propsData = { role: TopicRole.collection };
+    const wrapper = createWrapper({ propsData });
+    expect(wrapper.find('.topic-icon').is(TechnologyIcon)).toBe(true);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 107729097

## Summary

Renders the technology icon for curated collection topics.

## Testing

Steps:
1. Curate a top level collection page into a Topics section.
2. Verify that the curated links now have the top-level technology icon, similar to the documentation intro icon.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
