### PR TITLE
[5.9] Disable `skip-nav` VO link in IDE 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@
     :class="{ fromkeyboard: fromKeyboard, hascustomheader: hasCustomHeader }"
   >
     <div :id="AppTopID" />
-    <a href="#main" id="skip-nav">{{ $t('accessibility.skip-navigation') }}</a>
+    <a href="#main" id="skip-nav" v-if="!isTargetIDE">{{ $t('accessibility.skip-navigation') }}</a>
     <InitialLoadingPlaceholder />
     <slot name="header" :isTargetIDE="isTargetIDE">
       <SuggestLang v-if="enablei18n" />


### PR DESCRIPTION
- **Explanation:** VO should not pick up “Skip Navigation” in IDE
- **Scope:** IDE mode only
- **Issue:** rdar://108634054
- **Risk:** Small
- **Testing:** Manual testing
- **Reviewer:** @dobromir-hristov @marinaaisa 
- **Original PR:** #622