### PR TITLE
Don't override monospaced font with localized body text font variant

### DIFF
--- a/src/styles/core/typography/_font-style-utils.scss
+++ b/src/styles/core/typography/_font-style-utils.scss
@@ -57,18 +57,21 @@ $font-weight-bold: 700 !default;
       }
       $prevAttributes: $attributes;
     }
-  } @else {
-    @warn 'The font style `#{$font-style-name}` is not defined.';
-  }
-  //
-  // Add support for localized font families
-  //
-  @if ($localizedFonts) {
-    @each $lang, $fonts in $localizedFonts {
-      :lang(#{$lang}) & {
-        font-family: $fonts;
+
+    //
+    // Add support for localized font families
+    //
+    // Note: localized monospace font families are not yet supported
+    $-font-family: map-deep-get($font-attributes, (map-get($styles, large), font-family));
+    @if ($localizedFonts and $-font-family != $font-mono) {
+      @each $lang, $fonts in $localizedFonts {
+        :lang(#{$lang}) & {
+          font-family: $fonts;
+        }
       }
     }
+  } @else {
+    @warn 'The font style `#{$font-style-name}` is not defined.';
   }
 }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 110021706

## Summary

This is a slight update to #677 to fix an issue where localized variants of normal body text fonts are mistakenly overriding the monospaced font variant, as we don't support localized monospaced variants (yet).

## Testing

Steps:
1. Configure a localized font for body text
2. View a page with both body text and code-voice text
3. Verify that only the body text gets the localized font and not the code-voice text

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (sass-only change, no unit infrastructure for sass code)
- [X] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
