### PR TITLE
[5.9] It prevents breaking words inside header cell in an HTML tables

### DIFF
--- a/src/components/ContentNode/Table.vue
+++ b/src/components/ContentNode/Table.vue
@@ -45,6 +45,7 @@ table {
   th {
     font-weight: $font-weight-semibold;
     word-break: keep-all;
+    hyphens: auto;
   }
 
   td,

--- a/src/components/ContentNode/Table.vue
+++ b/src/components/ContentNode/Table.vue
@@ -44,6 +44,7 @@ table {
 /deep/ {
   th {
     font-weight: $font-weight-semibold;
+    word-break: keep-all;
   }
 
   td,


### PR DESCRIPTION
- **Explanation:** It prevents breaking words inside header cell in an HTML tables
- **Scope:** Tables
- **Issue:** rdar://107874086
- **Risk:** Low, only config change
- **Testing:** Verifies that table title don't allow words to break
- **Reviewer:** @hqhhuang @dobromir-hristov 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/661