### PR TITLE
[5.9] Update reference to renamed font style

### DIFF
--- a/src/components/ContentNode/Caption.vue
+++ b/src/components/ContentNode/Caption.vue
@@ -44,7 +44,7 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .caption {
-  @include font-styles(documentation-figcaption);
+  @include font-styles(documentation-caption);
 
   &:last-child {
     margin-top: var(--spacing-stacked-margin-large);


### PR DESCRIPTION
- **Explanation:** Fixes issue where a font-style was renamed but a reference to the old name was not properly updated, resulting in unexpectedly large text for figure captions.
- **Scope:** Impacts any caption for a figure.
- **Issue:** rdar://110085109
- **Risk:** Low, single word/argument change
- **Testing:** Verified that warning is no longer emitted in console and verified that caption text is back to its expected size.
- **Reviewer:** @dobromir-hristov
- **Original PR:** #683 