### PR TITLE
Remove accidental leading whitespace for some captions

### DIFF
--- a/src/components/ContentNode/FigureCaption.vue
+++ b/src/components/ContentNode/FigureCaption.vue
@@ -10,7 +10,12 @@
 
 <template>
   <figcaption class="caption" :class="{ centered }">
-    <strong v-if="title">{{ title }}</strong>&nbsp;<slot />
+    <template v-if="title">
+      <strong>{{ title }}</strong>&nbsp;<slot />
+    </template>
+    <template v-else>
+      <slot />
+    </template>
   </figcaption>
 </template>
 

--- a/tests/unit/components/ContentNode/FigureCaption.spec.js
+++ b/tests/unit/components/ContentNode/FigureCaption.spec.js
@@ -18,14 +18,16 @@ describe('FigureCaption', () => {
     const wrapper = shallowMount(FigureCaption, { propsData, slots });
 
     expect(wrapper.is('figcaption')).toBe(true);
-    expect(wrapper.text()).toMatch(/Figure 1\sBlah/);
+    expect(wrapper.text()).toBe('Figure 1\u00a0Blah');
   });
+
   it('renders a <figcaption> with slot content only', () => {
     const slots = { default: '<p>Blah</p>' };
     const wrapper = shallowMount(FigureCaption, { slots });
 
     expect(wrapper.is('figcaption')).toBe(true);
     expect(wrapper.text()).toBe('Blah');
+    expect(wrapper.text()).not.toBe('\u00a0Blah');
   });
 
   it('renders a <figcaption> centered', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 109060293

## Summary

Fixes an issue where captions without titles have an unnecessary leading whitespace character, which may slightly impact the alignment of the text.

## Testing

Steps:
1. Verify that captions without titles don't have leading whitespace anymore
2. Verify that captions with titles still have a whitespace between the caption title and content.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
