### PR TITLE
Fix horizontal scrollbars on Safari when code blocks are very long

### DIFF
--- a/src/components/CodeBlock.vue
+++ b/src/components/CodeBlock.vue
@@ -36,6 +36,8 @@ code {
     content: attr(data-after-code);
   }
   &::before, &::after {
+    // ensure the pseudo elements dont fly off in space
+    display: block;
     @include visuallyhidden()
   }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 110741983

## Summary

Fixes a bug on Safari, where if the last line in a codeblock is very long, the `after` accessibility pseudo element helper gets pushed to the side, causing the browser to render hirozontal scrollbars.

## Dependencies

NA

## Testing

Load a page with a codeblock that has very long last line

Steps:
1. Assert in Safari there are no horizontal scrollbars

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~ - css only
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
