### PR TITLE
[5.9] "Read only" ❌ "Read-only" ✅

### DIFF
--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -161,7 +161,7 @@
     "possible-values": "Value | Possible Values"
   },
   "content-type": "Content-Type: {value}",
-  "read-only": "Read only",
+  "read-only": "Read-only",
   "error": {
     "unknown": "An unknown error occurred.",
     "image": "Image failed to load"


### PR DESCRIPTION
- **Explanation:** Updates text from "Read only" to "Read-only"
- **Scope:** Impacts docs for REST APIs with read-only object fields
- **Issue:** rdar://107896158
- **Risk:** Low, only config change
- **Testing:** Verified that new string renders where expected for a REST API
- **Reviewer:** @dobromir-hristov and @marinaaisa 
- **Original PR:** #668 