### PR TITLE
Reduce the Declaration conditional constraint spacing to 20px

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
@@ -141,6 +141,6 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .conditional-constraints {
-  margin-top: var(--declaration-conditional-constraints-margin, 30px);
+  margin-top: var(--declaration-conditional-constraints-margin, 20px);
 }
 </style>


### PR DESCRIPTION
Bug/issue #, if applicable: 105460303

## Summary

Reduces the space between Declaration and the conditional constraint to 20px from 30px.

## Dependencies

NA

## Testing

Assert the space is correct

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
