### PR TITLE
Improve swift attribute formatting

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -127,6 +127,18 @@ export default {
           }
         }
 
+        // check if this is a text token following an attribute token
+        // so we can insert a newline here and split each attribute onto its
+        // own line
+        //
+        // we want to avoid doing this when the attribute is encountered
+        // in a param clause for attributes like `@escaping`
+        if (token.kind === TokenKind.text && i > 0
+          && tokens[i - 1].kind === TokenKind.attribute
+          && numUnclosedParens === 0) {
+          newToken.text = `${token.text.trimEnd()}\n`;
+        }
+
         // if we find some text ending with ", " and the next token is the start
         // of a new param, update this token text to replace the space with a
         // newline followed by 4 spaces

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -741,4 +741,52 @@ describe('Swift function/initializer formatting', () => {
     expect(tokenComponents.at(1).props('text')).toBe('\n');
     expect(tokenComponents.at(3).props('text')).toBe('(baz)\n');
   });
+
+  it('does not add newlines to attributes within param clause', () => {
+    // func foo(bar: @escaping () -> ())
+    const tokens = [
+      {
+        kind: 'keyword',
+        text: 'func',
+      },
+      {
+        kind: 'text',
+        text: ' ',
+      },
+      {
+        kind: 'identifier',
+        text: 'foo',
+      },
+      {
+        kind: 'text',
+        text: '(',
+      },
+      {
+        kind: 'externalParam',
+        text: 'bar',
+      },
+      {
+        kind: 'text',
+        text: ': ',
+      },
+      {
+        kind: 'attribute',
+        text: '@escaping',
+      },
+      {
+        kind: 'text',
+        text: ' () -> ()',
+      },
+      {
+        kind: 'text',
+        text: ')',
+      },
+    ];
+    const wrapper = mountWithTokens(tokens);
+
+    const tokenComponents = wrapper.findAll(Token);
+    expect(tokenComponents.length).toBe(tokens.length);
+    expect(tokenComponents.at(6).props('text')).toBe(tokens[6].text);
+    expect(tokenComponents.at(7).props('text')).toBe(tokens[7].text);
+  });
 });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -686,4 +686,59 @@ describe('Swift function/initializer formatting', () => {
 
     themeSettingsState.theme = originalTheme;
   });
+
+  it('breaks attributes onto their own lines', () => {
+    // Before:
+    // @discardableResult @objc(baz) func foobarbaz() -> Int
+    //
+    // After:
+    // @discardableResult
+    // @objc(baz)
+    // func foobarbaz() -> Int
+    const tokens = [
+      {
+        kind: 'attribute',
+        text: '@discardableResult',
+      },
+      {
+        kind: 'text',
+        text: ' ',
+      },
+      {
+        kind: 'attribute',
+        text: '@objc',
+      },
+      {
+        kind: 'text',
+        text: '(baz) ',
+      },
+      {
+        kind: 'keyword',
+        text: 'func',
+      },
+      {
+        kind: 'text',
+        text: ' ',
+      },
+      {
+        kind: 'identifier',
+        text: 'foobarbaz',
+      },
+      {
+        kind: 'text',
+        text: '() -> ',
+      },
+      {
+        kind: 'typeIdentifier',
+        text: 'Int',
+        preciseIdentifier: 's:Si',
+      },
+    ];
+    const wrapper = mountWithTokens(tokens);
+
+    const tokenComponents = wrapper.findAll(Token);
+    expect(tokenComponents.length).toBe(tokens.length);
+    expect(tokenComponents.at(1).props('text')).toBe('\n');
+    expect(tokenComponents.at(3).props('text')).toBe('(baz)\n');
+  });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 108412440

## Summary

Updates the formatting logic for Swift declarations to break each [attribute][1] onto its own line.

Example:
```swift
// before
@discardableResult @objc(baz) func foobarbaz() -> Int

// after
@discardableResult
@objc(baz)
func foobarbaz() -> Int
```

\cc @ethan-kusters 

## Testing

Steps:
1. Configure [swift-docc-plugin][2] for a new or existing swift package that has examples of Swift symbols with attributes
2. Build this branch and note the location of `dist`
3. Run `DOCC_HTML_DIR=/path/to/dist swift package --disable-sandbox preview-documentation --target [target]` to preview it and verify that the symbols now have each attribute on its own line.

Here is an example package (target `AttributeExamples`) for convenience:
[AttributeExamples.zip](https://github.com/apple/swift-docc-render/files/11338015/AttributeExamples.zip)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary

[1]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes
[2]: https://github.com/apple/swift-docc-plugin