### PR TITLE
Restore breakpoint for small quick nav windows

### DIFF
--- a/src/styles/base/_reset.scss
+++ b/src/styles/base/_reset.scss
@@ -184,6 +184,10 @@ button {
 body {
   $min-width: map-deep-get($breakpoint-attributes, ('default', small, 'min-width'), false);
 
+  @include inTargetIde() {
+    $min-width: map-deep-get($breakpoint-attributes, ('default', xsmall, 'min-width'), false);
+  }
+
   height: 100%;
 
   @if $min-width {

--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -30,6 +30,11 @@ $breakpoint-attributes: (
       max-width: 735px,
       content-width: 280px,
     ),
+    xsmall: (
+      min-width: 245px,
+      max-width: 320px,
+      content-width: 215px,
+    ),
   ),
   nav: (
     large: (


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://108569652

## Summary
Restore breakpoint for small quick nav windows, which sets the proper min-width when the window is narrow.

## Testing
Manual testing
