### PR TITLE
[5.9] Remove accidental leading whitespace for certain captions

### DIFF
--- a/src/components/ContentNode/FigureCaption.vue
+++ b/src/components/ContentNode/FigureCaption.vue
@@ -10,7 +10,12 @@
 
 <template>
   <figcaption class="caption" :class="{ centered }">
-    <strong v-if="title">{{ title }}</strong>&nbsp;<slot />
+    <template v-if="title">
+      <strong>{{ title }}</strong>&nbsp;<slot />
+    </template>
+    <template v-else>
+      <slot />
+    </template>
   </figcaption>
 </template>
 

--- a/tests/unit/components/ContentNode/FigureCaption.spec.js
+++ b/tests/unit/components/ContentNode/FigureCaption.spec.js
@@ -18,14 +18,16 @@ describe('FigureCaption', () => {
     const wrapper = shallowMount(FigureCaption, { propsData, slots });
 
     expect(wrapper.is('figcaption')).toBe(true);
-    expect(wrapper.text()).toMatch(/Figure 1\sBlah/);
+    expect(wrapper.text()).toBe('Figure 1\u00a0Blah');
   });
+
   it('renders a <figcaption> with slot content only', () => {
     const slots = { default: '<p>Blah</p>' };
     const wrapper = shallowMount(FigureCaption, { slots });
 
     expect(wrapper.is('figcaption')).toBe(true);
     expect(wrapper.text()).toBe('Blah');
+    expect(wrapper.text()).not.toBe('\u00a0Blah');
   });
 
   it('renders a <figcaption> centered', () => {


### PR DESCRIPTION
- **Explanation:** Fixes issue where captions without titles have leading whitespace character when they shouldn't.
- **Scope:** Impacts pages with figure captions that have no titles
- **Issue:** rdar://109060293
- **Risk:** Low, minor HTML layout adjustment
- **Testing:** Updated unit tests and visually inspected alignment of captions without titles.
- **Reviewer:** @dobromir-hristov
- **Original PR:** #655 