### PR TITLE
[5.9] Add support for localized font families

### DIFF
--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -18,7 +18,14 @@ html {
   @include inTargetWeb {
     font: var(--typography-html-font, $body-font-size $font-content);
   }
+  /// The quotes CSS property sets how the browser should render quotation marks
+  /// added through a CSS content field or the HTML q element
   quotes: "“" "”";
+  @each $lang, $quotes in $localizedQuotes {
+    &:lang(#{$lang}) {
+      quotes: $quotes;
+    }
+  }
 }
 
 body {

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -81,3 +81,11 @@ $on-this-page-aside-width: 192px;
 
 // Suggest Lang
 $suggest-lang-height: 52px;
+
+// Localized Quotes
+$localizedQuotes: (
+  ja-JP: "「" "」",
+) !default;
+
+// Localized Fonts
+$localizedFonts: () !default;

--- a/src/styles/core/typography/_font-style-utils.scss
+++ b/src/styles/core/typography/_font-style-utils.scss
@@ -60,6 +60,16 @@ $font-weight-bold: 700 !default;
   } @else {
     @warn 'The font style `#{$font-style-name}` is not defined.';
   }
+  //
+  // Add support for localized font families
+  //
+  @if ($localizedFonts) {
+    @each $lang, $fonts in $localizedFonts {
+      :lang(#{$lang}) & {
+        font-family: $fonts;
+      }
+    }
+  }
 }
 
 //


### PR DESCRIPTION
- **Explanation:** Add support for dateTimeFormats in VueI18n
- **Scope:** i18n settings
- **Issue:** rdar://108129110
- **Risk:** Small
- **Testing:** Verified manually in browser
- **Reviewer:** @mportiz08 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/677