### PR TITLE
Fix small css issue with nav secondary menus becoming too bing

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -224,6 +224,9 @@ $sidenav-icon-padding-size: 5px;
   @include font-styles(documentation-nav);
 
   &-settings {
+    // ensure settings can get smaller if needed
+    min-width: 0;
+
     @include font-styles(nav-toggles);
 
     @include breakpoint-only-largenav() {
@@ -246,6 +249,7 @@ $sidenav-icon-padding-size: 5px;
       align-items: center;
       color: var(--color-nav-current-link);
       margin-left: 0;
+      min-width: 0;
 
       &:first-child:not(:only-child) {
         margin-right: $nav-space-between-elements;

--- a/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
+++ b/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
@@ -234,6 +234,11 @@ $nav-menu-toggle-label-margin: 6px;
 }
 
 .language {
+  &-container {
+    // ensure the language picker is never crushed
+    flex: 1 0 auto;
+  }
+
   &-dropdown {
     -webkit-text-size-adjust: none;
     appearance: none;


### PR DESCRIPTION
Bug/issue #, if applicable: 109801256

## Summary

Fixes a small possible issue with nav dropdown menus becoming too large

## Dependencies

NA

## Testing

Ensure there are no regressions with one or many lang options for docs.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
