### PR TITLE
[AX] <table> should be taken out of <figure> and the <figcaption> should become the table’s <caption>

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -213,14 +213,14 @@ function renderNode(createElement, references) {
     }
   };
 
-  const placeCaption = (rawContent, { abstract = [], title, ...others }) => {
+  const placeCaption = (rawContent, { abstract = [], title, tag }) => {
     const content = [rawContent];
     if (!abstract.length) return content;
 
     // if there is a `title`, it should be above, otherwise below
     content.splice(title ? 0 : 1, 0,
       createElement(Caption, {
-        props: { title, centered: !title, ...others },
+        props: { title, centered: !title, tag },
       }, renderChildren(abstract)));
     return content;
   };
@@ -308,16 +308,15 @@ function renderNode(createElement, references) {
       ));
     }
     case BlockType.table: {
-      let tableContent = [renderTableChildren(
+      let tableContent = renderTableChildren(
         node.rows, node.header, node.extendedData, node.alignments,
-      )];
+      );
 
       if (node.metadata && node.metadata.anchor) {
-        tableContent = placeCaption(renderTableChildren(
-          node.rows, node.header, node.extendedData, node.alignments,
-        ), {
+        tableContent = placeCaption(tableContent, {
           title: node.metadata.title,
           abstract: node.metadata.abstract,
+          tag: 'caption',
         });
       }
 

--- a/src/components/ContentNode/Caption.vue
+++ b/src/components/ContentNode/Caption.vue
@@ -33,8 +33,8 @@ export default {
     },
     tag: {
       type: String,
-      required: false,
-      default: () => 'caption',
+      required: true,
+      validator: v => new Set(['caption', 'figcaption']).has(v),
     },
   },
 };
@@ -44,10 +44,14 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .caption {
-  @include font-styles(documentation-figcaption);
+  @include font-styles(documentation-caption);
 
   &:last-child {
     margin-top: var(--spacing-stacked-margin-large);
+  }
+
+  &:has(+ *) {
+    margin-bottom: var(--spacing-stacked-margin-large);
   }
 
   &.centered {
@@ -57,9 +61,5 @@ export default {
 
 /deep/ p {
   display: inline-block;
-}
-
-caption {
-  margin: 1rem 0;
 }
 </style>

--- a/src/components/ContentNode/Caption.vue
+++ b/src/components/ContentNode/Caption.vue
@@ -9,19 +9,19 @@
 -->
 
 <template>
-  <figcaption class="caption" :class="{ centered }">
+  <component :is="tag" class="caption" :class="{ centered }">
     <template v-if="title">
       <strong>{{ title }}</strong>&nbsp;<slot />
     </template>
     <template v-else>
       <slot />
     </template>
-  </figcaption>
+  </component>
 </template>
 
 <script>
 export default {
-  name: 'FigureCaption',
+  name: 'Caption',
   props: {
     title: {
       type: String,
@@ -30,6 +30,11 @@ export default {
     centered: {
       type: Boolean,
       default: false,
+    },
+    tag: {
+      type: String,
+      required: false,
+      default: () => 'caption',
     },
   },
 };
@@ -52,5 +57,9 @@ export default {
 
 /deep/ p {
   display: inline-block;
+}
+
+caption {
+  margin: 1rem 0;
 }
 </style>

--- a/src/components/ContentNode/Figure.vue
+++ b/src/components/ContentNode/Figure.vue
@@ -23,9 +23,8 @@ export default {
   },
 };
 </script>
-
 <style scoped lang="scss">
-/deep/ figcaption + * {
-  margin-top: 1rem;
+/deep/ figcaption {
+  --spacing-stacked-margin-large: 1rem;
 }
 </style>

--- a/src/styles/core/typography/_font-styles.scss
+++ b/src/styles/core/typography/_font-styles.scss
@@ -153,7 +153,7 @@ $font-styles: (
   documentation-code-listing-number: (
     large: 12_18_normal_compact_mono,
   ),
-  documentation-figcaption: (
+  documentation-caption: (
     large: 14_21,
   ),
   documentation-declaration-link: (

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -16,7 +16,7 @@ import ContentNode from 'docc-render/components/ContentNode.vue';
 import DictionaryExample from 'docc-render/components/ContentNode/DictionaryExample.vue';
 import EndpointExample from 'docc-render/components/ContentNode/EndpointExample.vue';
 import Figure from 'docc-render/components/ContentNode/Figure.vue';
-import FigureCaption from 'docc-render/components/ContentNode/FigureCaption.vue';
+import Caption from 'docc-render/components/ContentNode/Caption.vue';
 import InlineImage from 'docc-render/components/ContentNode/InlineImage.vue';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
 import Table from 'docc-render/components/ContentNode/Table.vue';
@@ -111,29 +111,6 @@ describe('ContentNode', () => {
       expect(codeListing.props('fileType')).toBe(listing.fileType);
       expect(codeListing.props('content')).toEqual(listing.code);
       expect(codeListing.isEmpty()).toBe(true);
-    });
-
-    it('renders a `Figure`/`Figcaption` with metadata', () => {
-      const metadata = {
-        anchor: '42',
-        title: 'Listing 42',
-        abstract: [{
-          type: 'paragraph',
-          inlineContent: [{ type: 'text', text: 'blah' }],
-        }],
-      };
-      const wrapper = mountWithItem({ ...listing, metadata });
-
-      const figure = wrapper.find(Figure);
-      expect(figure.exists()).toBe(true);
-      expect(figure.props('anchor')).toBe(metadata.anchor);
-      expect(figure.contains(CodeListing)).toBe(true);
-
-      const caption = figure.find(FigureCaption);
-      expect(caption.exists()).toBe(true);
-      expect(caption.props('title')).toBe(metadata.title);
-      expect(caption.contains('p')).toBe(true);
-      expect(caption.text()).toContain('blah');
     });
   });
 
@@ -714,7 +691,7 @@ describe('ContentNode', () => {
       }, {})).not.toThrow();
     });
 
-    it('renders a `Figure`/`FigureCaption` with metadata', () => {
+    it('renders a `Figure`/`Caption` with metadata', () => {
       const metadata = {
         anchor: '42',
         title: 'Figure 42',
@@ -734,14 +711,14 @@ describe('ContentNode', () => {
       expect(figure.props('anchor')).toBe(metadata.anchor);
       expect(figure.contains(InlineImage)).toBe(true);
 
-      const caption = wrapper.find(FigureCaption);
+      const caption = wrapper.find(Caption);
       expect(caption.exists()).toBe(true);
       expect(caption.contains('p')).toBe(true);
       expect(caption.props('title')).toBe(metadata.title);
       expect(caption.text()).toContain('blah');
     });
 
-    it('renders a `Figure`/`FigureCaption` without an anchor, with text under the image', () => {
+    it('renders a `Figure`/`Caption` without an anchor, with text under the image', () => {
       const metadata = {
         abstract: [{
           type: 'paragraph',
@@ -759,7 +736,7 @@ describe('ContentNode', () => {
       expect(figure.props('anchor')).toBeFalsy();
       expect(figure.contains(InlineImage)).toBe(true);
 
-      const caption = wrapper.find(FigureCaption);
+      const caption = wrapper.find(Caption);
       expect(caption.exists()).toBe(true);
       expect(caption.contains('p')).toBe(true);
       expect(caption.props('title')).toBeFalsy();
@@ -769,9 +746,9 @@ describe('ContentNode', () => {
       expect(figure.html()).toMatchInlineSnapshot(`
         <figure-stub>
           <inlineimage-stub alt="" variants="[object Object],[object Object]"></inlineimage-stub>
-          <figurecaption-stub centered="true">
+          <caption-stub centered="true" tag="figcaption">
             <p>blah</p>
-          </figurecaption-stub>
+          </caption-stub>
         </figure-stub>
       `);
     });
@@ -791,9 +768,9 @@ describe('ContentNode', () => {
       }, references);
       expect(wrapper.find(Figure).html()).toMatchInlineSnapshot(`
         <figure-stub>
-          <figurecaption-stub title="foo">
+          <caption-stub title="foo" tag="figcaption">
             <p>blah</p>
-          </figurecaption-stub>
+          </caption-stub>
           <inlineimage-stub alt="" variants="[object Object],[object Object]"></inlineimage-stub>
         </figure-stub>
       `);
@@ -816,7 +793,7 @@ describe('ContentNode', () => {
       expect(figure.props('anchor')).toBe('foo-figure');
       expect(figure.contains(InlineImage)).toBe(true);
 
-      expect(wrapper.find(FigureCaption).exists()).toBe(false);
+      expect(wrapper.find(Caption).exists()).toBe(false);
     });
 
     it('renders within a `DeviceFrame`', () => {
@@ -892,7 +869,7 @@ describe('ContentNode', () => {
       }, {})).not.toThrow();
     });
 
-    it('renders a `Figure`/`FigureCaption` with metadata', () => {
+    it('renders a `Figure`/`Caption` with metadata', () => {
       const metadata = {
         anchor: 'foo',
         abstract: [{
@@ -911,15 +888,16 @@ describe('ContentNode', () => {
       expect(figure.props('anchor')).toBe('foo');
       expect(figure.contains(BlockVideo)).toBe(true);
 
-      const caption = wrapper.find(FigureCaption);
+      const caption = wrapper.find(Caption);
       expect(caption.exists()).toBe(true);
+      expect(caption.props('tag')).toBe('figcaption');
       expect(caption.contains('p')).toBe(true);
       expect(caption.props('title')).toBe(metadata.title);
       expect(caption.props('centered')).toBe(true);
       expect(caption.text()).toContain('blah');
     });
 
-    it('renders a `Figure`/`FigureCaption` without an anchor, with text under the video', () => {
+    it('renders a `Figure`/`Caption` without an anchor, with text under the video', () => {
       const metadata = {
         abstract: [{
           type: 'paragraph',
@@ -937,7 +915,7 @@ describe('ContentNode', () => {
       expect(figure.props('anchor')).toBeFalsy();
       expect(figure.contains(BlockVideo)).toBe(true);
 
-      const caption = wrapper.find(FigureCaption);
+      const caption = wrapper.find(Caption);
       expect(caption.exists()).toBe(true);
       expect(caption.contains('p')).toBe(true);
       expect(caption.props('title')).toBeFalsy();
@@ -947,9 +925,9 @@ describe('ContentNode', () => {
       expect(figure.html()).toMatchInlineSnapshot(`
         <figure-stub>
           <blockvideo-stub identifier="video.mp4"></blockvideo-stub>
-          <figurecaption-stub centered="true">
+          <caption-stub centered="true" tag="figcaption">
             <p>blah</p>
-          </figurecaption-stub>
+          </caption-stub>
         </figure-stub>
       `);
     });
@@ -1372,6 +1350,117 @@ describe('ContentNode', () => {
       expect(table.findAll('tbody tr td').length).toBe(4);
     });
 
+    it('renders a `Table`', () => {
+      const wrapper = mountWithItem({
+        type: 'table',
+        header: TableHeaderStyle.none,
+        rows,
+      });
+
+      const table = wrapper.find('.content').find(Table);
+      expect(table.exists()).toBe(true);
+
+      expect(wrapper.find(Table).html()).toMatchInlineSnapshot(`
+        <table-stub>
+          <tbody>
+            <tr>
+              <td>row0col0</td>
+              <td>row0col1</td>
+            </tr>
+            <tr>
+              <td>row1col0</td>
+              <td>row1col1</td>
+            </tr>
+          </tbody>
+        </table-stub>
+      `);
+    });
+
+    it('renders a `Table` with metadata', () => {
+      const metadata = {
+        anchor: '42',
+        title: 'Listing 42',
+        abstract: [{
+          type: 'paragraph',
+          inlineContent: [{ type: 'text', text: 'AbstractText' }],
+        }],
+      };
+
+      const wrapper = mountWithItem({
+        type: 'table',
+        header: TableHeaderStyle.none,
+        rows,
+        metadata,
+      });
+
+      const table = wrapper.find('.content').find(Table);
+      expect(table.exists()).toBe(true);
+      expect(table.attributes('id')).toBe(metadata.anchor);
+
+      const caption = wrapper.find(Caption);
+      expect(caption.exists()).toBe(true);
+      expect(caption.props('title')).toBe(metadata.title);
+      expect(caption.text()).toContain('AbstractText');
+
+      expect(wrapper.find(Table).html()).toMatchInlineSnapshot(`
+        <table-stub id="42">
+          <caption-stub title="Listing 42" tag="caption">
+            <p>AbstractText</p>
+          </caption-stub>
+          <tbody>
+            <tr>
+              <td>row0col0</td>
+              <td>row0col1</td>
+            </tr>
+            <tr>
+              <td>row1col0</td>
+              <td>row1col1</td>
+            </tr>
+          </tbody>
+        </table-stub>
+      `);
+    });
+
+    it('renders a abstract for `Table` using a caption at the bottom of the content and centered if there is no title', () => {
+      const metadata = {
+        anchor: '42',
+        abstract: [{
+          type: 'paragraph',
+          inlineContent: [{ type: 'text', text: 'AbstractText' }],
+        }],
+      };
+
+      const wrapper = mountWithItem({
+        type: 'table',
+        header: TableHeaderStyle.none,
+        rows,
+        metadata,
+      });
+
+      const caption = wrapper.find(Caption);
+      expect(caption.exists()).toBe(true);
+      expect(caption.props('centered')).toBe(true);
+      expect(caption.text()).toBe('AbstractText');
+
+      expect(wrapper.find(Table).html()).toMatchInlineSnapshot(`
+        <table-stub id="42">
+          <tbody>
+            <tr>
+              <td>row0col0</td>
+              <td>row0col1</td>
+            </tr>
+            <tr>
+              <td>row1col0</td>
+              <td>row1col1</td>
+            </tr>
+          </tbody>
+          <caption-stub centered="true" tag="caption">
+            <p>AbstractText</p>
+          </caption-stub>
+        </table-stub>
+      `);
+    });
+
     it('renders header="both" style tables', () => {
       const wrapper = mountWithItem({
         type: 'table',
@@ -1408,35 +1497,6 @@ describe('ContentNode', () => {
       expect(table.contains('thead')).toBe(false);
       expect(table.findAll('tbody tr th[scope="row"]').length).toBe(2);
       expect(table.findAll('tbody tr td').length).toBe(2);
-    });
-
-    it('renders a `Figure`/`FigureCaption` with metadata', () => {
-      const metadata = {
-        anchor: '42',
-        title: 'Table 42',
-        abstract: [{
-          type: 'paragraph',
-          inlineContent: [{ type: 'text', text: 'blah' }],
-        }],
-      };
-      const wrapper = mountWithItem({
-        type: 'table',
-        header: TableHeaderStyle.none,
-        rows,
-        metadata,
-      });
-
-      const figure = wrapper.find(Figure);
-      expect(figure.exists()).toBe(true);
-      expect(figure.props('anchor')).toBe(metadata.anchor);
-      expect(figure.contains(Table)).toBe(true);
-
-      const caption = figure.find(FigureCaption);
-      expect(caption.exists()).toBe(true);
-      expect(caption.props('title')).toBe(metadata.title);
-      expect(caption.props('centered')).toBe(false);
-      expect(caption.contains('p')).toBe(true);
-      expect(caption.text()).toContain('blah');
     });
 
     describe('and column/row spanning', () => {

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -1421,7 +1421,7 @@ describe('ContentNode', () => {
       `);
     });
 
-    it('renders a abstract for `Table` using a caption at the bottom of the content and centered if there is no title', () => {
+    it('renders an abstract for `Table` using a caption at the bottom of the content and centered if there is no title', () => {
       const metadata = {
         anchor: '42',
         abstract: [{

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -112,6 +112,29 @@ describe('ContentNode', () => {
       expect(codeListing.props('content')).toEqual(listing.code);
       expect(codeListing.isEmpty()).toBe(true);
     });
+
+    it('renders a `Figure`/`Caption` with metadata', () => {
+      const metadata = {
+        anchor: '42',
+        title: 'Listing 42',
+        abstract: [{
+          type: 'paragraph',
+          inlineContent: [{ type: 'text', text: 'blah' }],
+        }],
+      };
+      const wrapper = mountWithItem({ ...listing, metadata });
+
+      const figure = wrapper.find(Figure);
+      expect(figure.exists()).toBe(true);
+      expect(figure.props('anchor')).toBe(metadata.anchor);
+      expect(figure.contains(CodeListing)).toBe(true);
+
+      const caption = figure.find(Caption);
+      expect(caption.exists()).toBe(true);
+      expect(caption.props('title')).toBe(metadata.title);
+      expect(caption.contains('p')).toBe(true);
+      expect(caption.text()).toContain('blah');
+    });
   });
 
   describe('with type="endpointExample"', () => {
@@ -753,7 +776,7 @@ describe('ContentNode', () => {
       `);
     });
 
-    it('renders a `FigureCaption` before the image, if it has a title', () => {
+    it('renders a `Caption` before the image, if it has a title', () => {
       const metadata = {
         title: 'foo',
         abstract: [{
@@ -776,7 +799,7 @@ describe('ContentNode', () => {
       `);
     });
 
-    it('renders no `FigureCaption`, if there is a `title`, but no `abstract`', () => {
+    it('renders no `Caption`, if there is a `title`, but no `abstract`', () => {
       const metadata = {
         postTitle: true,
         title: 'Foo',

--- a/tests/unit/components/ContentNode/Caption.spec.js
+++ b/tests/unit/components/ContentNode/Caption.spec.js
@@ -9,7 +9,7 @@
 */
 
 import { shallowMount } from '@vue/test-utils';
-import Caption from '@/components/ContentNode/Caption.vue';
+import Caption from 'docc-render/components/ContentNode/Caption.vue';
 
 describe('Caption', () => {
   it('renders a <caption> with the title and slot content', () => {

--- a/tests/unit/components/ContentNode/Caption.spec.js
+++ b/tests/unit/components/ContentNode/Caption.spec.js
@@ -9,30 +9,37 @@
 */
 
 import { shallowMount } from '@vue/test-utils';
-import FigureCaption from 'docc-render/components/ContentNode/FigureCaption.vue';
+import Caption from '@/components/ContentNode/Caption.vue';
 
-describe('FigureCaption', () => {
-  it('renders a <figcaption> with the title and slot content', () => {
+describe('Caption', () => {
+  it('renders a <caption> with the title and slot content', () => {
     const propsData = { title: 'Figure 1' };
     const slots = { default: '<p>Blah</p>' };
-    const wrapper = shallowMount(FigureCaption, { propsData, slots });
+    const wrapper = shallowMount(Caption, { propsData, slots });
 
-    expect(wrapper.is('figcaption')).toBe(true);
-    expect(wrapper.text()).toBe('Figure 1\u00a0Blah');
+    expect(wrapper.is('caption')).toBe(true);
+    expect(wrapper.text()).toMatch(/Figure 1\sBlah/);
   });
 
   it('renders a <figcaption> with slot content only', () => {
     const slots = { default: '<p>Blah</p>' };
-    const wrapper = shallowMount(FigureCaption, { slots });
+    const wrapper = shallowMount(Caption, { slots });
 
-    expect(wrapper.is('figcaption')).toBe(true);
+    expect(wrapper.is('caption')).toBe(true);
     expect(wrapper.text()).toBe('Blah');
     expect(wrapper.text()).not.toBe('\u00a0Blah');
   });
 
   it('renders a <figcaption> centered', () => {
     const slots = { default: '<p>Blah</p>' };
-    const wrapper = shallowMount(FigureCaption, { slots, propsData: { centered: true } });
+    const wrapper = shallowMount(Caption, { slots, propsData: { centered: true } });
     expect(wrapper.classes()).toContain('centered');
+  });
+
+  it('renders a <figcaption> if tag is `figcaption`', () => {
+    const propsData = { title: 'Figure 1', tag: 'figcaption' };
+    const wrapper = shallowMount(Caption, { propsData });
+
+    expect(wrapper.is('figcaption')).toBe(true);
   });
 });


### PR DESCRIPTION
Bug/issue #30234820, if applicable: 

## Summary

Tables were contained within a `<figure>` element. However, there is no need for this and it was making the tables much less accessible. Tables should stand on their own with the previous `<figcaption>` as the table’s `<caption>`. 

This is a improved implementation of https://github.com/apple/swift-docc-render/pull/40 that was not taking into account https://github.com/apple/swift-docc-render/pull/404 and had to be reverted.

## Dependencies

NA

## Testing

Use the provided fixture folder:
[manual-fixtures.zip](https://github.com/apple/swift-docc-render/files/7803705/manual-fixtures.zip)

Steps:
1. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/manual-fixtures/ npm run serve`
2. Go to http://localhost:8080/documentation/framework/sloth
3. Assert that tables' markup is as described in the Summary.

## Checklist

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary