### PR TITLE
[5.9] Fix indentation formatting for params with attributes

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -140,8 +140,10 @@ export default {
         // if we find some text ending with ", " and the next token is the start
         // of a new param, update this token text to replace the space with a
         // newline followed by 4 spaces
-        if (token.text && token.text.endsWith(', ')
-          && nextToken && nextToken.kind === TokenKind.externalParam) {
+        const isStartOfParam = ({ kind }) => (
+          kind === TokenKind.attribute || kind === TokenKind.externalParam
+        );
+        if (token.text && token.text.endsWith(', ') && nextToken && isStartOfParam(nextToken)) {
           newToken.text = `${token.text.trimEnd()}\n${indent}`;
           indentedParams = true;
         }

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -774,4 +774,105 @@ func foobarbaz() -> Int`,
 func foo(bar: @escaping () -> ()) -> Int`,
     );
   });
+
+  it('adds newlines for params that start with attribute tokens', () => {
+    const param = name => ([
+      {
+        kind: TokenKind.externalParam,
+        text: name,
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+    ]);
+    const attributeParam = name => ([
+      {
+        kind: TokenKind.attribute,
+        text: '@StringBuilder',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: name,
+      },
+      {
+        kind: TokenKind.text,
+        text: ': () -> ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'String',
+      },
+    ]);
+    const tokens = (paramA, paramB) => ([
+      {
+        kind: TokenKind.keyword,
+        text: 'func',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.identifier,
+        text: 'qux',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(',
+      },
+      ...paramA,
+      {
+        kind: TokenKind.text,
+        text: ', ',
+      },
+      ...paramB,
+      {
+        kind: TokenKind.text,
+        text: ')',
+      },
+    ]);
+
+    // Before:
+    // func qux(a: Int, @StringBuilder b: () -> String)
+    //
+    // After:
+    // func qux(
+    //     a: Int,
+    //     @StringBuilder b: () -> String
+    // )
+    const wrapper = mountWithTokens(tokens(param('a'), attributeParam('b')));
+    const tokenComponents = wrapper.findAll(Token);
+    expect(getText(tokenComponents)).toBe(
+`func qux(
+    a: Int,
+    @StringBuilder b: () -> String
+)`,
+    );
+
+    // Before:
+    // func qux(@StringBuilder a: () -> String, b: Int)
+    //
+    // After:
+    // func qux(
+    //     @StringBuilder a: () -> String,
+    //     b: Int
+    // )
+    const wrapper2 = mountWithTokens(tokens(attributeParam('a'), param('b')));
+    const tokenComponents2 = wrapper2.findAll(Token);
+    expect(getText(tokenComponents2)).toBe(
+`func qux(
+    @StringBuilder a: () -> String,
+    b: Int
+)`,
+    );
+  });
 });


### PR DESCRIPTION
- **Explanation:** Fixes issue with indenting parameters that start with attributes in Swift symbols.
- **Scope:** Impacts all Swift declarations with multiple params that contain attributes.
- **Issue:** rdar://108472125
- **Risk:** Medium, small change but impacts all Swift decls
- **Testing:** Added/updated unit tests and manually tested various kinds of declarations with varying number of params both with and without attributes.
- **Reviewer:** @hqhhuang 
- **Original PR:** #642 