### PR TITLE
Enable screen readers to skip 'main' in IDE mode

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -13,7 +13,11 @@
     class="doc-topic"
     :class="{ 'with-on-this-page': enableOnThisPageNav && isOnThisPageNavVisible }"
   >
-    <main class="main" id="main" role="main" tabindex="0">
+    <component
+      :is="isTargetIDE ? 'div' : 'main'"
+      :role="isTargetIDE? 'none' : 'main'"
+      class="main" id="main" tabindex="0"
+    >
       <DocumentationHero
         :role="role"
         :enhanceBackground="enhanceBackground"
@@ -135,7 +139,7 @@
         </template>
       </div>
       <BetaLegalText v-if="!isTargetIDE && hasBetaContent" />
-    </main>
+    </component>
     <div aria-live="polite" class="visuallyhidden">
       {{ $t('documentation.current-page', { title: pageTitle }) }}
     </div>

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -15,7 +15,7 @@
   >
     <component
       :is="isTargetIDE ? 'div' : 'main'"
-      :role="isTargetIDE? 'none' : 'main'"
+      :role="isTargetIDE ? 'none' : 'main'"
       class="main" id="main" tabindex="0"
     >
       <DocumentationHero


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://107573378 

## Summary
In IDE mode, the content in the `<main>` tag is the only content visible. VO would read "you are currently on a main", which creates an extra layer for users to step into before reading the actual content of the page.
This PR allows screen readers to not announce a `main` in IDE mode.

## Testing
Steps:
1. Manual testing

