### PR TITLE
[5.9] fix stale AdjustableSidebarWidth transitioning state

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -55,7 +55,7 @@ import { storage } from 'docc-render/utils/storage';
 import debounce from 'docc-render/utils/debounce';
 import BreakpointEmitter from 'docc-render/components/BreakpointEmitter.vue';
 import { BreakpointName, BreakpointScopes } from 'docc-render/utils/breakpoints';
-import { waitFrames } from 'docc-render/utils/loading';
+import { waitFor, waitFrames } from 'docc-render/utils/loading';
 import scrollLock from 'docc-render/utils/scroll-lock';
 import FocusTrap from 'docc-render/utils/FocusTrap';
 import changeElementVOVisibility from 'docc-render/utils/changeElementVOVisibility';
@@ -234,8 +234,15 @@ export default {
       this.noTransition = false;
     },
     shownOnMobile: 'handleExternalOpen',
-    isTransitioning(value) {
-      if (!value) this.updateContentWidthInStore();
+    async isTransitioning(value) {
+      if (!value) {
+        this.updateContentWidthInStore();
+      } else {
+        // transitionEnd is not guaranteed to fire, so we ensure we stop
+        // transitioning after some time
+        await waitFor(1000);
+        this.isTransitioning = false;
+      }
     },
     hiddenOnLarge() {
       this.isTransitioning = true;
@@ -353,7 +360,7 @@ export default {
     storeTopOffset: throttle(function storeTopOffset() {
       this.topOffset = this.getTopOffset();
     }, 60),
-    trackTransitionStart({ propertyName }) {
+    async trackTransitionStart({ propertyName }) {
       if (propertyName === 'width' || propertyName === 'transform') {
         this.isTransitioning = true;
       }


### PR DESCRIPTION
- **Explanation:** Fixes an edge case where on Safari, the navigator search bar gets cutoff
- **Scope:** Navigator
- **Issue:** rdar://108279303
- **Risk:** Low
- **Testing:** Added unit test and verified manually
- **Reviewer:** @marinaaisa 
- **Original PR:** #599 