### PR TITLE
Add translated strings

### DIFF
--- a/src/lang/locales/ja-JP.json
+++ b/src/lang/locales/ja-JP.json
@@ -1,6 +1,6 @@
 {
-  "view-in": "英語で表示",
-  "continue-viewing": "英語で表示を続ける",
+  "view-in": "日本語で表示",
+  "continue-viewing": "日本語で表示を続ける",
   "language": "言語",
   "video": {
     "replay": "リプレイ",

--- a/src/lang/locales/ja-JP.json
+++ b/src/lang/locales/ja-JP.json
@@ -1,10 +1,11 @@
 {
-  "view-in": "日本語で表示",
-  "continue-viewing": "日本語で表示を続ける",
+  "view-in": "英語で表示",
+  "continue-viewing": "英語で表示を続ける",
   "language": "言語",
   "video": {
     "replay": "リプレイ",
     "play": "再生",
+    "pause": "一時停止",
     "watch": "概要のビデオを観る"
   },
   "tutorials": {
@@ -55,7 +56,15 @@
       "open-menu": "メニューを開く",
       "close-menu": "メニューを閉じる"
     },
-    "current-page": "現在のページは{title}です"
+    "current-page": "現在のページは{title}です",
+    "card": {
+      "learn-more": "詳しい情報",
+      "read-article": "記事を読む",
+      "start-tutorial": "チュートリアルを開始",
+      "view-api": "APIのコレクションを表示",
+      "view-symbol": "記号を表示",
+      "view-sample-code": "サンプルコードを表示"
+    }
   },
   "aside-kind": {
     "beta": "ベータ版",
@@ -83,7 +92,7 @@
     "default-implementations": "デフォルト実装",
     "relationships": "関連項目",
     "see-also": "参照",
-    "declarations": "宣言",
+    "declaration": "宣言",
     "details": "詳細",
     "parameters": "パラメータ",
     "possible-values": "使用できる値",
@@ -104,22 +113,22 @@
     "default-implementation": "デフォルト実装あり。| デフォルト実装あり。"
   },
   "availability": {
-    "introduced-and-deprecated": "{name}{introducedAt}で導入され、{name}{deprecatedAt}で非推奨になりました",
-    "available-on": "{name}{introducedAt}以降で使用できます"
+    "introduced-and-deprecated": "{name} {introducedAt}で導入され、{name} {deprecatedAt}で非推奨になりました",
+    "available-on": "{name} {introducedAt}以降で使用できます"
   },
   "more": "さらに表示",
   "less": "表示を減らす",
   "api-reference": "APIリファレンス",
   "filter": {
     "title": "フィルタ",
-    "search-symbols": "記号を検索",
-    "suggested-tags": "提案されたタグ",
-    "selected-tags": "選択したタグ",
+    "search-symbols": "{technology}でシンボルを検索",
+    "suggested-tags": "提案されたタグ | 提案されたタグ",
+    "selected-tags": "選択したタグ | 選択したタグ",
     "add-tag": "タグを追加",
     "tag-select-remove": "タグ。選択してリストから削除します。",
     "navigate": "シンボルを移動するには、上下左右の矢印キーを押します。",
-    "siblings-label": "{number-siblings}個中{total-siblings} 個のシンボルが中にあります {parent-siblings}",
-    "parent-label": "@:filter.siblings-label 1個のシンボルを含む | @:filter.siblings-label {number-parent} 個のシンボルを含む",
+    "siblings-label": "{total-siblings}個中{number-siblings}個のシンボルが{parent-siblings}の中にあります",
+    "parent-label": "{total-siblings}個中{number-siblings}個のシンボルが1個のシンボルを含む{parent-siblings}の中にあります | {total-siblings}個中{number-siblings}個のシンボルが{number-parent}個のシンボルを含む{parent-siblings}の中にあります",
     "reset-filter": "フィルタをリセット"
   },
   "navigator": {
@@ -148,10 +157,10 @@
     "default": "デフォルト",
     "minimum": "最小",
     "maximum": "最大",
-    "possible-types": "使用できるタイプ",
-    "possible-values": "使用できる値"
+    "possible-types": "タイプ | 使用できるタイプ",
+    "possible-values": "値 | 使用できる値"
   },
-  "content-type": "コンテンツタイプ: {value}",
+  "content-type": "Content-Type: {value}",
   "read-only": "読み出し専用",
   "error": {
     "unknown": "原因不明のエラーが起きました。",
@@ -169,8 +178,8 @@
       "end": "取り消し線テキストの終了"
     },
     "code": {
-      "start": "start of code block",
-      "end": "end of code block"
+      "start": "コードブロックの開始",
+      "end": "コードブロックの終了"
     },
     "skip-navigation": "ナビゲーションをスキップ"
   },
@@ -183,5 +192,11 @@
   "formats": {
     "parenthesis": "（{content}）",
     "colon": "{content}: "
+  },
+  "quicknav": {
+    "button": {
+      "label": "クイックナビゲーションを開く",
+      "title": "クリックするか「/」を入力すると素早く移動します"
+    }
   }
 }

--- a/src/lang/locales/zh-CN.json
+++ b/src/lang/locales/zh-CN.json
@@ -5,6 +5,7 @@
   "video": {
     "replay": "重新播放",
     "play": "播放",
+    "pause": "暂停",
     "watch": "观看介绍视频"
   },
   "tutorials": {
@@ -55,7 +56,15 @@
       "open-menu": "打开菜单",
       "close-menu": "关闭菜单"
     },
-    "current-page": "当前页面为：{title}"
+    "current-page": "当前页面为：{title}",
+    "card": {
+      "learn-more": "进一步了解",
+      "read-article": "阅读文章",
+      "start-tutorial": "开始教程",
+      "view-api": "查看 API 集合",
+      "view-symbol": "查看符号",
+      "view-sample-code": "查看示例代码"
+    }
   },
   "aside-kind": {
     "beta": "Beta 版",
@@ -83,7 +92,7 @@
     "default-implementations": "默认实现",
     "relationships": "关系",
     "see-also": "另请参阅",
-    "declarations": "声明",
+    "declaration": "声明",
     "details": "详细信息",
     "parameters": "参数",
     "possible-values": "可能值",
@@ -101,31 +110,31 @@
       "legal": "此文档涉及 Beta 版软件且可能会改动。",
       "software": "Beta 版软件"
     },
-    "default-implementation": "已提供默认实现。"
+    "default-implementation": "提供默认实现。| 提供默认实现方法。"
   },
   "availability": {
-    "introduced-and-deprecated": "{name}{introducedAt}中引入，{name}{deprecatedAt}中弃用",
-    "available-on": "{name}{introducedAt}及更高版本中可用"
+    "introduced-and-deprecated": "{name} {introducedAt} 中引入，{name} {deprecatedAt} 中弃用",
+    "available-on": "{name} {introducedAt} 及更高版本中可用"
   },
   "more": "更多",
   "less": "更少",
   "api-reference": "API 参考",
   "filter": {
     "title": "过滤",
-    "search-symbols": "搜索符号",
+    "search-symbols": "在 {technology} 搜索符号",
     "suggested-tags": "建议标签",
     "selected-tags": "所选标签",
     "add-tag": "添加标签",
     "tag-select-remove": "标签。选择以从列表中移除。",
     "navigate": "若要导航符号，请按下上箭头、下箭头、左箭头或右箭头。",
-    "siblings-label": "内含 {number-siblings} 个符号（共 {total-siblings} 个）{parent-siblings}",
-    "parent-label": "@:filter.siblings-label 包含 1 个符号 | @:filter.siblings-label 包含 {number-parent} 个符号",
+    "siblings-label": "{Parent-siblings} 内含 {number-siblings} 个符号（共 {total-siblings} 个）",
+    "parent-label": "{parent-siblings} 内含 {number-siblings} 个符号（共 {total-siblings} 个）包含一个符号 | {parent-siblings} 内含 {number-siblings} 个符号（共 {total-siblings} 个）包含 {number-parent} 个符号",
     "reset-filter": "还原过滤条件"
   },
   "navigator": {
-    "title": "文档 导航器",
-    "open-navigator": "打开文档 导航器",
-    "close-navigator": "关闭文档 导航器",
+    "title": "文档导航器",
+    "open-navigator": "打开文档导航器",
+    "close-navigator": "关闭文档导航器",
     "no-results": "未找到结果。",
     "no-children": "无可用数据。",
     "error-fetching": "获取数据时出错。",
@@ -148,8 +157,8 @@
     "default": "默认",
     "minimum": "最小值",
     "maximum": "最大值",
-    "possible-types": "可能类型",
-    "possible-values": "可能值"
+    "possible-types": "类型 | 可能类型",
+    "possible-values": "值 | 可能值"
   },
   "content-type": "内容类型：{value}",
   "read-only": "只读",
@@ -169,8 +178,8 @@
       "end": "删除线文本结束"
     },
     "code": {
-      "start": "start of code block",
-      "end": "end of code block"
+      "start": "代码块开头",
+      "end": "代码块结尾"
     },
     "skip-navigation": "跳过导航"
   },
@@ -181,7 +190,13 @@
     "search": "搜索"
   },
   "formats": {
-    "parenthesis": "（{content}）",
-    "colon": "{content}："
+    "parenthesis": "({content})",
+    "colon": "{content}： "
+  },
+  "quicknav": {
+    "button": {
+      "label": "打开快速导航",
+      "title": "点按或键入 / 进行快速导航"
+    }
   }
 }

--- a/src/lang/locales/zh-CN.json
+++ b/src/lang/locales/zh-CN.json
@@ -127,7 +127,7 @@
     "add-tag": "添加标签",
     "tag-select-remove": "标签。选择以从列表中移除。",
     "navigate": "若要导航符号，请按下上箭头、下箭头、左箭头或右箭头。",
-    "siblings-label": "{Parent-siblings} 内含 {number-siblings} 个符号（共 {total-siblings} 个）",
+    "siblings-label": "{parent-siblings} 内含 {number-siblings} 个符号（共 {total-siblings} 个）",
     "parent-label": "{parent-siblings} 内含 {number-siblings} 个符号（共 {total-siblings} 个）包含一个符号 | {parent-siblings} 内含 {number-siblings} 个符号（共 {total-siblings} 个）包含 {number-parent} 个符号",
     "reset-filter": "还原过滤条件"
   },


### PR DESCRIPTION
Bug/issue #108904481, if applicable: 

## Summary

Add translated strings

## Dependencies

NA

## Testing

Steps:
1. Add the following to `theme-settings.json` file at public folder
```json
{
  "features": {
    "docs": {
      "i18n": {
        "enable": true
      }
    }
  }
}
```
3. Run `npm run serve`
4. Go to the bottom of the page and change the language in the locale selector to Chinese and Japanese
5. Assert that strings are correct

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
