### PR TITLE
[5.9] Fix param formatting with complex attributes

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -89,6 +89,7 @@ export default {
       let closeParenTokenIndex = null;
       let closeParenCharIndex = null;
       let numUnclosedParens = 0;
+      let firstKeywordTokenIndex = null;
 
       // loop through every declaration token
       while (i < tokens.length) {
@@ -98,31 +99,39 @@ export default {
         const prevToken = tokens[i - 1];
         const nextToken = tokens[i + 1];
 
-        // loop through the token text to look for "(" and ")" characters
-        const tokenLength = (token.text || '').length;
-        // eslint-disable-next-line no-plusplus
-        for (let k = 0; k < tokenLength; k++) {
-          if (token.text.charAt(k) === '(') {
-            numUnclosedParens += 1;
-            // keep track of the token/character position of the first "("
-            if (openParenCharIndex == null) {
-              openParenCharIndex = k;
-              openParenTokenIndex = i;
-            }
-          }
+        // keep track of the index of the first keyword token
+        if (!firstKeywordTokenIndex && token.kind === TokenKind.keyword) {
+          firstKeywordTokenIndex = i;
+        }
 
-          if (token.text.charAt(k) === ')') {
-            numUnclosedParens -= 1;
-            // if this ")" balances out the number of "(" characters that have
-            // been seen, this is the one that pairs up with the first one
-            if (
-              openParenTokenIndex !== null
-              && closeParenTokenIndex == null
-              && numUnclosedParens === 0
-            ) {
-              closeParenCharIndex = k;
-              closeParenTokenIndex = i;
-              break;
+        // loop through the token text to look for "(" and ")" characters after
+        // we've already encountered the first keyword
+        if (firstKeywordTokenIndex !== null) {
+          const tokenLength = (token.text || '').length;
+          // eslint-disable-next-line no-plusplus
+          for (let k = 0; k < tokenLength; k++) {
+            if (token.text.charAt(k) === '(') {
+              numUnclosedParens += 1;
+              // keep track of the token/character position of the first "("
+              if (openParenCharIndex == null) {
+                openParenCharIndex = k;
+                openParenTokenIndex = i;
+              }
+            }
+
+            if (token.text.charAt(k) === ')') {
+              numUnclosedParens -= 1;
+              // if this ")" balances out the number of "(" characters that have
+              // been seen, this is the one that pairs up with the first one
+              if (
+                openParenTokenIndex !== null
+                && closeParenTokenIndex == null
+                && numUnclosedParens === 0
+              ) {
+                closeParenCharIndex = k;
+                closeParenTokenIndex = i;
+                break;
+              }
             }
           }
         }

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -875,4 +875,160 @@ func foo(bar: @escaping () -> ()) -> Int`,
 )`,
     );
   });
+
+  it('indents params properly for functions prefixed with attributes which take arguments', () => {
+    const tokens = [
+      {
+        kind: TokenKind.attribute,
+        text: '@objc',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(quxA:B:) ',
+      },
+      {
+        kind: TokenKind.keyword,
+        text: 'func',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.identifier,
+        text: 'quxqux',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: 'a',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+      {
+        kind: TokenKind.text,
+        text: ', ',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: 'b',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+      {
+        kind: TokenKind.text,
+        text: ') -> ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+    ];
+
+    // Before:
+    // @objc(quxA:B:) func quxqux(a: Int, b: Int) -> Int
+    //
+    // After:
+    // @objc(quxA:B:)
+    // func quxqux(
+    //     a: Int,
+    //     b: Int
+    // ) -> Int
+    const wrapper = mountWithTokens(tokens);
+    const tokenComponents = wrapper.findAll(Token);
+    expect(getText(tokenComponents)).toBe(
+`@objc(quxA:B:)
+func quxqux(
+    a: Int,
+    b: Int
+) -> Int`,
+    );
+  });
+
+  it('indents params properly for initializers prefixed with attributes which take arguments', () => {
+    const tokens = [
+      {
+        kind: TokenKind.attribute,
+        text: '@objc',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(initWithA:B:) ',
+      },
+      {
+        kind: TokenKind.keyword,
+        text: 'init',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: 'a',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+      {
+        kind: TokenKind.text,
+        text: ', ',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: 'b',
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+      {
+        kind: TokenKind.text,
+        text: ')',
+      },
+    ];
+
+    // Before:
+    // @objc(initWithA:B:) init(a: Int, b: Int)
+    //
+    // After:
+    // @objc(initWithA:B:)
+    // init(
+    //    a: Int,
+    //    b: Int
+    // )
+    const wrapper = mountWithTokens(tokens);
+    const tokenComponents = wrapper.findAll(Token);
+    expect(getText(tokenComponents)).toBe(
+`@objc(initWithA:B:)
+init(
+    a: Int,
+    b: Int
+)`,
+    );
+  });
 });


### PR DESCRIPTION
- **Explanation:** Fixes issue where attributes with arguments break the indentation formatting of multi-parameter symbols.
- **Scope:** Impacts any Swift function/initializer/macro/subscript taking multiple parameters that is prefixed with an attribute that takes arguments.
- **Issue:** rdar://108167163
- **Risk:** Medium, small JS logic change that impacts all Swift declarations
- **Testing:** Added unit tests and manually tested various kinds of Swift declarations that have attributes and varying number of parameters.
- **Reviewer:** @dobromir-hristov 
- **Original PR:** #656 