### PR TITLE
[5.9] Add syntax colors for diff additions/deletions

### DIFF
--- a/src/styles/core/_syntax.scss
+++ b/src/styles/core/_syntax.scss
@@ -10,9 +10,15 @@
 
 // Map each color to the list of syntax highlighter tokens that use it
 $syntax-tokens-for-color: (
+  addition: (
+    addition,
+  ),
   comments: (
     comment,
     quote
+  ),
+  deletion: (
+    deletion,
   ),
   keywords: (
     keyword,

--- a/src/styles/core/colors/_light.scss
+++ b/src/styles/core/colors/_light.scss
@@ -142,9 +142,11 @@
   --color-step-focused: var(--color-figure-light-gray);
   --color-step-text: var(--color-figure-gray-secondary);
   --color-svg-icon: #{light-color(figure-gray-secondary)};
+  --color-syntax-addition: var(--color-figure-green);
   --color-syntax-attributes: rgb(148, 113, 0);
   --color-syntax-characters: rgb(39, 42, 216);
   --color-syntax-comments: rgb(112, 127, 140);
+  --color-syntax-deletion: var(--color-figure-red);
   --color-syntax-documentation-markup: rgb(80, 99, 117);
   --color-syntax-documentation-markup-keywords: rgb(80, 99, 117);
   --color-syntax-heading: rgb(186, 45, 162);


### PR DESCRIPTION
- **Explanation:** Adds missing color mappings for code listings with `diff` language
- **Scope:** Impacts any pages with a code listing with language `diff`
- **Issue:** rdar://105420253 (#712 )
- **Risk:** Low, 2 added CSS variables for syntax span nodes
- **Testing:** Verify that red/green added/deleted lines are now visible in code listings of language `diff`
- **Reviewer:** @dobromir-hristov 
- **Original PR:** #713 