### PR TITLE
Respect formatting of links to symbols using custom titles

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -438,6 +438,7 @@ function renderNode(createElement, references) {
           isActive: node.isActive,
           ideTitle: reference.ideTitle,
           titleStyle: reference.titleStyle,
+          hasInlineFormatting: !!titleInlineContent,
         },
       }, (
         titleInlineContent ? renderChildren(titleInlineContent) : titlePlainText

--- a/src/components/ContentNode/Reference.vue
+++ b/src/components/ContentNode/Reference.vue
@@ -43,7 +43,7 @@ export default {
       return name !== notFoundRouteName;
     },
     isSymbolReference() {
-      return this.kind === 'symbol'
+      return this.kind === 'symbol' && !this.hasInlineFormatting
         && (this.role === TopicRole.symbol || this.role === TopicRole.dictionarySymbol);
     },
     isDisplaySymbol({ isSymbolReference, titleStyle, ideTitle }) {
@@ -90,6 +90,10 @@ export default {
     titleStyle: {
       type: String,
       required: false,
+    },
+    hasInlineFormatting: {
+      type: Boolean,
+      default: false,
     },
   },
 };

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -1027,6 +1027,7 @@ describe('ContentNode', () => {
       expect(reference.props('url')).toBe('/foo/bar');
       expect(reference.props('ideTitle')).toBe('IDETitle');
       expect(reference.props('titleStyle')).toBe('symbol');
+      expect(reference.props('hasInlineFormatting')).toBe(false);
       expect(reference.isEmpty()).toBe(false);
       expect(reference.text()).toBe('FooBar');
     });
@@ -1119,6 +1120,7 @@ describe('ContentNode', () => {
       const reference = wrapper.find('.content').find(Reference);
       expect(reference.exists()).toBe(true);
       expect(reference.props('url')).toBe('/foo/bar');
+      expect(reference.props('hasInlineFormatting')).toBe(true);
 
       const emphasis = reference.find('em');
       expect(emphasis.exists()).toBe(true);

--- a/tests/unit/components/ContentNode/Reference.spec.js
+++ b/tests/unit/components/ContentNode/Reference.spec.js
@@ -127,6 +127,7 @@ describe('Reference', () => {
     const ref = wrapper.find(ReferenceInternal);
     expect(ref.exists()).toBe(true);
     expect(ref.props('url')).toBe('/documentation/uikit/uiview');
+    expect(wrapper.find(ReferenceInternalSymbol).exists()).toBe(false);
   });
 
   it('renders a `ReferenceInternal` for external "dictionarySymbol" kind references with a human readable name', () => {

--- a/tests/unit/components/ContentNode/Reference.spec.js
+++ b/tests/unit/components/ContentNode/Reference.spec.js
@@ -112,6 +112,23 @@ describe('Reference', () => {
     expect(ref.props('url')).toBe('/documentation/uikit/uiview');
   });
 
+  it('renders a `ReferenceInternal` for a symbol with its own inline formatting', () => {
+    const wrapper = shallowMount(Reference, {
+      localVue,
+      router,
+      propsData: {
+        url: '/documentation/uikit/uiview',
+        kind: 'symbol',
+        role: TopicRole.symbol,
+        hasInlineFormatting: true,
+      },
+      slots: { default: 'custom text for UIView symbol' },
+    });
+    const ref = wrapper.find(ReferenceInternal);
+    expect(ref.exists()).toBe(true);
+    expect(ref.props('url')).toBe('/documentation/uikit/uiview');
+  });
+
   it('renders a `ReferenceInternal` for external "dictionarySymbol" kind references with a human readable name', () => {
     const wrapper = shallowMount(Reference, {
       localVue,


### PR DESCRIPTION
Bug/issue #, if applicable: #632 (108515663)

## Summary

This resolves #632, which is a bug where code voice is automatically applied to a symbol link that has a custom title, even if it doesn't use any code voice itself.

If a custom title is used for a markdown link to a DocC symbol, the inline markdown formatting of that title should be respected as-is.

**Example:**
```markdown
/// Default, should use code voice: ``StringBuilder``
///
/// Custom title, should use code voice: [`custom text`](doc:StringBuilder)
///
/// Custom title, should not use code voice: [custom text](doc:StringBuilder)
///
/// Custom title, should use italics and bold: [_**custom text**_](doc:StringBuilder)
```

## Testing

Steps:
1. Build this branch with `npm run build`
2. Download/unzip example Swift package [`AttributeExamples.zip`][1] with custom title examples.
3. Run `env DOCC_HTML_DIR=/path/to/dist swift package --disable-sandbox preview-documentation --target AttributeExamples` to preview the example package with this branch of the renderer.
4. Open http://localhost:8080/documentation/attributeexamples/exampleusingcomplexattributes#overview and verify that all links are rendered with the expected formatting, given the markdown input from the source code. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary

[1]: https://github.com/apple/swift-docc-render/files/11425626/AttributeExamples.zip