### PR TITLE
Aria-label that indicates scrolling behaviour interferes in headings content for screen readers

### DIFF
--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -9,25 +9,24 @@
 -->
 
 <template>
-  <div class="heading-wrapper">
-    <component
-      :id="anchor"
-      :is="`h${level}`"
-      class="heading"
-    >
-      <slot />
-    </component>
+  <component
+    :id="anchor"
+    :is="`h${level}`"
+  >
     <router-link
       v-if="shouldLink"
       :to="{ hash: `#${anchor}` }"
-      class="anchor"
+      class="header-anchor"
       @click="handleFocusAndScroll(anchor)"
     >
-      <LinkIcon class="icon" aria-hidden="true" />
-      <span :aria-labelledby="anchor" class="visuallyhidden" />
+      <slot />
       <span class="visuallyhidden" >{{ $t('accessibility.in-page-link') }}</span>
+      <LinkIcon class="icon" aria-hidden="true" />
     </router-link>
-  </div>
+    <template v-else>
+      <slot />
+    </template>
+  </component>
 </template>
 
 <script>
@@ -74,39 +73,26 @@ export default {
 
 $icon-margin: 7px;
 
-.heading-wrapper {
-  display: flex;
-  align-items: baseline;
-}
-
-.heading {
-  &:hover + .anchor > .icon {
-    visibility: visible;
-  }
-}
-
-.anchor {
+.header-anchor {
   color: inherit;
   text-decoration: none;
-  margin: 0;
-  padding-right: $icon-margin;
-
-  &:hover > .icon {
-    visibility: visible;
-  }
-
-  &:focus > .icon {
-    visibility: visible;
-  }
+  position: relative;
+  padding-right: $icon-size-default + $icon-margin;
+  display: inline-block;
 
   .icon {
-    visibility: hidden;
+    position: absolute;
+    right: 0;
+    bottom: .2em;
+    display: none;
     height: $icon-size-default;
     margin-left: $icon-margin;
   }
 
-  &:hover .icon {
-    display: inline;
+  &:hover, &:focus {
+    .icon {
+      display: inline;
+    }
   }
 }
 </style>

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <div class="wrapper">
+  <div class="heading-wrapper">
     <component
       :id="anchor"
       :is="`h${level}`"
@@ -22,10 +22,10 @@
       :to="{ hash: `#${anchor}` }"
       class="anchor"
       @click="handleFocusAndScroll(anchor)"
-      :aria-labelledby="`${anchor} inPageLink`"
     >
-      <span class="visuallyhidden" id="inPageLink" >{{ $t('accessibility.in-page-link') }}</span>
       <LinkIcon class="icon" aria-hidden="true" />
+      <span :aria-labelledby="anchor" class="visuallyhidden" />
+      <span class="visuallyhidden" >{{ $t('accessibility.in-page-link') }}</span>
     </router-link>
   </div>
 </template>
@@ -74,7 +74,7 @@ export default {
 
 $icon-margin: 7px;
 
-.wrapper {
+.heading-wrapper {
   display: flex;
   align-items: baseline;
 }

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -9,24 +9,25 @@
 -->
 
 <template>
-  <component
-    :id="anchor"
-    :is="`h${level}`"
-  >
+  <div class="wrapper">
+    <component
+      :id="anchor"
+      :is="`h${level}`"
+      class="heading"
+    >
+      <slot />
+    </component>
     <router-link
       v-if="shouldLink"
       :to="{ hash: `#${anchor}` }"
-      class="header-anchor"
-      aria-label="Scroll to section"
+      class="anchor"
       @click="handleFocusAndScroll(anchor)"
+      :aria-labelledby="`${anchor} inPageLink`"
     >
-      <slot />
+      <span class="visuallyhidden" id="inPageLink" >{{ $t('accessibility.in-page-link') }}</span>
       <LinkIcon class="icon" aria-hidden="true" />
     </router-link>
-    <template v-else>
-      <slot />
-    </template>
-  </component>
+  </div>
 </template>
 
 <script>
@@ -73,18 +74,33 @@ export default {
 
 $icon-margin: 7px;
 
-.header-anchor {
+.wrapper {
+  display: flex;
+  align-items: baseline;
+}
+
+.heading {
+  &:hover + .anchor > .icon {
+    visibility: visible;
+  }
+}
+
+.anchor {
   color: inherit;
   text-decoration: none;
-  position: relative;
-  padding-right: $icon-size-default + $icon-margin;
-  display: inline-block;
+  margin: 0;
+  padding-right: $icon-margin;
+
+  &:hover > .icon {
+    visibility: visible;
+  }
+
+  &:focus > .icon {
+    visibility: visible;
+  }
 
   .icon {
-    position: absolute;
-    right: 0;
-    bottom: .2em;
-    display: none;
+    visibility: hidden;
     height: $icon-size-default;
     margin-left: $icon-margin;
   }

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -181,7 +181,8 @@
       "start": "start of code block",
       "end": "end of code block"
     },
-    "skip-navigation": "Skip Navigation"
+    "skip-navigation": "Skip Navigation",
+    "in-page-link": "in page link"
   },
   "select-language": "Select the language for this page",
   "icons": {

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -68,7 +68,8 @@ h2,
 h3,
 h4,
 h5,
-h6 {
+h6,
+.heading-wrapper {
   color: var(--colors-header-text, var(--color-header-text));
 
   // Add top margin to any element that immediately follows a heading.

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -75,8 +75,7 @@ h2,
 h3,
 h4,
 h5,
-h6,
-.heading-wrapper {
+h6 {
   color: var(--colors-header-text, var(--color-header-text));
 
   // Add top margin to any element that immediately follows a heading.

--- a/tests/unit/components/ContentNode/LinkableHeading.spec.js
+++ b/tests/unit/components/ContentNode/LinkableHeading.spec.js
@@ -48,6 +48,9 @@ describe('LinkableHeading', () => {
     expect(wrapper.find('.heading').text()).toBe('Title');
     expect(wrapper.find('.heading').attributes('id')).toBe('title');
     expect(wrapper.find('.anchor').props('to')).toEqual({ hash: '#title' });
+    // assert screen readers description of title + in page link
+    expect(wrapper.find('[aria-labelledby="title"]').exists()).toBe(true);
+    expect(wrapper.find('.anchor').text()).toBe('accessibility.in-page-link');
   });
 
   it('does not render anchor if there is no anchor', () => {

--- a/tests/unit/components/ContentNode/LinkableHeading.spec.js
+++ b/tests/unit/components/ContentNode/LinkableHeading.spec.js
@@ -48,7 +48,7 @@ describe('LinkableHeading', () => {
     expect(wrapper.attributes('id')).toBe('title');
     const headerAnchor = wrapper.find('.header-anchor');
     expect(headerAnchor.props('to')).toEqual({ hash: '#title' });
-    expect(headerAnchor.text()).toBe('Title');
+    expect(headerAnchor.text()).toBe('Title accessibility.in-page-link');
   });
 
   it('does not render anchor if there is no anchor', () => {

--- a/tests/unit/components/ContentNode/LinkableHeading.spec.js
+++ b/tests/unit/components/ContentNode/LinkableHeading.spec.js
@@ -23,7 +23,7 @@ describe('LinkableHeading', () => {
       slots: { default: 'Title' },
     });
     expect(wrapper.text()).toBe('Title');
-    expect(wrapper.is('h2')).toBe(true);
+    expect(wrapper.find('h2').exists()).toBe(true);
   });
 
   it('renders a heading with a given level', () => {
@@ -33,10 +33,10 @@ describe('LinkableHeading', () => {
         level: 3,
       },
     });
-    expect(wrapper.is('h3')).toBe(true);
+    expect(wrapper.find('h3').exists()).toBe(true);
   });
 
-  it('renders a heading with a header anchor and an id on the wrapper', async () => {
+  it('renders a heading and an anchor inside a wrapper', async () => {
     const wrapper = shallowMount(LinkableHeading, {
       stubs,
       propsData: {
@@ -45,15 +45,14 @@ describe('LinkableHeading', () => {
       slots: { default: 'Title' },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.attributes('id')).toBe('title');
-    const headerAnchor = wrapper.find('.header-anchor');
-    expect(headerAnchor.props('to')).toEqual({ hash: '#title' });
-    expect(headerAnchor.text()).toBe('Title');
+    expect(wrapper.find('.heading').text()).toBe('Title');
+    expect(wrapper.find('.heading').attributes('id')).toBe('title');
+    expect(wrapper.find('.anchor').props('to')).toEqual({ hash: '#title' });
   });
 
   it('does not render anchor if there is no anchor', () => {
     const wrapper = shallowMount(LinkableHeading);
-    expect(wrapper.find('.header-anchor').exists()).toBe(false);
+    expect(wrapper.find('.anchor').exists()).toBe(false);
   });
 
   it('does not render anchor if target ide is true', () => {
@@ -66,7 +65,7 @@ describe('LinkableHeading', () => {
         isTargetIDE: true,
       },
     });
-    expect(wrapper.find('.header-anchor').exists()).toBe(false);
+    expect(wrapper.find('.anchor').exists()).toBe(false);
   });
 
   it('does not render anchor if `enableMinimized` is true', () => {
@@ -79,6 +78,6 @@ describe('LinkableHeading', () => {
         enableMinimized: true,
       },
     });
-    expect(wrapper.find('.header-anchor').exists()).toBe(false);
+    expect(wrapper.find('.anchor').exists()).toBe(false);
   });
 });

--- a/tests/unit/components/ContentNode/LinkableHeading.spec.js
+++ b/tests/unit/components/ContentNode/LinkableHeading.spec.js
@@ -23,7 +23,7 @@ describe('LinkableHeading', () => {
       slots: { default: 'Title' },
     });
     expect(wrapper.text()).toBe('Title');
-    expect(wrapper.find('h2').exists()).toBe(true);
+    expect(wrapper.is('h2')).toBe(true);
   });
 
   it('renders a heading with a given level', () => {
@@ -33,10 +33,10 @@ describe('LinkableHeading', () => {
         level: 3,
       },
     });
-    expect(wrapper.find('h3').exists()).toBe(true);
+    expect(wrapper.is('h3')).toBe(true);
   });
 
-  it('renders a heading and an anchor inside a wrapper', async () => {
+  it('renders a heading with a header anchor and an id on the wrapper', async () => {
     const wrapper = shallowMount(LinkableHeading, {
       stubs,
       propsData: {
@@ -45,17 +45,15 @@ describe('LinkableHeading', () => {
       slots: { default: 'Title' },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('.heading').text()).toBe('Title');
-    expect(wrapper.find('.heading').attributes('id')).toBe('title');
-    expect(wrapper.find('.anchor').props('to')).toEqual({ hash: '#title' });
-    // assert screen readers description of title + in page link
-    expect(wrapper.find('[aria-labelledby="title"]').exists()).toBe(true);
-    expect(wrapper.find('.anchor').text()).toBe('accessibility.in-page-link');
+    expect(wrapper.attributes('id')).toBe('title');
+    const headerAnchor = wrapper.find('.header-anchor');
+    expect(headerAnchor.props('to')).toEqual({ hash: '#title' });
+    expect(headerAnchor.text()).toBe('Title');
   });
 
   it('does not render anchor if there is no anchor', () => {
     const wrapper = shallowMount(LinkableHeading);
-    expect(wrapper.find('.anchor').exists()).toBe(false);
+    expect(wrapper.find('.header-anchor').exists()).toBe(false);
   });
 
   it('does not render anchor if target ide is true', () => {
@@ -68,7 +66,7 @@ describe('LinkableHeading', () => {
         isTargetIDE: true,
       },
     });
-    expect(wrapper.find('.anchor').exists()).toBe(false);
+    expect(wrapper.find('.header-anchor').exists()).toBe(false);
   });
 
   it('does not render anchor if `enableMinimized` is true', () => {
@@ -81,6 +79,6 @@ describe('LinkableHeading', () => {
         enableMinimized: true,
       },
     });
-    expect(wrapper.find('.anchor').exists()).toBe(false);
+    expect(wrapper.find('.header-anchor').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
Bug/issue #111006953, if applicable: 

## Summary

Aria-label that indicates scrolling behaviour interferes in headings content for screen readers

It's been fixed by restructuring how the anchor link is set and adding AX description that should read: Content of heading + "in page link" to describe that the link is within the page.

<img width="860" alt="Screenshot 2023-06-26 at 20 30 31" src="https://github.com/apple/swift-docc-render/assets/8567677/cf4d7193-4e24-40eb-b6b8-34341b53b12c">

## Dependencies

NA

## Testing

Steps:
1. Run any doccarchive
2. Go to section title
3. Assert that you can read its content using VoiceOver

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
