### PR TITLE
Support linkable attribute tokens

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationToken.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationToken.vue
@@ -46,14 +46,20 @@ export default {
     }
     case TokenKind.typeIdentifier: {
       const props = { identifier: this.identifier };
-      return createElement(LinkableToken, { class: 'type-identifier-link', props }, [
+      return createElement(LinkableToken, {
+        class: 'type-identifier-link',
+        props,
+      }, [
         createElement(WordBreak, text),
       ]);
     }
     case TokenKind.attribute: {
       const { identifier } = this;
       return identifier ? (
-        createElement(LinkableToken, { class: 'attribute-link', props: { identifier } }, [
+        createElement(LinkableToken, {
+          class: 'attribute-link',
+          props: { identifier },
+        }, [
           createElement(WordBreak, text),
         ])
       ) : (

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationToken.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationToken.vue
@@ -46,9 +46,19 @@ export default {
     }
     case TokenKind.typeIdentifier: {
       const props = { identifier: this.identifier };
-      return createElement(LinkableToken, { props }, [
+      return createElement(LinkableToken, { class: 'type-identifier-link', props }, [
         createElement(WordBreak, text),
       ]);
+    }
+    case TokenKind.attribute: {
+      const { identifier } = this;
+      return identifier ? (
+        createElement(LinkableToken, { class: 'attribute-link', props: { identifier } }, [
+          createElement(WordBreak, text),
+        ])
+      ) : (
+        createElement(SyntaxToken, { props: { kind, text } })
+      );
     }
     case TokenKind.added:
     case TokenKind.removed:
@@ -110,7 +120,8 @@ export default {
   color: var(--syntax-string, var(--color-syntax-strings));
 }
 
-.token-attribute {
+.token-attribute,
+.attribute-link {
   color: var(--syntax-attribute, var(--color-syntax-keywords));
 }
 

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationToken.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationToken.vue
@@ -11,9 +11,9 @@
 <script>
 import WordBreak from 'docc-render/components/WordBreak.vue';
 import ChangedToken from './DeclarationToken/ChangedToken.vue';
+import LinkableToken from './DeclarationToken/LinkableToken.vue';
 import RawText from './DeclarationToken/RawText.vue';
 import SyntaxToken from './DeclarationToken/SyntaxToken.vue';
-import TypeIdentifierLink from './DeclarationToken/TypeIdentifierLink.vue';
 
 const TokenKind = {
   attribute: 'attribute',
@@ -46,7 +46,7 @@ export default {
     }
     case TokenKind.typeIdentifier: {
       const props = { identifier: this.identifier };
-      return createElement(TypeIdentifierLink, { props }, [
+      return createElement(LinkableToken, { props }, [
         createElement(WordBreak, text),
       ]);
     }

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue
@@ -17,12 +17,10 @@ export default {
   name: 'LinkableToken',
   mixins: [referencesProvider],
   render(createElement) {
-    const klass = 'type-identifier-link';
     const reference = this.references[this.identifier];
     // internal and external link
     if (reference && reference.url) {
       return createElement(Reference, {
-        class: klass,
         props: {
           url: reference.url,
           kind: reference.kind,
@@ -33,9 +31,7 @@ export default {
       ));
     }
     // unresolved link, use span tag
-    return createElement('span', {
-      class: klass,
-    }, (
+    return createElement('span', {}, (
       this.$slots.default
     ));
   },

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue
@@ -14,7 +14,7 @@ import Reference from 'docc-render/components/ContentNode/Reference.vue';
 import referencesProvider from 'docc-render/mixins/referencesProvider';
 
 export default {
-  name: 'TypeIdentifierLink',
+  name: 'LinkableToken',
   mixins: [referencesProvider],
   render(createElement) {
     const klass = 'type-identifier-link';

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken.spec.js
@@ -114,7 +114,7 @@ describe('DeclarationToken', () => {
   it('renders a `LinkableToken` for `attribute` tokens with an `identifier`', () => {
     const propsData = {
       kind: TokenKind.attribute,
-      identifier: '@foo',
+      identifier: 'foo',
       text: '@foo',
     };
     const wrapper = mountToken({ propsData });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken.spec.js
@@ -49,6 +49,7 @@ describe('DeclarationToken', () => {
     expect(link.props()).toEqual({ identifier: propsData.identifier });
     expect(link.contains(WordBreak)).toBe(true);
     expect(link.text()).toBe(propsData.text);
+    expect(link.classes()).toContain('type-identifier-link');
   });
 
   it('renders a `SyntaxToken` for other tokens', () => {
@@ -96,5 +97,32 @@ describe('DeclarationToken', () => {
     expect(token.exists()).toBe(true);
     expect(token.props('tokens')).toEqual(propsData.tokens);
     expect(token.props('kind')).toEqual(propsData.kind);
+  });
+
+  it('renders a `SyntaxToken` for basic `attribute` tokens', () => {
+    const propsData = {
+      kind: TokenKind.attribute,
+      text: '@foo',
+    };
+    const wrapper = mountToken({ propsData });
+    const token = wrapper.find(SyntaxToken);
+    expect(token.exists()).toBe(true);
+    expect(token.props('kind')).toBe(TokenKind.attribute);
+    expect(token.props('text')).toBe(propsData.text);
+  });
+
+  it('renders a `LinkableToken` for `attribute` tokens with an `identifier`', () => {
+    const propsData = {
+      kind: TokenKind.attribute,
+      identifier: '@foo',
+      text: '@foo',
+    };
+    const wrapper = mountToken({ propsData });
+    const link = wrapper.find(LinkableToken);
+    expect(link.exists()).toBe(true);
+    expect(link.props()).toEqual({ identifier: propsData.identifier });
+    expect(link.contains(WordBreak)).toBe(true);
+    expect(link.text()).toBe(propsData.text);
+    expect(link.classes()).toContain('attribute-link');
   });
 });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken.spec.js
@@ -15,8 +15,8 @@ import DeclarationToken from 'docc-render/components/DocumentationTopic/PrimaryC
 import RawText from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationToken/RawText.vue';
 import SyntaxToken
   from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationToken/SyntaxToken.vue';
-import TypeIdentifierLink
-  from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationToken/TypeIdentifierLink.vue';
+import LinkableToken
+  from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue';
 import WordBreak from 'docc-render/components/WordBreak.vue';
 
 const { TokenKind } = DeclarationToken.constants;
@@ -36,7 +36,7 @@ describe('DeclarationToken', () => {
     expect(rawText.props()).toEqual({ text: propsData.text });
   });
 
-  it('renders a `TypeIdentifierLink` for `typeIdentifier` tokens', () => {
+  it('renders a `LinkableToken` for `typeIdentifier` tokens', () => {
     const propsData = {
       kind: TokenKind.typeIdentifier,
       identifier: 'foo',
@@ -44,7 +44,7 @@ describe('DeclarationToken', () => {
     };
     const wrapper = mountToken({ propsData });
 
-    const link = wrapper.find(TypeIdentifierLink);
+    const link = wrapper.find(LinkableToken);
     expect(link.exists()).toBe(true);
     expect(link.props()).toEqual({ identifier: propsData.identifier });
     expect(link.contains(WordBreak)).toBe(true);

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.spec.js
@@ -47,7 +47,7 @@ describe('LinkableToken', () => {
 
   it('renders a span for unresolved references', () => {
     const wrapper = shallowMount(LinkableToken, defaultOpts);
-    expect(wrapper.is('span.type-identifier-link')).toBe(true);
+    expect(wrapper.is('span')).toBe(true);
     expect(wrapper.text()).toBe(foo.title);
   });
 
@@ -65,10 +65,8 @@ describe('LinkableToken', () => {
       },
     });
 
-    expect(wrapper.is('.type-identifier-link')).toBe(true);
     const link = wrapper.find(Reference);
     expect(link.exists()).toBe(true);
-    expect(link.classes('type-identifier-link')).toBe(true);
     expect(link.props('url')).toBe(foo.url);
     expect(link.text()).toBe(foo.title);
   });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.spec.js
@@ -9,11 +9,11 @@
 */
 
 import { shallowMount } from '@vue/test-utils';
-import TypeIdentifierLink
-  from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationToken/TypeIdentifierLink.vue';
+import LinkableToken
+  from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
 
-describe('TypeIdentifierLink', () => {
+describe('LinkableToken', () => {
   const foo = {
     identifier: 'foo',
     title: 'Foo',
@@ -46,13 +46,13 @@ describe('TypeIdentifierLink', () => {
   };
 
   it('renders a span for unresolved references', () => {
-    const wrapper = shallowMount(TypeIdentifierLink, defaultOpts);
+    const wrapper = shallowMount(LinkableToken, defaultOpts);
     expect(wrapper.is('span.type-identifier-link')).toBe(true);
     expect(wrapper.text()).toBe(foo.title);
   });
 
   it('renders a link for resolved references', () => {
-    const wrapper = shallowMount(TypeIdentifierLink, {
+    const wrapper = shallowMount(LinkableToken, {
       ...defaultOpts,
       provide: {
         store: {


### PR DESCRIPTION
Bug/issue #, if applicable: 108472125

## Summary

This adds support for rendering certain attribute tokens as links to symbols instead of just plaintext.

As a basic example, DocC would generate a linkable `@StringBuilder` token in the contrived `buildABC` function here:

```swift
@resultBuilder
public struct StringBuilder {
  static func buildBlock(_ parts: String...) -> String {
    parts.joined(separator: "\n")
  }
}

@StringBuilder public func buildABC() -> String {
  "a"
  "b"
  "c"
}
```

## Dependencies

https://github.com/apple/swift/pull/63637

## Testing

To test this using swift-docc-plugin, you may need a recent 5.9 toolchain version of Swift to ensure that the symbol graph tokens get generated with the data for linking (see above dependency).

Steps:
1. Build this branch with `npm run build`
2. Preview docs for an example package that has an example like the one above with `env DOCC_HTML_DIR=/path/to/dist swift package --disable-sandbox preview-documentation --target [target]`
3. Verify that the example attribute can be clicked in a declaration, which should take you to that symbol page.

Here is an example package (target "AttributeExamples") that has the `@StringBuilder` example code from above:
[AttributeExamples.zip](https://github.com/apple/swift-docc-render/files/11391749/AttributeExamples.zip)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
