### PR TITLE
Fix param formatting with complex attributes

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -89,7 +89,7 @@ export default {
       let closeParenTokenIndex = null;
       let closeParenCharIndex = null;
       let numUnclosedParens = 0;
-      let identifierTokenIndex = null;
+      let firstKeywordTokenIndex = null;
 
       // loop through every declaration token
       while (i < tokens.length) {
@@ -99,14 +99,14 @@ export default {
         const prevToken = tokens[i - 1];
         const nextToken = tokens[i + 1];
 
-        // keep track of the index of the first identifier token
-        if (!identifierTokenIndex && token.kind === TokenKind.identifier) {
-          identifierTokenIndex = i;
+        // keep track of the index of the first keyword token
+        if (!firstKeywordTokenIndex && token.kind === TokenKind.keyword) {
+          firstKeywordTokenIndex = i;
         }
 
-        // loop through the token text to look for "(" and ")" characters once
-        // we've already encountered the symbol identifier
-        if (identifierTokenIndex !== null) {
+        // loop through the token text to look for "(" and ")" characters after
+        // we've already encountered the first keyword
+        if (firstKeywordTokenIndex !== null) {
           const tokenLength = (token.text || '').length;
           // eslint-disable-next-line no-plusplus
           for (let k = 0; k < tokenLength; k++) {

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -89,6 +89,7 @@ export default {
       let closeParenTokenIndex = null;
       let closeParenCharIndex = null;
       let numUnclosedParens = 0;
+      let identifierTokenIndex = null;
 
       // loop through every declaration token
       while (i < tokens.length) {
@@ -98,31 +99,39 @@ export default {
         const prevToken = tokens[i - 1];
         const nextToken = tokens[i + 1];
 
-        // loop through the token text to look for "(" and ")" characters
-        const tokenLength = (token.text || '').length;
-        // eslint-disable-next-line no-plusplus
-        for (let k = 0; k < tokenLength; k++) {
-          if (token.text.charAt(k) === '(') {
-            numUnclosedParens += 1;
-            // keep track of the token/character position of the first "("
-            if (openParenCharIndex == null) {
-              openParenCharIndex = k;
-              openParenTokenIndex = i;
-            }
-          }
+        // keep track of the index of the first identifier token
+        if (!identifierTokenIndex && token.kind === TokenKind.identifier) {
+          identifierTokenIndex = i;
+        }
 
-          if (token.text.charAt(k) === ')') {
-            numUnclosedParens -= 1;
-            // if this ")" balances out the number of "(" characters that have
-            // been seen, this is the one that pairs up with the first one
-            if (
-              openParenTokenIndex !== null
-              && closeParenTokenIndex == null
-              && numUnclosedParens === 0
-            ) {
-              closeParenCharIndex = k;
-              closeParenTokenIndex = i;
-              break;
+        // loop through the token text to look for "(" and ")" characters once
+        // we've already encountered the symbol identifier
+        if (identifierTokenIndex !== null) {
+          const tokenLength = (token.text || '').length;
+          // eslint-disable-next-line no-plusplus
+          for (let k = 0; k < tokenLength; k++) {
+            if (token.text.charAt(k) === '(') {
+              numUnclosedParens += 1;
+              // keep track of the token/character position of the first "("
+              if (openParenCharIndex == null) {
+                openParenCharIndex = k;
+                openParenTokenIndex = i;
+              }
+            }
+
+            if (token.text.charAt(k) === ')') {
+              numUnclosedParens -= 1;
+              // if this ")" balances out the number of "(" characters that have
+              // been seen, this is the one that pairs up with the first one
+              if (
+                openParenTokenIndex !== null
+                && closeParenTokenIndex == null
+                && numUnclosedParens === 0
+              ) {
+                closeParenCharIndex = k;
+                closeParenTokenIndex = i;
+                break;
+              }
             }
           }
         }

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -876,7 +876,7 @@ func foo(bar: @escaping () -> ()) -> Int`,
     );
   });
 
-  it('indents params properly for symbols prefixed with attributes which take arguments', () => {
+  it('indents params properly for functions prefixed with attributes which take arguments', () => {
     const tokens = [
       {
         kind: TokenKind.attribute,
@@ -943,7 +943,7 @@ func foo(bar: @escaping () -> ()) -> Int`,
     // Before:
     // @objc(quxA:B:) func quxqux(a: Int, b: Int) -> Int
     //
-    // After
+    // After:
     // @objc(quxA:B:)
     // func quxqux(
     //     a: Int,
@@ -957,6 +957,78 @@ func quxqux(
     a: Int,
     b: Int
 ) -> Int`,
+    );
+  });
+
+  it('indents params properly for initializers prefixed with attributes which take arguments', () => {
+    const tokens = [
+      {
+        kind: TokenKind.attribute,
+        text: '@objc',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(initWithA:B:) ',
+      },
+      {
+        kind: TokenKind.keyword,
+        text: 'init',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: 'a',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+      {
+        kind: TokenKind.text,
+        text: ', ',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: 'b',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+      {
+        kind: TokenKind.text,
+        text: ')',
+      },
+    ];
+
+    // Before:
+    // @objc(initWithA:B:) init(a: Int, b: Int)
+    //
+    // After:
+    // @objc(initWithA:B:)
+    // init(
+    //    a: Int,
+    //    b: Int
+    // )
+    const wrapper = mountWithTokens(tokens);
+    const tokenComponents = wrapper.findAll(Token);
+    expect(getText(tokenComponents)).toBe(
+`@objc(initWithA:B:)
+init(
+    a: Int,
+    b: Int
+)`,
     );
   });
 });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -875,4 +875,88 @@ func foo(bar: @escaping () -> ()) -> Int`,
 )`,
     );
   });
+
+  it('indents params properly for symbols prefixed with attributes which take arguments', () => {
+    const tokens = [
+      {
+        kind: TokenKind.attribute,
+        text: '@objc',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(quxA:B:) ',
+      },
+      {
+        kind: TokenKind.keyword,
+        text: 'func',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.identifier,
+        text: 'quxqux',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: 'a',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+      {
+        kind: TokenKind.text,
+        text: ', ',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: 'b',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+      {
+        kind: TokenKind.text,
+        text: ') -> ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+    ];
+
+    // Before:
+    // @objc(quxA:B:) func quxqux(a: Int, b: Int) -> Int
+    //
+    // After
+    // @objc(quxA:B:)
+    // func quxqux(
+    //     a: Int,
+    //     b: Int
+    // ) -> Int
+    const wrapper = mountWithTokens(tokens);
+    const tokenComponents = wrapper.findAll(Token);
+    expect(getText(tokenComponents)).toBe(
+`@objc(quxA:B:)
+func quxqux(
+    a: Int,
+    b: Int
+) -> Int`,
+    );
+  });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 108167163

## Summary

Fixes an issue where attributes are being incorrectly indented.

This happens because the existing logic for indenting parameters simply looks for the first opening `(` character to indent the first param of a multi-param symbol—this doesn't work when a symbol is prefixed with an attribute that takes arguments, since it also uses parenthesis.

To fix it—the logic has been updated to look for the first `(` character _that follows the first keyword token_.

**Example:**

```swift
// original declaration
@objc(quxA:B:) func quxqux(a: Int, b: Int) -> Int

// formatted declaration before this fix
@objc(quxA:B:
)
    func quxqux(a: Int,
    b: Int) -> Int

// formatted declaration after this fix
@objc(quxA:B:)
func quxqux(
    a: Int,
    b: Int
) -> Int
```

**Notes:**
The diff might be a little hard to read, but I basically just added a variable to track the index of the first keyword token and then wrapped an existing for-loop in an if-check that makes sure that variable is not null.

## Testing

Steps:
1. Build this branch with `npm run build`
2. Download/unzip example Swift package [AttributeExamples.zip](https://github.com/apple/swift-docc-render/files/11456549/AttributeExamples.zip)
3. Run `env DOCC_HTML_DIR=/path/to/dist swift package --disable-sandbox preview-documentation --target AttributeExamples`
4. Open http://localhost:8080/documentation/attributeexamples/exampleusingcomplexattributes/quxqux(a:b:) and verify that the formatted declaration matches the expectation from the example above.
5. Open http://localhost:8080/documentation/attributeexamples/exampleusingcomplexattributes/init(a:b:) and verify that the formatted initializer looks right as well.
6. Check out other declaration content to verify that there are no regressions with the formatting.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
