### PR TITLE
Code blocks should not be tabbable 

### DIFF
--- a/src/components/CodeBlock.vue
+++ b/src/components/CodeBlock.vue
@@ -10,7 +10,6 @@
 
 <template>
   <code
-    tabindex="0"
     :data-before-code="$t('accessibility.code.start')"
     :data-after-code="$t('accessibility.code.end')"
   >


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://111580884

## Summary
Code blocks should not be tubbable unless there are links within the code block.