### PR TITLE
"Read only" ❌ "Read-only" ✅

### DIFF
--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -161,7 +161,7 @@
     "possible-values": "Value | Possible Values"
   },
   "content-type": "Content-Type: {value}",
-  "read-only": "Read only",
+  "read-only": "Read-only",
   "error": {
     "unknown": "An unknown error occurred.",
     "image": "Image failed to load"


### PR DESCRIPTION
Bug/issue #, if applicable: 107896158

## Summary

A minor change to use the English phrase "Read-only" instead of "Read only"

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (text string constant change only)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
