### PR TITLE
Move the references setting back to the DocTopic component

### DIFF
--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -169,6 +169,12 @@ export default {
     this.store.reset();
     this.store.setReferences(this.references);
   },
+  watch: {
+    // update the references in the store, in case they update, but the component is not re-created
+    references(references) {
+      this.store.setReferences(references);
+    },
+  },
   SectionKind,
 };
 </script>

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -622,6 +622,7 @@ export default {
     }
 
     this.store.reset();
+    this.store.setReferences(this.references);
   },
 };
 </script>

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -624,6 +624,12 @@ export default {
     this.store.reset();
     this.store.setReferences(this.references);
   },
+  watch: {
+    // update the references in the store, in case they update, but the component is not re-created
+    references(references) {
+      this.store.setReferences(references);
+    },
+  },
 };
 </script>
 

--- a/src/components/Navigator/QuickNavigationPreview.vue
+++ b/src/components/Navigator/QuickNavigationPreview.vue
@@ -108,16 +108,6 @@ export default {
       };
     },
   },
-  watch: {
-    json: {
-      immediate: true,
-      async handler(json) {
-        const { references = {} } = json || {};
-        await this.$nextTick();
-        PreviewStore.setReferences(references);
-      },
-    },
-  },
 };
 </script>
 

--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -138,6 +138,12 @@ export default {
     this.store.reset();
     this.store.setReferences(this.references);
   },
+  watch: {
+    // update the references in the store, in case they update, but the component is not re-created
+    references(references) {
+      this.store.setReferences(references);
+    },
+  },
   mounted() {
     this.$bridge.on('codeColors', this.handleCodeColorsChange);
     this.$bridge.send({ type: 'requestCodeColors' });

--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -103,6 +103,12 @@ export default {
     this.store.reset();
     this.store.setReferences(this.references);
   },
+  watch: {
+    // update the references in the store, in case they update, but the component is not re-created
+    references(references) {
+      this.store.setReferences(references);
+    },
+  },
 };
 </script>
 

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -382,7 +382,6 @@ export default {
       this.$nextTick(() => {
         // Send a 'rendered' message to the host when new data has been patched onto the DOM.
         this.newContentMounted();
-        this.store.setReferences(this.topicProps.references);
       });
     },
   },

--- a/tests/unit/components/Navigator/QuickNavigationPreview.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationPreview.spec.js
@@ -11,7 +11,6 @@
 import { shallowMount } from '@vue/test-utils';
 import DocumentationTopic from 'docc-render/components/DocumentationTopic.vue';
 import QuickNavigationPreview from 'docc-render/components/Navigator/QuickNavigationPreview.vue';
-import { flushPromises } from '../../../../test-utils';
 
 const { PreviewState, PreviewStore } = QuickNavigationPreview.constants;
 
@@ -53,7 +52,7 @@ describe('QuickNavigationPreview', () => {
     expect(topic.props('abstract')).toEqual(json.abstract);
   });
 
-  it('provides a new store, setting the references when the JSON changes', async () => {
+  it('provides a PreviewStore', async () => {
     const json = {
       abstract: [{ type: 'text', text: 'a' }],
       identifier: {
@@ -76,18 +75,6 @@ describe('QuickNavigationPreview', () => {
     });
     // eslint-disable-next-line no-underscore-dangle
     expect(wrapper.vm._provided).toHaveProperty('store', PreviewStore);
-    await flushPromises();
-    expect(PreviewStore.state.references).toEqual(json.references);
-    wrapper.setProps({
-      json: {
-        ...json,
-        references: {
-          c: 'c',
-        },
-      },
-    });
-    await flushPromises();
-    expect(PreviewStore.state.references).toEqual({ c: 'c' });
   });
 
   it('renders a "Preview unavailable" message for errors', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 109856608

## Summary

Moves the setting of the references back into the `components/DocumentationTopic` instead of the `view`.

This should fix potential rendering issues in Safari.

## Dependencies

NA

## Testing

Ensure all links and interact-able elements on pages are rendered properly and console has no errors.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
