### PR TITLE
Allow inner scroll in modals when device is iOS

### DIFF
--- a/src/components/GenericModal.vue
+++ b/src/components/GenericModal.vue
@@ -91,6 +91,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    allowInnerScroll: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
@@ -168,7 +172,7 @@ export default {
       // make sure PortalVue is ready
       await this.$nextTick();
       // lock scroll
-      scrollLock.lockScroll(this.$refs.container);
+      scrollLock.lockScroll(this.$refs.container, this.allowInnerScroll);
       // remember last focus item
       await this.focusCloseButton();
       // update the focus container

--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -11,6 +11,7 @@
 <template>
   <GenericModal
     isFullscreen
+    allowInnerScroll
     :showClose="false"
     :visible.sync="isVisible"
     backdropBackgroundColorOverride="rgba(0, 0, 0, 0.7)"

--- a/src/utils/scroll-lock.js
+++ b/src/utils/scroll-lock.js
@@ -127,11 +127,12 @@ export default {
    * Locks the scrolling of the body, except for an element
    * @param {HTMLElement} targetElement
    */
-  lockScroll(targetElement) {
+  lockScroll(targetElement, allowInnerScroll) {
     // skip lock if already locked
     if (isLocked) return;
-    // iOS devices require a more advanced locking.
-    if (!isIosDevice()) {
+    // use simple lock if device is not iOS
+    // or it allows inner scrolling
+    if (!isIosDevice() || allowInnerScroll) {
       simpleLock();
     } else {
       advancedLock(targetElement);


### PR DESCRIPTION
Bug/issue #108269711, if applicable: 

## Summary

Allow inner scroll in modals when device is iOS.
Using the advance lock was preventing Quick Navigation from being able to scroll the list in iOS devices.

## Dependencies

NA

## Testing

Steps:
1. Run a doccarchive with Quick Navigator
2. Open the Simulator app in Xcode
3. Use an iPad Pro simulator in landscape mode
4. Open Quick Navigator
5. Make sure you can scroll the list of results

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
