### PR TITLE
[5.9] Add support for hard line breaks from markdown text

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -478,7 +478,11 @@ function renderNode(createElement, references) {
         renderChildren(node.inlineContent)
       ));
     case InlineType.text:
-      return node.text;
+      return node.text === '\n' ? (
+        createElement('br')
+      ) : (
+        node.text
+      );
     case InlineType.superscript:
       return createElement('sup', renderChildren(node.inlineContent));
     case InlineType.subscript:

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -1344,6 +1344,15 @@ describe('ContentNode', () => {
       const content = wrapper.find('.content');
       expect(content.text()).toBe('foobar');
     });
+
+    it('renders a <br> if the text is a single newline', () => {
+      const wrapper = mountWithItem({
+        type: 'text',
+        text: '\n',
+      });
+      const br = wrapper.find('.content br');
+      expect(br.exists()).toBe(true);
+    });
   });
 
   describe('with type="table"', () => {


### PR DESCRIPTION
- **Explanation:** Adds support for rendering hard line breaks within individual paragraphs of content
- **Scope:** Impacts pages where `\` character is used to hard break lines in the markdown input
- **Issue:** rdar://101684224 (#697)
- **Risk:** Low, minor JS logic change for mapping text nodes to HTML
- **Testing:** Verify that hard line breaks from markdown sources now appear on subsequent lines instead of getting collapsed into a single space or another paragraph in the rendered page
- **Reviewer:** @dobromir-hristov and @Kyle-Ye 
- **Original PR:** #714 