### PR TITLE
[5.9] Fix onThisPageNav top spacing

### DIFF
--- a/src/components/DocumentationTopic/OnThisPageStickyContainer.vue
+++ b/src/components/DocumentationTopic/OnThisPageStickyContainer.vue
@@ -24,7 +24,7 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .OnThisPageStickyContainer {
-  $top: $nav-height + rem(10px);
+  $top: $nav-height + rem(13px);
   margin-top: $contenttable-spacing-single-side;
   position: sticky;
   top: $top;

--- a/src/components/OnThisPageNav.vue
+++ b/src/components/OnThisPageNav.vue
@@ -132,6 +132,10 @@ export default {
 ul {
   list-style-type: none;
   margin: 0;
+
+  li:first-child .base-link {
+    margin-top: 0;
+  }
 }
 
 .parent-item .base-link {
@@ -142,7 +146,7 @@ ul {
   color: var(--color-figure-gray-secondary);
   @include font-styles(body-reduced-tight);
   display: inline-block;
-  margin-bottom: 5px;
+  margin: 5px 0;
   transition: color 0.15s ease-in;
   max-width: 100%;
 }


### PR DESCRIPTION
- **Explanation:** Fixes the spacings on the OnThisPage Nav component, so they align better with the Navigator
- **Scope:** Impacts docs pages with enabled OnThisPageNav
- **Issue:** rdar://107572361
- **Risk:** Low, css only
- **Testing:** Manually verify in browser
- **Reviewer:** @mportiz08 @SamLanier 
- **Original PR:** #586 