### PR TITLE
Update reference to renamed font style

### DIFF
--- a/src/components/ContentNode/Caption.vue
+++ b/src/components/ContentNode/Caption.vue
@@ -44,7 +44,7 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .caption {
-  @include font-styles(documentation-figcaption);
+  @include font-styles(documentation-caption);
 
   &:last-child {
     margin-top: var(--spacing-stacked-margin-large);


### PR DESCRIPTION
Bug/issue #, if applicable: 110085109

## Summary

Fixes a minor typography issue introduced with #40 where a font-style was renamed, but the place where it was used was not updated to use the new name.

## Testing

Steps:
1. Run `npm run serve` and verify that no sass warning messages are emitted
2. Find example content with a captioned figure and verify that it now has the smaller font-size that it did previously

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS-only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
