### PR TITLE
[5.9] Fix regression with Objective-C api whitespace formatting

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -196,7 +196,7 @@ export default {
   async mounted() {
     if (this.language === Language.objectiveC.key.api) {
       await this.$nextTick();
-      indentDeclaration(this.$refs.code, this.language);
+      indentDeclaration(this.$refs.code.$el, this.language);
     }
     if (hasMultipleLines(this.$refs.declarationGroup)) this.hasMultipleLines = true;
   },

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -109,7 +109,7 @@ describe('DeclarationSource', () => {
     await flushPromises();
     expect(indentDeclaration).toHaveBeenCalledTimes(1);
     expect(indentDeclaration)
-      .toHaveBeenCalledWith(wrapper.find({ ref: 'code' }).vm, Language.objectiveC.key.api);
+      .toHaveBeenCalledWith(wrapper.find({ ref: 'code' }).vm.$el, Language.objectiveC.key.api);
     expect(callStack).toEqual(['indentDeclaration', 'hasMultipleLines']);
   });
 });


### PR DESCRIPTION
- **Explanation:** Fixes regression where ObjC APIs no longer get the appropriate whitespace formatting
- **Scope:** Impacts pages for any multi-parameter ObjC initializers/functions
- **Issue:** rdar://109681482
- **Risk:** Low, single line JS change to property access (one additional nesting level needed)
- **Testing:** Verified that multi-param ObjC APIs now get broken onto newlines and indented properly, as before
- **Reviewer:** @dobromir-hristov and @marinaaisa 
- **Original PR:** #670 