### PR TITLE
Add support for localized font families

### DIFF
--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -18,8 +18,9 @@ html {
   @include inTargetWeb {
     font: var(--typography-html-font, $body-font-size $font-content);
   }
+  /// The quotes CSS property sets how the browser should render quotation marks
+  /// added through a CSS content field or the HTML q element
   quotes: "“" "”";
-
   @each $lang, $quotes in $localizedQuotes {
     &:lang(#{$lang}) {
       quotes: $quotes;

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -18,7 +18,12 @@ html {
   @include inTargetWeb {
     font: var(--typography-html-font, $body-font-size $font-content);
   }
-  quotes: "“" "”";
+
+  @each $lang, $quotes in $localizedQuotes {
+    :lang(#{$lang}) {
+      quotes: $quotes;
+    }
+  }
 }
 
 body {

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -18,6 +18,7 @@ html {
   @include inTargetWeb {
     font: var(--typography-html-font, $body-font-size $font-content);
   }
+  quotes: "“" "”";
 
   @each $lang, $quotes in $localizedQuotes {
     :lang(#{$lang}) {

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -21,7 +21,7 @@ html {
   quotes: "“" "”";
 
   @each $lang, $quotes in $localizedQuotes {
-    :lang(#{$lang}) {
+    &:lang(#{$lang}) {
       quotes: $quotes;
     }
   }

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -85,7 +85,7 @@ $suggest-lang-height: 52px;
 // Localized Quotes
 $localizedQuotes: (
   ja-JP: "「" "」",
-);
+) !default;
 
 // Localized Fonts
-$localizedFonts: ()
+$localizedFonts: () !default;

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -84,7 +84,5 @@ $suggest-lang-height: 52px;
 
 // Localized Quotes
 $localizedQuotes: (
-  en-US: "“" "”",
-  zh-CN: "“" "”",
   ja-JP: "「" "」",
 );

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -86,3 +86,6 @@ $suggest-lang-height: 52px;
 $localizedQuotes: (
   ja-JP: "「" "」",
 );
+
+// Localized Fonts
+$localizedFonts: ()

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -81,3 +81,10 @@ $on-this-page-aside-width: 192px;
 
 // Suggest Lang
 $suggest-lang-height: 52px;
+
+// Localized Quotes
+$localizedQuotes: (
+  en-US: "“" "”",
+  zh-CN: "“" "”",
+  ja-JP: "「" "」",
+);

--- a/src/styles/core/typography/_font-style-utils.scss
+++ b/src/styles/core/typography/_font-style-utils.scss
@@ -60,6 +60,16 @@ $font-weight-bold: 700 !default;
   } @else {
     @warn 'The font style `#{$font-style-name}` is not defined.';
   }
+  //
+  // Add support for localized font families
+  //
+  @if ($localizedFonts) {
+    @each $lang, $fonts in $localizedFonts {
+      :lang(#{$lang}) & {
+        font-family: $fonts;
+      }
+    }
+  }
 }
 
 //


### PR DESCRIPTION
Bug/issue #108129110, if applicable: 

## Summary

Add support for localized font families

## Dependencies

NA

## Testing

Steps:
1. Make sure current fonts look correct 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
