### PR TITLE
Ensure the navigator filter picked tags are slightly visible, even on very narrow screens.

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1144,8 +1144,14 @@ $filter-height-small: 60px;
     --input-border-color: var(--color-grid);
     --input-text: var(--color-figure-gray-secondary);
 
-    /deep/ .filter__input {
-      @include font-styles(body);
+    /deep/ {
+      .filter__input {
+        @include font-styles(body);
+
+        &-label::after {
+          min-width: 70px;
+        }
+      }
     }
   }
 }

--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -145,7 +145,7 @@ import keyboardNavigation from 'docc-render/mixins/keyboardNavigation';
 import LRUMap from 'docc-render/utils/lru-map';
 import { convertChildrenArrayToObject, getParents } from 'docc-render/utils/navigatorData';
 import { fetchDataForPreview } from 'docc-render/utils/data';
-import { SCROLL_LOCK_DISABLE_ATTR } from '@/utils/scroll-lock';
+import { SCROLL_LOCK_DISABLE_ATTR } from 'docc-render/utils/scroll-lock';
 
 const { PreviewState } = QuickNavigationPreview.constants;
 


### PR DESCRIPTION
Bug/issue #, if applicable: 108916627

## Summary

Adjusts the minimum filter width in the Navigator, so you can always see parts of the picked tags, on empty input.

closes #603 

## Dependencies

NA

## Testing

1. Make screen very narrow and then make the Navigator as narrow as possible.
2. Then try to pick a tag from the list
3. Assert at least some part of the tag is visible

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
