### PR TITLE
Add syntax colors for diff additions/deletions.

### DIFF
--- a/src/styles/core/_syntax.scss
+++ b/src/styles/core/_syntax.scss
@@ -10,9 +10,15 @@
 
 // Map each color to the list of syntax highlighter tokens that use it
 $syntax-tokens-for-color: (
+  addition: (
+    addition,
+  ),
   comments: (
     comment,
     quote
+  ),
+  deletion: (
+    deletion,
   ),
   keywords: (
     keyword,

--- a/src/styles/core/colors/_light.scss
+++ b/src/styles/core/colors/_light.scss
@@ -142,9 +142,11 @@
   --color-step-focused: var(--color-figure-light-gray);
   --color-step-text: var(--color-figure-gray-secondary);
   --color-svg-icon: #{light-color(figure-gray-secondary)};
+  --color-syntax-addition: var(--color-figure-green);
   --color-syntax-attributes: rgb(148, 113, 0);
   --color-syntax-characters: rgb(39, 42, 216);
   --color-syntax-comments: rgb(112, 127, 140);
+  --color-syntax-deletion: var(--color-figure-red);
   --color-syntax-documentation-markup: rgb(80, 99, 117);
   --color-syntax-documentation-markup-keywords: rgb(80, 99, 117);
   --color-syntax-heading: rgb(186, 45, 162);


### PR DESCRIPTION
Bug/issue #, if applicable: #712 

## Summary

Maps the appropriate colors for the "addition" and "deletion" syntax nodes when highlighting code listings of language "diff" or "patch".

Before:
![before screenshot with no syntax highlighting](https://github.com/apple/swift-docc-render/assets/212918/2b61e1f6-27e3-4d83-9cd5-6c5b05b7fb92)

After:
![after screenshot with syntax highlighting](https://github.com/apple/swift-docc-render/assets/212918/2f5d5560-ae96-4b4e-9a3e-21bb48cd8df5)

Resolves #712 

## Testing

Example code listing:

```diff
diff --git a/1.txt b/2.txt
index de98044..6372083 100644
--- a/1.txt
+++ b/2.txt
@@ -1,3 +1,3 @@
 a
-b
 c
+d
```

Steps:
1. Copy the contents of the example diff from above to a fenced code block with language "diff" in the markdown (or use any other example diff).
2. Verify that the lines starting with "+" are now in green
3. Verify that the lines starting with "-" are now in red

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS-only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
