### PR TITLE
[5.9] Minimized mode bottom margin should match side padding

### DIFF
--- a/src/components/DocumentationTopic/ViewMore.vue
+++ b/src/components/DocumentationTopic/ViewMore.vue
@@ -38,7 +38,7 @@ export default {
   @include font-styles(body-reduced-tight);
   display: flex;
   flex-flow: row-reverse;
-  margin-bottom: 20px;
+  margin-bottom: 1.3rem;
 }
 
 </style>


### PR DESCRIPTION
- **Explanation:** Quick Nav bottom margin should also increase when font size increases
- **Scope:** Quick Nav only
- **Issue:** rdar://108577661
- **Risk:** Small
- **Testing:** Manual testing
- **Reviewer:** @mportiz08  
- **Original PR:** #617 