### PR TITLE
[5.9] Respect formatting of links to symbols using custom titles

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -438,6 +438,7 @@ function renderNode(createElement, references) {
           isActive: node.isActive,
           ideTitle: reference.ideTitle,
           titleStyle: reference.titleStyle,
+          hasInlineFormatting: !!titleInlineContent,
         },
       }, (
         titleInlineContent ? renderChildren(titleInlineContent) : titlePlainText

--- a/src/components/ContentNode/Reference.vue
+++ b/src/components/ContentNode/Reference.vue
@@ -43,7 +43,7 @@ export default {
       return name !== notFoundRouteName;
     },
     isSymbolReference() {
-      return this.kind === 'symbol'
+      return this.kind === 'symbol' && !this.hasInlineFormatting
         && (this.role === TopicRole.symbol || this.role === TopicRole.dictionarySymbol);
     },
     isDisplaySymbol({ isSymbolReference, titleStyle, ideTitle }) {
@@ -90,6 +90,10 @@ export default {
     titleStyle: {
       type: String,
       required: false,
+    },
+    hasInlineFormatting: {
+      type: Boolean,
+      default: false,
     },
   },
 };

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -1027,6 +1027,7 @@ describe('ContentNode', () => {
       expect(reference.props('url')).toBe('/foo/bar');
       expect(reference.props('ideTitle')).toBe('IDETitle');
       expect(reference.props('titleStyle')).toBe('symbol');
+      expect(reference.props('hasInlineFormatting')).toBe(false);
       expect(reference.isEmpty()).toBe(false);
       expect(reference.text()).toBe('FooBar');
     });
@@ -1119,6 +1120,7 @@ describe('ContentNode', () => {
       const reference = wrapper.find('.content').find(Reference);
       expect(reference.exists()).toBe(true);
       expect(reference.props('url')).toBe('/foo/bar');
+      expect(reference.props('hasInlineFormatting')).toBe(true);
 
       const emphasis = reference.find('em');
       expect(emphasis.exists()).toBe(true);

--- a/tests/unit/components/ContentNode/Reference.spec.js
+++ b/tests/unit/components/ContentNode/Reference.spec.js
@@ -112,6 +112,24 @@ describe('Reference', () => {
     expect(ref.props('url')).toBe('/documentation/uikit/uiview');
   });
 
+  it('renders a `ReferenceInternal` for a symbol with its own inline formatting', () => {
+    const wrapper = shallowMount(Reference, {
+      localVue,
+      router,
+      propsData: {
+        url: '/documentation/uikit/uiview',
+        kind: 'symbol',
+        role: TopicRole.symbol,
+        hasInlineFormatting: true,
+      },
+      slots: { default: 'custom text for UIView symbol' },
+    });
+    const ref = wrapper.find(ReferenceInternal);
+    expect(ref.exists()).toBe(true);
+    expect(ref.props('url')).toBe('/documentation/uikit/uiview');
+    expect(wrapper.find(ReferenceInternalSymbol).exists()).toBe(false);
+  });
+
   it('renders a `ReferenceInternal` for external "dictionarySymbol" kind references with a human readable name', () => {
     const wrapper = shallowMount(Reference, {
       localVue,


### PR DESCRIPTION
- **Explanation:** Fixes bug where code voice is incorrectly applied to links with custom titles/formatting which point to symbols. Now the inline formatting of the custom links will be respected as-is.
- **Scope:** Impacts all DocC links with custom titles/formatting
- **Issue:** rdar://108515663
- **Risk:** Low, added flag/logic for links with custom titles
- **Testing:** Added/updated unit tests and manually tested various kinds of DocC links to verify that the formatting is appropriate.
- **Reviewer:** @dobromir-hristov and @marinaaisa 
- **Original PR:** #647 