### PR TITLE
[5.9] Don't override monospace fonts with localized variants (yet)

### DIFF
--- a/src/styles/core/typography/_font-style-utils.scss
+++ b/src/styles/core/typography/_font-style-utils.scss
@@ -57,18 +57,21 @@ $font-weight-bold: 700 !default;
       }
       $prevAttributes: $attributes;
     }
-  } @else {
-    @warn 'The font style `#{$font-style-name}` is not defined.';
-  }
-  //
-  // Add support for localized font families
-  //
-  @if ($localizedFonts) {
-    @each $lang, $fonts in $localizedFonts {
-      :lang(#{$lang}) & {
-        font-family: $fonts;
+
+    //
+    // Add support for localized font families
+    //
+    // Note: localized monospace font families are not yet supported
+    $-font-family: map-deep-get($font-attributes, (map-get($styles, large), font-family));
+    @if ($localizedFonts and $-font-family != $font-mono) {
+      @each $lang, $fonts in $localizedFonts {
+        :lang(#{$lang}) & {
+          font-family: $fonts;
+        }
       }
     }
+  } @else {
+    @warn 'The font style `#{$font-style-name}` is not defined.';
   }
 }
 


### PR DESCRIPTION
- **Explanation:** Fixes issue where wrong font may be used for code in non-default locale
- **Scope:** Impacts code-style text in configurations with localized fonts
- **Issue:** rdar://110021706
- **Risk:** Low, minor conditional added to sass logic
- **Testing:** Manually verified that code fonts don't get overwritten anymore and no regressions with existing typography functionality.
- **Reviewer:** @dobromir-hristov
- **Original PR:** #682  