### PR TITLE
Fix extra empty line issue on tutorial

### DIFF
--- a/src/utils/syntax-highlight.js
+++ b/src/utils/syntax-highlight.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -192,7 +192,7 @@ function duplicateMultilineNode(element) {
 
   // wrap each new line with the current element's class
   const result = getLines(element.innerHTML)
-    .reduce((all, lineText) => `${all}<span class="${className}">${lineText || '\n\n'}</span>\n`, '');
+    .reduce((all, lineText) => `${all}<span class="${className}">${lineText || ''}</span>\n`, '');
 
   // return a list of newly wrapped HTML elements
   return htmlToElements(result.trim());

--- a/tests/unit/utils/syntax-highlight.spec.js
+++ b/tests/unit/utils/syntax-highlight.spec.js
@@ -107,17 +107,11 @@ describe("syntax-highlight", () => {
     expect(sanitizedCode).toMatchInlineSnapshot(`
       <span class="syntax-keyword">let</span> multiline = <span class="syntax-string">""</span><span class="syntax-string">"</span>
       <span class="syntax-string">Needs</span>
-      <span class="syntax-string">
-
-      </span>
+      <span class="syntax-string"></span>
       <span class="syntax-string">Spaces</span>
-      <span class="syntax-string">
-
-      </span>
+      <span class="syntax-string"></span>
       <span class="syntax-string">Between</span>
-      <span class="syntax-string">
-
-      </span>
+      <span class="syntax-string"></span>
       <span class="syntax-string">Lines</span>
       <span class="syntax-string">"</span><span class="syntax-string">""</span>
     `);


### PR DESCRIPTION
Bug/issue #, if applicable: 

Close #662

## Summary

See the full context on #622

Another way to fix the problem is changing the logic here `src/components/ContentNode/CodeListing.vue`

> Note:
> After this change when we try to copy the content of `CodeListing`, we will miss the "\n"

<img width="346" alt="image" src="https://github.com/apple/swift-docc-render/assets/43724855/7001face-7124-48cb-a7a8-f11bd81246e4">

```
// Expected copy result
/*
S

A
*/

// Actual copy result
/*
S
A
*/
```

A later fix to implement a clipboard button may help lift the issue.

https://github.com/apple/swift-docc-render/issues/449

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
