### PR TITLE
Add support for hard line breaks from markdown text

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -478,7 +478,11 @@ function renderNode(createElement, references) {
         renderChildren(node.inlineContent)
       ));
     case InlineType.text:
-      return node.text;
+      return node.text === '\n' ? (
+        createElement('br')
+      ) : (
+        node.text
+      );
     case InlineType.superscript:
       return createElement('sup', renderChildren(node.inlineContent));
     case InlineType.subscript:

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -1344,6 +1344,15 @@ describe('ContentNode', () => {
       const content = wrapper.find('.content');
       expect(content.text()).toBe('foobar');
     });
+
+    it('renders a <br> if the text is a single newline', () => {
+      const wrapper = mountWithItem({
+        type: 'text',
+        text: '\n',
+      });
+      const br = wrapper.find('.content br');
+      expect(br.exists()).toBe(true);
+    });
   });
 
   describe('with type="table"', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: #697 

## Summary

DocC now generates a single text node with a newline character to represent a hard line break that can be expressed in markdown using the "\\" character to end a line that is followed immediately by a next line of text—this can be mapped to a hard line break in HTML by using the `<br>` HTML element, since newlines are normally collapsed into whitespaces within normal paragraphs.

For example, the following markdown text should be rendered how it looks (minus the escape character):

```markdown
This text should\
appear on two lines.

Next paragraph.
```

Resolves #697 

_Note: marking this as a draft PR until I verify that the data is expected to come through like this always_

## Dependencies

https://github.com/apple/swift-docc/pull/633 (already merged to swift-docc#main)

## Testing

Steps:
1. Checkout this branch and build it with `npm run build`
2. Download [example-text.patch](https://github.com/apple/swift-docc-render/files/11986866/example-text.patch) and run `git apply example-text.patch` to quickly make some example content in the Swift-DocC-Render docs
3. Download/build the latest swift-docc from main and run `DOCC_HTML_DIR=/path/to/swift-docc-render/dist swift run docc preview /path/to/swift-docc-render/SwiftDocCRender.docc`
4. Open http://localhost:8080/documentation/swiftdoccrender and verify that the example text looks like it should, with 2 new paragraphs where the first paragraph has two distinct lines

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
