### PR TITLE
Use <caption> for table captions instead of <figcaption>

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -17,7 +17,7 @@ import CodeVoice from './ContentNode/CodeVoice.vue';
 import DictionaryExample from './ContentNode/DictionaryExample.vue';
 import EndpointExample from './ContentNode/EndpointExample.vue';
 import Figure from './ContentNode/Figure.vue';
-import FigureCaption from './ContentNode/FigureCaption.vue';
+import Caption from './ContentNode/Caption.vue';
 import InlineImage from './ContentNode/InlineImage.vue';
 import Reference from './ContentNode/Reference.vue';
 import Table from './ContentNode/Table.vue';
@@ -31,7 +31,7 @@ import TaskList from './ContentNode/TaskList.vue';
 import LinksBlock from './ContentNode/LinksBlock.vue';
 import DeviceFrame from './ContentNode/DeviceFrame.vue';
 
-const { CaptionTag } = FigureCaption.constants;
+const { CaptionTag } = Caption.constants;
 
 export const BlockType = {
   aside: 'aside',
@@ -232,7 +232,7 @@ function renderNode(createElement, references) {
     if ((title && abstract.length) || abstract.length) {
       // if there is a `title`, it should be above, otherwise below
       figureContent.splice(title ? 0 : 1, 0,
-        createElement(FigureCaption, {
+        createElement(Caption, {
           props: {
             title,
             centered: !title,
@@ -309,7 +309,7 @@ function renderNode(createElement, references) {
       );
 
       if (node.metadata && node.metadata.abstract) {
-        children.unshift(createElement(FigureCaption, {
+        children.unshift(createElement(Caption, {
           props: {
             centered: !node.metadata.title,
             tag: CaptionTag.caption,

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -31,7 +31,7 @@ import TaskList from './ContentNode/TaskList.vue';
 import LinksBlock from './ContentNode/LinksBlock.vue';
 import DeviceFrame from './ContentNode/DeviceFrame.vue';
 
-const { CaptionTag } = Caption.constants;
+const { CaptionPosition, CaptionTag } = Caption.constants;
 
 export const BlockType = {
   aside: 'aside',
@@ -231,12 +231,15 @@ function renderNode(createElement, references) {
     const figureContent = [renderChildren([node])];
     if ((title && abstract.length) || abstract.length) {
       // if there is a `title`, it should be above, otherwise below
-      figureContent.splice(title ? 0 : 1, 0,
+      const position = title ? CaptionPosition.leading : CaptionPosition.trailing;
+      const index = position === CaptionPosition.trailing ? 1 : 0;
+      const tag = CaptionTag.figcaption;
+      figureContent.splice(index, 0,
         createElement(Caption, {
           props: {
             title,
-            centered: !title,
-            tag: CaptionTag.figcaption,
+            position,
+            tag,
           },
         }, renderChildren(abstract)));
     }
@@ -309,11 +312,14 @@ function renderNode(createElement, references) {
       );
 
       if (node.metadata && node.metadata.abstract) {
+        const { title } = node.metadata;
+        const position = title ? CaptionPosition.leading : CaptionPosition.trailing;
+        const tag = CaptionTag.caption;
         children.unshift(createElement(Caption, {
           props: {
-            centered: !node.metadata.title,
-            tag: CaptionTag.caption,
-            title: node.metadata.title,
+            title,
+            position,
+            tag,
           },
         }, (
           renderChildren(node.metadata.abstract)

--- a/src/components/ContentNode/Caption.vue
+++ b/src/components/ContentNode/Caption.vue
@@ -26,7 +26,7 @@ const CaptionTag = {
 };
 
 export default {
-  name: 'FigureCaption',
+  name: 'Caption',
   constants: { CaptionTag },
   props: {
     title: {
@@ -50,7 +50,7 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .caption {
-  @include font-styles(documentation-figcaption);
+  @include font-styles(documentation-caption);
 
   &.centered {
     text-align: center;

--- a/src/components/ContentNode/Caption.vue
+++ b/src/components/ContentNode/Caption.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <component class="caption" :class="{ centered }" :is="tag">
+  <component class="caption" :class="{ trailing }" :is="tag">
     <template v-if="title">
       <strong>{{ title }}</strong>&nbsp;<slot />
     </template>
@@ -25,23 +25,35 @@ const CaptionTag = {
   figcaption: 'figcaption',
 };
 
+const CaptionPosition = {
+  leading: 'leading', // before element and left aligned
+  trailing: 'trailing', // after element and center aligned
+};
+
 export default {
   name: 'Caption',
-  constants: { CaptionTag },
+  constants: {
+    CaptionPosition,
+    CaptionTag,
+  },
   props: {
     title: {
       type: String,
       required: false,
-    },
-    centered: {
-      type: Boolean,
-      default: false,
     },
     tag: {
       type: String,
       required: true,
       validator: v => Object.hasOwnProperty.call(CaptionTag, v),
     },
+    position: {
+      type: String,
+      default: () => CaptionPosition.leading,
+      validator: v => Object.hasOwnProperty.call(CaptionPosition, v),
+    },
+  },
+  computed: {
+    trailing: ({ position }) => position === CaptionPosition.trailing,
   },
 };
 </script>
@@ -51,34 +63,18 @@ export default {
 
 .caption {
   @include font-styles(documentation-caption);
+  margin: 0 0 var(--spacing-stacked-margin-large) 0;
 
-  &.centered {
+  &.trailing {
+    margin: var(--spacing-stacked-margin-large) 0 0 0;
     text-align: center;
   }
 }
 
-// `space-out-between-siblings` helper would normally be used, but it won't work
-// for certain things like <picture> or <thead>/<tbody> with different
-// display types, so the spacing is manually done here for both kinds of
-// captions
-figcaption {
-  &:first-child {
-    margin: 0 0 var(--spacing-stacked-margin-large) 0;
-  }
-  &:last-child {
-    margin: var(--spacing-stacked-margin-large) 0 0 0;
-  }
-}
-caption {
-  margin: 0 0 var(--spacing-stacked-margin-large) 0;
-
-  // `caption-side` must be used for the table version of <caption> to appear
-  // underneath the table since the element must always be the first element
-  // within the <table> in the DOM according to the spec
-  &.centered {
-    caption-side: bottom;
-    margin: var(--spacing-stacked-margin-large) 0 0 0;
-  }
+// for <caption> specifically since it must be the first element in a <table>
+// even when displayed at the bottom using this property
+caption.trailing {
+  caption-side: bottom;
 }
 
 /deep/ p {

--- a/src/components/ContentNode/Figure.vue
+++ b/src/components/ContentNode/Figure.vue
@@ -23,9 +23,3 @@ export default {
   },
 };
 </script>
-
-<style scoped lang="scss">
-/deep/ figcaption + * {
-  margin-top: 1rem;
-}
-</style>

--- a/src/components/ContentNode/FigureCaption.vue
+++ b/src/components/ContentNode/FigureCaption.vue
@@ -9,19 +9,25 @@
 -->
 
 <template>
-  <figcaption class="caption" :class="{ centered }">
+  <component class="caption" :class="{ centered }" :is="tag">
     <template v-if="title">
       <strong>{{ title }}</strong>&nbsp;<slot />
     </template>
     <template v-else>
       <slot />
     </template>
-  </figcaption>
+  </component>
 </template>
 
 <script>
+const CaptionTag = {
+  caption: 'caption',
+  figcaption: 'figcaption',
+};
+
 export default {
   name: 'FigureCaption',
+  constants: { CaptionTag },
   props: {
     title: {
       type: String,
@@ -30,6 +36,11 @@ export default {
     centered: {
       type: Boolean,
       default: false,
+    },
+    tag: {
+      type: String,
+      required: true,
+      validator: v => Object.hasOwnProperty.call(CaptionTag, v),
     },
   },
 };
@@ -41,12 +52,32 @@ export default {
 .caption {
   @include font-styles(documentation-figcaption);
 
-  &:last-child {
-    margin-top: var(--spacing-stacked-margin-large);
-  }
-
   &.centered {
     text-align: center;
+  }
+}
+
+// `space-out-between-siblings` helper would normally be used, but it won't work
+// for certain things like <picture> or <thead>/<tbody> with different
+// display types, so the spacing is manually done here for both kinds of
+// captions
+figcaption {
+  &:first-child {
+    margin: 0 0 var(--spacing-stacked-margin-large) 0;
+  }
+  &:last-child {
+    margin: var(--spacing-stacked-margin-large) 0 0 0;
+  }
+}
+caption {
+  margin: 0 0 var(--spacing-stacked-margin-large) 0;
+
+  // `caption-side` must be used for the table version of <caption> to appear
+  // underneath the table since the element must always be the first element
+  // within the <table> in the DOM according to the spec
+  &.centered {
+    caption-side: bottom;
+    margin: var(--spacing-stacked-margin-large) 0 0 0;
   }
 }
 

--- a/src/styles/core/typography/_font-styles.scss
+++ b/src/styles/core/typography/_font-styles.scss
@@ -153,7 +153,7 @@ $font-styles: (
   documentation-code-listing-number: (
     large: 12_18_normal_compact_mono,
   ),
-  documentation-figcaption: (
+  documentation-caption: (
     large: 14_21,
   ),
   documentation-declaration-link: (

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -943,7 +943,7 @@ describe('ContentNode', () => {
       expect(caption.props('title')).toBeFalsy();
       expect(caption.props('centered')).toBe(true);
       expect(caption.text()).toContain('blah');
-      // assert figurecaption is below the image
+      // assert figcaption is below the image
       expect(figure.html()).toMatchInlineSnapshot(`
         <figure-stub>
           <blockvideo-stub identifier="video.mp4"></blockvideo-stub>

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -769,7 +769,7 @@ describe('ContentNode', () => {
       expect(figure.html()).toMatchInlineSnapshot(`
         <figure-stub>
           <inlineimage-stub alt="" variants="[object Object],[object Object]"></inlineimage-stub>
-          <figurecaption-stub centered="true">
+          <figurecaption-stub centered="true" tag="figcaption">
             <p>blah</p>
           </figurecaption-stub>
         </figure-stub>
@@ -791,7 +791,7 @@ describe('ContentNode', () => {
       }, references);
       expect(wrapper.find(Figure).html()).toMatchInlineSnapshot(`
         <figure-stub>
-          <figurecaption-stub title="foo">
+          <figurecaption-stub title="foo" tag="figcaption">
             <p>blah</p>
           </figurecaption-stub>
           <inlineimage-stub alt="" variants="[object Object],[object Object]"></inlineimage-stub>
@@ -947,7 +947,7 @@ describe('ContentNode', () => {
       expect(figure.html()).toMatchInlineSnapshot(`
         <figure-stub>
           <blockvideo-stub identifier="video.mp4"></blockvideo-stub>
-          <figurecaption-stub centered="true">
+          <figurecaption-stub centered="true" tag="figcaption">
             <p>blah</p>
           </figurecaption-stub>
         </figure-stub>
@@ -1426,15 +1426,15 @@ describe('ContentNode', () => {
         metadata,
       });
 
-      const figure = wrapper.find(Figure);
-      expect(figure.exists()).toBe(true);
-      expect(figure.props('anchor')).toBe(metadata.anchor);
-      expect(figure.contains(Table)).toBe(true);
+      const table = wrapper.find('.content').find(Table);
+      expect(table.exists()).toBe(true);
+      expect(table.attributes('id')).toBe(metadata.anchor);
 
-      const caption = figure.find(FigureCaption);
+      const caption = table.find(FigureCaption);
       expect(caption.exists()).toBe(true);
       expect(caption.props('title')).toBe(metadata.title);
       expect(caption.props('centered')).toBe(false);
+      expect(caption.props('tag')).toBe('caption');
       expect(caption.contains('p')).toBe(true);
       expect(caption.text()).toContain('blah');
     });

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -16,7 +16,7 @@ import ContentNode from 'docc-render/components/ContentNode.vue';
 import DictionaryExample from 'docc-render/components/ContentNode/DictionaryExample.vue';
 import EndpointExample from 'docc-render/components/ContentNode/EndpointExample.vue';
 import Figure from 'docc-render/components/ContentNode/Figure.vue';
-import FigureCaption from 'docc-render/components/ContentNode/FigureCaption.vue';
+import Caption from 'docc-render/components/ContentNode/Caption.vue';
 import InlineImage from 'docc-render/components/ContentNode/InlineImage.vue';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
 import Table from 'docc-render/components/ContentNode/Table.vue';
@@ -113,7 +113,7 @@ describe('ContentNode', () => {
       expect(codeListing.isEmpty()).toBe(true);
     });
 
-    it('renders a `Figure`/`Figcaption` with metadata', () => {
+    it('renders a `Figure`/`Caption` with metadata', () => {
       const metadata = {
         anchor: '42',
         title: 'Listing 42',
@@ -129,7 +129,7 @@ describe('ContentNode', () => {
       expect(figure.props('anchor')).toBe(metadata.anchor);
       expect(figure.contains(CodeListing)).toBe(true);
 
-      const caption = figure.find(FigureCaption);
+      const caption = figure.find(Caption);
       expect(caption.exists()).toBe(true);
       expect(caption.props('title')).toBe(metadata.title);
       expect(caption.contains('p')).toBe(true);
@@ -714,7 +714,7 @@ describe('ContentNode', () => {
       }, {})).not.toThrow();
     });
 
-    it('renders a `Figure`/`FigureCaption` with metadata', () => {
+    it('renders a `Figure`/`Caption` with metadata', () => {
       const metadata = {
         anchor: '42',
         title: 'Figure 42',
@@ -734,14 +734,14 @@ describe('ContentNode', () => {
       expect(figure.props('anchor')).toBe(metadata.anchor);
       expect(figure.contains(InlineImage)).toBe(true);
 
-      const caption = wrapper.find(FigureCaption);
+      const caption = wrapper.find(Caption);
       expect(caption.exists()).toBe(true);
       expect(caption.contains('p')).toBe(true);
       expect(caption.props('title')).toBe(metadata.title);
       expect(caption.text()).toContain('blah');
     });
 
-    it('renders a `Figure`/`FigureCaption` without an anchor, with text under the image', () => {
+    it('renders a `Figure`/`Caption` without an anchor, with text under the image', () => {
       const metadata = {
         abstract: [{
           type: 'paragraph',
@@ -759,24 +759,24 @@ describe('ContentNode', () => {
       expect(figure.props('anchor')).toBeFalsy();
       expect(figure.contains(InlineImage)).toBe(true);
 
-      const caption = wrapper.find(FigureCaption);
+      const caption = wrapper.find(Caption);
       expect(caption.exists()).toBe(true);
       expect(caption.contains('p')).toBe(true);
       expect(caption.props('title')).toBeFalsy();
       expect(caption.props('centered')).toBe(true);
       expect(caption.text()).toContain('blah');
-      // assert figurerecaption is below the image
+      // assert figurercaption is below the image
       expect(figure.html()).toMatchInlineSnapshot(`
         <figure-stub>
           <inlineimage-stub alt="" variants="[object Object],[object Object]"></inlineimage-stub>
-          <figurecaption-stub centered="true" tag="figcaption">
+          <caption-stub centered="true" tag="figcaption">
             <p>blah</p>
-          </figurecaption-stub>
+          </caption-stub>
         </figure-stub>
       `);
     });
 
-    it('renders a `FigureCaption` before the image, if it has a title', () => {
+    it('renders a `Caption` before the image, if it has a title', () => {
       const metadata = {
         title: 'foo',
         abstract: [{
@@ -791,15 +791,15 @@ describe('ContentNode', () => {
       }, references);
       expect(wrapper.find(Figure).html()).toMatchInlineSnapshot(`
         <figure-stub>
-          <figurecaption-stub title="foo" tag="figcaption">
+          <caption-stub title="foo" tag="figcaption">
             <p>blah</p>
-          </figurecaption-stub>
+          </caption-stub>
           <inlineimage-stub alt="" variants="[object Object],[object Object]"></inlineimage-stub>
         </figure-stub>
       `);
     });
 
-    it('renders no `FigureCaption`, if there is a `title`, but no `abstract`', () => {
+    it('renders no `Caption`, if there is a `title`, but no `abstract`', () => {
       const metadata = {
         postTitle: true,
         title: 'Foo',
@@ -816,7 +816,7 @@ describe('ContentNode', () => {
       expect(figure.props('anchor')).toBe('foo-figure');
       expect(figure.contains(InlineImage)).toBe(true);
 
-      expect(wrapper.find(FigureCaption).exists()).toBe(false);
+      expect(wrapper.find(Caption).exists()).toBe(false);
     });
 
     it('renders within a `DeviceFrame`', () => {
@@ -892,7 +892,7 @@ describe('ContentNode', () => {
       }, {})).not.toThrow();
     });
 
-    it('renders a `Figure`/`FigureCaption` with metadata', () => {
+    it('renders a `Figure`/`Caption` with metadata', () => {
       const metadata = {
         anchor: 'foo',
         abstract: [{
@@ -911,7 +911,7 @@ describe('ContentNode', () => {
       expect(figure.props('anchor')).toBe('foo');
       expect(figure.contains(BlockVideo)).toBe(true);
 
-      const caption = wrapper.find(FigureCaption);
+      const caption = wrapper.find(Caption);
       expect(caption.exists()).toBe(true);
       expect(caption.contains('p')).toBe(true);
       expect(caption.props('title')).toBe(metadata.title);
@@ -919,7 +919,7 @@ describe('ContentNode', () => {
       expect(caption.text()).toContain('blah');
     });
 
-    it('renders a `Figure`/`FigureCaption` without an anchor, with text under the video', () => {
+    it('renders a `Figure`/`Caption` without an anchor, with text under the video', () => {
       const metadata = {
         abstract: [{
           type: 'paragraph',
@@ -937,19 +937,19 @@ describe('ContentNode', () => {
       expect(figure.props('anchor')).toBeFalsy();
       expect(figure.contains(BlockVideo)).toBe(true);
 
-      const caption = wrapper.find(FigureCaption);
+      const caption = wrapper.find(Caption);
       expect(caption.exists()).toBe(true);
       expect(caption.contains('p')).toBe(true);
       expect(caption.props('title')).toBeFalsy();
       expect(caption.props('centered')).toBe(true);
       expect(caption.text()).toContain('blah');
-      // assert figurerecaption is below the image
+      // assert figurecaption is below the image
       expect(figure.html()).toMatchInlineSnapshot(`
         <figure-stub>
           <blockvideo-stub identifier="video.mp4"></blockvideo-stub>
-          <figurecaption-stub centered="true" tag="figcaption">
+          <caption-stub centered="true" tag="figcaption">
             <p>blah</p>
-          </figurecaption-stub>
+          </caption-stub>
         </figure-stub>
       `);
     });
@@ -1410,7 +1410,7 @@ describe('ContentNode', () => {
       expect(table.findAll('tbody tr td').length).toBe(2);
     });
 
-    it('renders a `Figure`/`FigureCaption` with metadata', () => {
+    it('renders a `Figure`/`Caption` with metadata', () => {
       const metadata = {
         anchor: '42',
         title: 'Table 42',
@@ -1430,7 +1430,7 @@ describe('ContentNode', () => {
       expect(table.exists()).toBe(true);
       expect(table.attributes('id')).toBe(metadata.anchor);
 
-      const caption = table.find(FigureCaption);
+      const caption = table.find(Caption);
       expect(caption.exists()).toBe(true);
       expect(caption.props('title')).toBe(metadata.title);
       expect(caption.props('centered')).toBe(false);

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -763,13 +763,13 @@ describe('ContentNode', () => {
       expect(caption.exists()).toBe(true);
       expect(caption.contains('p')).toBe(true);
       expect(caption.props('title')).toBeFalsy();
-      expect(caption.props('centered')).toBe(true);
+      expect(caption.props('position')).toBe('trailing');
       expect(caption.text()).toContain('blah');
       // assert figurercaption is below the image
       expect(figure.html()).toMatchInlineSnapshot(`
         <figure-stub>
           <inlineimage-stub alt="" variants="[object Object],[object Object]"></inlineimage-stub>
-          <caption-stub centered="true" tag="figcaption">
+          <caption-stub tag="figcaption" position="trailing">
             <p>blah</p>
           </caption-stub>
         </figure-stub>
@@ -791,7 +791,7 @@ describe('ContentNode', () => {
       }, references);
       expect(wrapper.find(Figure).html()).toMatchInlineSnapshot(`
         <figure-stub>
-          <caption-stub title="foo" tag="figcaption">
+          <caption-stub title="foo" tag="figcaption" position="leading">
             <p>blah</p>
           </caption-stub>
           <inlineimage-stub alt="" variants="[object Object],[object Object]"></inlineimage-stub>
@@ -915,7 +915,7 @@ describe('ContentNode', () => {
       expect(caption.exists()).toBe(true);
       expect(caption.contains('p')).toBe(true);
       expect(caption.props('title')).toBe(metadata.title);
-      expect(caption.props('centered')).toBe(true);
+      expect(caption.props('position')).toBe('trailing');
       expect(caption.text()).toContain('blah');
     });
 
@@ -941,13 +941,13 @@ describe('ContentNode', () => {
       expect(caption.exists()).toBe(true);
       expect(caption.contains('p')).toBe(true);
       expect(caption.props('title')).toBeFalsy();
-      expect(caption.props('centered')).toBe(true);
+      expect(caption.props('position')).toBe('trailing');
       expect(caption.text()).toContain('blah');
       // assert figcaption is below the image
       expect(figure.html()).toMatchInlineSnapshot(`
         <figure-stub>
           <blockvideo-stub identifier="video.mp4"></blockvideo-stub>
-          <caption-stub centered="true" tag="figcaption">
+          <caption-stub tag="figcaption" position="trailing">
             <p>blah</p>
           </caption-stub>
         </figure-stub>
@@ -1433,7 +1433,7 @@ describe('ContentNode', () => {
       const caption = table.find(Caption);
       expect(caption.exists()).toBe(true);
       expect(caption.props('title')).toBe(metadata.title);
-      expect(caption.props('centered')).toBe(false);
+      expect(caption.props('position')).toBe('leading');
       expect(caption.props('tag')).toBe('caption');
       expect(caption.contains('p')).toBe(true);
       expect(caption.text()).toContain('blah');

--- a/tests/unit/components/ContentNode/Caption.spec.js
+++ b/tests/unit/components/ContentNode/Caption.spec.js
@@ -9,13 +9,13 @@
 */
 
 import { shallowMount } from '@vue/test-utils';
-import FigureCaption from 'docc-render/components/ContentNode/FigureCaption.vue';
+import Caption from 'docc-render/components/ContentNode/Caption.vue';
 
-describe('FigureCaption', () => {
+describe('Caption', () => {
   it('renders a <figcaption> with the title and slot content', () => {
     const propsData = { title: 'Figure 1', tag: 'figcaption' };
     const slots = { default: '<p>Blah</p>' };
-    const wrapper = shallowMount(FigureCaption, { propsData, slots });
+    const wrapper = shallowMount(Caption, { propsData, slots });
 
     expect(wrapper.is('figcaption')).toBe(true);
     expect(wrapper.text()).toBe('Figure 1\u00a0Blah');
@@ -24,7 +24,7 @@ describe('FigureCaption', () => {
   it('renders a <figcaption> with slot content only', () => {
     const propsData = { tag: 'figcaption' };
     const slots = { default: '<p>Blah</p>' };
-    const wrapper = shallowMount(FigureCaption, { propsData, slots });
+    const wrapper = shallowMount(Caption, { propsData, slots });
 
     expect(wrapper.is('figcaption')).toBe(true);
     expect(wrapper.text()).toBe('Blah');
@@ -34,14 +34,14 @@ describe('FigureCaption', () => {
   it('renders a <figcaption> centered', () => {
     const propsData = { centered: true, tag: 'figcaption' };
     const slots = { default: '<p>Blah</p>' };
-    const wrapper = shallowMount(FigureCaption, { slots, propsData });
+    const wrapper = shallowMount(Caption, { slots, propsData });
     expect(wrapper.classes()).toContain('centered');
   });
 
   it('renders a <caption>', () => {
     const propsData = { tag: 'caption' };
     const slots = { default: '<p>Blah</p>' };
-    const wrapper = shallowMount(FigureCaption, { slots, propsData });
+    const wrapper = shallowMount(Caption, { slots, propsData });
     expect(wrapper.is('caption')).toBe(true);
   });
 });

--- a/tests/unit/components/ContentNode/Caption.spec.js
+++ b/tests/unit/components/ContentNode/Caption.spec.js
@@ -31,11 +31,11 @@ describe('Caption', () => {
     expect(wrapper.text()).not.toBe('\u00a0Blah');
   });
 
-  it('renders a <figcaption> centered', () => {
-    const propsData = { centered: true, tag: 'figcaption' };
+  it('renders a trailing <figcaption>', () => {
+    const propsData = { position: 'trailing', tag: 'figcaption' };
     const slots = { default: '<p>Blah</p>' };
     const wrapper = shallowMount(Caption, { slots, propsData });
-    expect(wrapper.classes()).toContain('centered');
+    expect(wrapper.classes()).toContain('trailing');
   });
 
   it('renders a <caption>', () => {

--- a/tests/unit/components/ContentNode/FigureCaption.spec.js
+++ b/tests/unit/components/ContentNode/FigureCaption.spec.js
@@ -13,7 +13,7 @@ import FigureCaption from 'docc-render/components/ContentNode/FigureCaption.vue'
 
 describe('FigureCaption', () => {
   it('renders a <figcaption> with the title and slot content', () => {
-    const propsData = { title: 'Figure 1' };
+    const propsData = { title: 'Figure 1', tag: 'figcaption' };
     const slots = { default: '<p>Blah</p>' };
     const wrapper = shallowMount(FigureCaption, { propsData, slots });
 
@@ -22,8 +22,9 @@ describe('FigureCaption', () => {
   });
 
   it('renders a <figcaption> with slot content only', () => {
+    const propsData = { tag: 'figcaption' };
     const slots = { default: '<p>Blah</p>' };
-    const wrapper = shallowMount(FigureCaption, { slots });
+    const wrapper = shallowMount(FigureCaption, { propsData, slots });
 
     expect(wrapper.is('figcaption')).toBe(true);
     expect(wrapper.text()).toBe('Blah');
@@ -31,8 +32,16 @@ describe('FigureCaption', () => {
   });
 
   it('renders a <figcaption> centered', () => {
+    const propsData = { centered: true, tag: 'figcaption' };
     const slots = { default: '<p>Blah</p>' };
-    const wrapper = shallowMount(FigureCaption, { slots, propsData: { centered: true } });
+    const wrapper = shallowMount(FigureCaption, { slots, propsData });
     expect(wrapper.classes()).toContain('centered');
+  });
+
+  it('renders a <caption>', () => {
+    const propsData = { tag: 'caption' };
+    const slots = { default: '<p>Blah</p>' };
+    const wrapper = shallowMount(FigureCaption, { slots, propsData });
+    expect(wrapper.is('caption')).toBe(true);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 30234820

## Summary

Use `<caption>` for tables instead of `<figcaption>`.
    
Tables with captions will no longer be embedded in a `<figure>` with a `<figcaption>`. Instead, the `<table>` will simply have a `<caption>` as its first element when needed.
    
For table captions, the position of the caption must be done in CSS since the `<caption>` is always required to be the first element of the `<table>` and cannot be moved to the end like they can with figure captions.

## Testing

Steps:
1. Find a page with a captioned table
2. Verify that the DOM structure now looks like `<table><caption>` instead of `<figure><figcaption><table>`
3. Verify that there are no visual regressions with figures, captions, or tables

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
