### PR TITLE
Symbol links should respect the formatting provided in `overridingTitleInlineContent`

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -430,10 +430,12 @@ function renderNode(createElement, references) {
       const titleInlineContent = node.overridingTitleInlineContent
         || reference.titleInlineContent;
       const titlePlainText = node.overridingTitle || reference.title;
+      const kind = node.overridingTitleInlineContent
+        ? node.overridingTitleInlineContent[0].type : reference.kind;
       return createElement(Reference, {
         props: {
           url: reference.url,
-          kind: reference.kind,
+          kind,
           role: reference.role,
           isActive: node.isActive,
           ideTitle: reference.ideTitle,

--- a/src/components/ContentNode/Reference.vue
+++ b/src/components/ContentNode/Reference.vue
@@ -43,7 +43,7 @@ export default {
       return name !== notFoundRouteName;
     },
     isSymbolReference() {
-      return this.kind === 'symbol'
+      return (this.kind === 'symbol' || this.kind === 'codeVoice')
         && (this.role === TopicRole.symbol || this.role === TopicRole.dictionarySymbol);
     },
     isDisplaySymbol({ isSymbolReference, titleStyle, ideTitle }) {

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -1254,11 +1254,41 @@ describe('ContentNode', () => {
       const reference = wrapper.find('.content').find(Reference);
       expect(reference.exists()).toBe(true);
       expect(reference.props('url')).toBe('/foo/bar');
+      expect(reference.props('kind')).toBe('codeVoice');
 
       const codeVoice = reference.find(CodeVoice);
       expect(codeVoice.exists()).toBe(true);
       expect(codeVoice.text()).not.toBe('FooBar with Code Voice');
       expect(codeVoice.text()).toBe('Foo the Bar with Code Voice');
+    });
+
+    it('renders a `Reference` with an overwritten title of type="text"', () => {
+      const wrapper = mountWithItem({
+        type: 'reference',
+        identifier: 'foobar',
+        overridingTitle: 'Foo with Text',
+        overridingTitleInlineContent: [
+          {
+            type: 'text',
+            text: 'Foo the Bar with Text',
+          },
+        ],
+      }, {
+        foobar: {
+          title: 'FooBar',
+          url: '/foo/bar',
+          kind: 'bla',
+        },
+      });
+
+      const reference = wrapper.find('.content').find(Reference);
+      expect(reference.exists()).toBe(true);
+      expect(reference.props('kind')).toBe('text');
+
+      const codeVoice = reference.find(CodeVoice);
+      expect(codeVoice.exists()).toBe(false);
+      expect(reference.text()).not.toBe('FooBar with Code Voice');
+      expect(reference.text()).toBe('Foo the Bar with Text');
     });
 
     it('renders a reference as a none link when isActive is false', () => {

--- a/tests/unit/components/ContentNode/Reference.spec.js
+++ b/tests/unit/components/ContentNode/Reference.spec.js
@@ -79,6 +79,22 @@ describe('Reference', () => {
     expect(ref.props('url')).toBe('/documentation/uikit/uiview');
   });
 
+  it('renders a `ReferenceInternalSymbol` for external "codeVoice" kind references', () => {
+    const wrapper = shallowMount(Reference, {
+      localVue,
+      router,
+      propsData: {
+        url: '/documentation/uikit/uiview',
+        kind: 'codeVoice',
+        role: TopicRole.symbol,
+      },
+      slots: { default: 'UIView' },
+    });
+    const ref = wrapper.find(ReferenceInternalSymbol);
+    expect(ref.exists()).toBe(true);
+    expect(ref.props('url')).toBe('/documentation/uikit/uiview');
+  });
+
   it('renders a `ReferenceInternal` for external "symbol" kind references with human readable name', () => {
     const wrapper = shallowMount(Reference, {
       localVue,


### PR DESCRIPTION
Bug/issue #108515663, if applicable: 

## Summary

Symbol links should respect the formatting provided in `overridingTitleInlineContent`

- resolves https://github.com/apple/swift-docc-render/issues/632

### Before
<img width="978" alt="Screenshot 2023-05-08 at 19 32 41" src="https://user-images.githubusercontent.com/8567677/236891652-ca572fb4-9587-4b9a-a711-955b045272e0.png">

### After

<img width="985" alt="Screenshot 2023-05-08 at 19 32 26" src="https://user-images.githubusercontent.com/8567677/236891683-2a994eb7-370d-43f6-bcdc-4fdfbc4d1567.png">

## Dependencies

NA

## Testing

[eat(_:quantity:).json.zip](https://github.com/apple/swift-docc-render/files/11423647/eat._.quantity.json.zip)

Steps:
1. Use json attached in your doccarchive and run `VUE_APP_DEV_SERVER_PROXY=[path to doccarchive] npm run serve`
2. Go to `http://localhost:8080/documentation/slothcreator/Sloth/eat(_:quantity:)`
3. Assert that "energy" inside Discussion section does not use the CodeVoice component

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
