### PR TITLE
[5.9-0626] Fix horizontal scrollbars on Safari when code blocks are very long

### DIFF
--- a/src/components/CodeBlock.vue
+++ b/src/components/CodeBlock.vue
@@ -36,6 +36,8 @@ code {
     content: attr(data-after-code);
   }
   &::before, &::after {
+    // ensure the pseudo elements dont fly off in space
+    display: block;
     @include visuallyhidden()
   }
 }


### PR DESCRIPTION
- **Explanation:** Fixes an issue where pages with long code listings make the page scroll horizontally in Safari when it shouldn't
- **Scope:** Impacts pages with long code listings in Safari only
- **Issue:** rdar://110741983
- **Risk:** Low, single CSS property addition
- **Testing:** Tested problematic pages to verify that the page no longer scrolls past the expected layout and verified that there are no other regressions for other pages in Safari and other browsers
- **Reviewer:** @mportiz08 and @hqhhuang 
- **Original PR:** #700 