### PR TITLE
[5.9] Add support for dateTimeFormats in VueI18n

### DIFF
--- a/src/setup-utils/SwiftDocCRenderi18n.js
+++ b/src/setup-utils/SwiftDocCRenderi18n.js
@@ -12,9 +12,10 @@ import VueI18n from 'vue-i18n';
 import * as lang from 'theme/lang/index.js';
 
 export default function createi18nInstance(config = lang) {
-  const { defaultLocale, messages } = config;
+  const { defaultLocale, messages, dateTimeFormats = {} } = config;
 
   const i18n = new VueI18n({
+    dateTimeFormats,
     locale: defaultLocale,
     fallbackLocale: defaultLocale,
     messages,


### PR DESCRIPTION
- **Explanation:** Add support for dateTimeFormats in VueI18n
- **Scope:** i18n settings
- **Issue:** rdar://09731672
- **Risk:** Small
- **Testing:** Verified manually in browser
- **Reviewer:** @hqhhuang 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/678