### PR TITLE
It prevents breaking words inside header cell in an HTML tables.

### DIFF
--- a/src/components/ContentNode/Table.vue
+++ b/src/components/ContentNode/Table.vue
@@ -44,6 +44,10 @@ table {
 /deep/ {
   th {
     font-weight: $font-weight-semibold;
+
+    > p {
+      word-break: keep-all;
+    }
   }
 
   td,

--- a/src/components/ContentNode/Table.vue
+++ b/src/components/ContentNode/Table.vue
@@ -45,6 +45,7 @@ table {
   th {
     font-weight: $font-weight-semibold;
     word-break: keep-all;
+    hyphens: auto;
   }
 
   td,

--- a/src/components/ContentNode/Table.vue
+++ b/src/components/ContentNode/Table.vue
@@ -44,10 +44,7 @@ table {
 /deep/ {
   th {
     font-weight: $font-weight-semibold;
-
-    > p {
-      word-break: keep-all;
-    }
+    word-break: keep-all;
   }
 
   td,


### PR DESCRIPTION
Bug/issue #107874086, if applicable: 

## Summary

It prevents breaking words inside header cell in an HTML tables.
In Japanese alphabet, words were being broken making reading difficult.

### Before
<img width="967" alt="Screenshot 2023-05-12 at 19 23 43" src="https://github.com/apple/swift-docc-render/assets/8567677/b6af86ab-525f-4b11-88d4-17cde236293b">

### After
<img width="1035" alt="Screenshot 2023-05-12 at 19 23 30" src="https://github.com/apple/swift-docc-render/assets/8567677/7967e165-2fdc-47fd-b7ca-7fe8db3f5df2">

## Dependencies

NA

## Testing

[SlothCreatori18n.doccarchive.zip](https://github.com/apple/swift-docc-render/files/11466531/SlothCreatori18n.doccarchive.zip)

Steps:
1. Use the doccarchive attached above
2. Go to http://localhost:8080/ja-JP/documentation/slothcreator
3. Assert that the table displayed at Overview in Japanese don't break their words 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
