### PR TITLE
Minimized mode bottom margin should match side padding

### DIFF
--- a/src/components/DocumentationTopic/ViewMore.vue
+++ b/src/components/DocumentationTopic/ViewMore.vue
@@ -38,7 +38,7 @@ export default {
   @include font-styles(body-reduced-tight);
   display: flex;
   flex-flow: row-reverse;
-  margin-bottom: 1.4rem;
+  margin-bottom: 1.3rem;
 }
 
 </style>

--- a/src/components/DocumentationTopic/ViewMore.vue
+++ b/src/components/DocumentationTopic/ViewMore.vue
@@ -38,7 +38,7 @@ export default {
   @include font-styles(body-reduced-tight);
   display: flex;
   flex-flow: row-reverse;
-  margin-bottom: 20px;
+  margin-bottom: 1.4rem;
 }
 
 </style>


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://108577661

## Summary
Minimized mode bottom margin should scale as font size increase & match the side padding.
