### PR TITLE
Fix regression with Objective-C api whitespace formatting

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -196,7 +196,7 @@ export default {
   async mounted() {
     if (this.language === Language.objectiveC.key.api) {
       await this.$nextTick();
-      indentDeclaration(this.$refs.code, this.language);
+      indentDeclaration(this.$refs.code.$el, this.language);
     }
     if (hasMultipleLines(this.$refs.declarationGroup)) this.hasMultipleLines = true;
   },

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -109,7 +109,7 @@ describe('DeclarationSource', () => {
     await flushPromises();
     expect(indentDeclaration).toHaveBeenCalledTimes(1);
     expect(indentDeclaration)
-      .toHaveBeenCalledWith(wrapper.find({ ref: 'code' }).vm, Language.objectiveC.key.api);
+      .toHaveBeenCalledWith(wrapper.find({ ref: 'code' }).vm.$el, Language.objectiveC.key.api);
     expect(callStack).toEqual(['indentDeclaration', 'hasMultipleLines']);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 109681482

## Summary

Fixes a regression that was introduced in #564 where multi-parameter Objective-C functions/initializers are not being formatted onto newlines anymore.

This happened because the code relies on a reference to a DOM node, and that PR introduced an additional layer of indirection where the reference is now a Vue component, requiring the need to also call `.$el` on that updated ref.

\cc @ethan-kusters 

## Testing

Steps:
1. Find any Objective-C symbol that has multiple parameters
2. Verify that the symbol is now being broken onto multiple lines instead of being on a single line

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
