### PR TITLE
Add identifierItems support

### DIFF
--- a/src/components/DocumentationTopic/TopicsTable.vue
+++ b/src/components/DocumentationTopic/TopicsTable.vue
@@ -110,8 +110,20 @@ export default {
     sectionsWithTopics() {
       return this.sections.map(section => ({
         ...section,
-        topics: section.identifiers.reduce(
-          (list, id) => (this.references[id] ? list.concat(this.references[id]) : list),
+        topics: section.identifierItems.reduce(
+          (list, item) => {
+            if (this.references[item.identifier]) {
+              const ref = this.references[item.identifier];
+              if (item.overrideTitle) {
+                ref.title = item.overrideTitle;
+              }
+              if (item.overridingTitleInlineContent) {
+                ref.titleInlineContent = item.overridingTitleInlineContent;
+              }
+              return list.concat(ref);
+            }
+            return list;
+          },
           [],
         ),
       }));


### PR DESCRIPTION
Bug/issue #, if applicable: 

Close https://github.com/apple/swift-docc/issues/480

## Summary

Add identifierItems support to make see also link with different title

## Dependencies

https://github.com/apple/swift-docc/pull/505

## TODO

Due to my unfamiliarity with VueJS, I can't complete the PR on the swift-docc-render side independently.

The current behavior is not as expected.

It would be highly appreciated if you can give me some help. cc @dobromir-hristov

### Input

```
## Overview

For more information see the [specification](https://example.com).

## See Also
- [Name 1](https://example.com)

- [Name 2](https://example.com)

- [Name 3](https://example3.com)

- [this great link ![random image](https://picsum.photos/200)](https://example3.com)
```

with https://github.com/apple/swift-docc/pull/505

### Ouput

<img width="325" alt="image" src="https://github.com/apple/swift-docc-render/assets/43724855/19684e47-7ded-41f3-b448-1749e645cdd9">

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
