### PR TITLE
[5.9] Restore breakpoint for small quick nav windows

### DIFF
--- a/src/styles/base/_reset.scss
+++ b/src/styles/base/_reset.scss
@@ -184,6 +184,10 @@ button {
 body {
   $min-width: map-deep-get($breakpoint-attributes, ('default', small, 'min-width'), false);
 
+  @include inTargetIde() {
+    $min-width: map-deep-get($breakpoint-attributes, ('default', xsmall, 'min-width'), false);
+  }
+
   height: 100%;
 
   @if $min-width {

--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -30,6 +30,11 @@ $breakpoint-attributes: (
       max-width: 735px,
       content-width: 280px,
     ),
+    xsmall: (
+      min-width: 245px,
+      max-width: 320px,
+      content-width: 215px,
+    ),
   ),
   nav: (
     large: (


### PR DESCRIPTION
- **Explanation:** Fixes regression where Quick Nav content is cut off when window is small
- **Scope:** Quick Nav only
- **Issue:** rdar://108569652
- **Risk:** Small
- **Testing:** Manual testing
- **Reviewer:** @mportiz08  
- **Original PR:** #619 