### PR TITLE
don't display declaration platforms if they're all the same

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
@@ -53,6 +53,7 @@ import DeclarationSourceLink
 
 import { ChangeTypes } from 'docc-render/constants/Changes';
 import { multipleLinesClass } from 'docc-render/constants/multipleLines';
+import { isEqual } from 'docc-render/utils/arrays';
 
 export default {
   name: 'Declaration',
@@ -85,11 +86,18 @@ export default {
   computed: {
     /**
      * Show the captions of DeclarationGroup without changes
-     * when there are more than one declarations
+     * when there are multiple sets of platforms among the
+     * declarations.
      * @returns {boolean}
      */
     hasPlatformVariants() {
-      return this.declarations.length > 1;
+      const platforms = [];
+      for (let i = 0; i < this.declarations.length; i += 1) {
+        if (!platforms.some(platform => isEqual(platform, this.declarations[i].platforms))) {
+          platforms.push(this.declarations[i].platforms);
+        }
+      }
+      return platforms.length > 1;
     },
     /**
      * Returns whether there are declaration changes.

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/Declaration.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/Declaration.spec.js
@@ -140,6 +140,31 @@ describe('Declaration', () => {
     expect(labels.at(1).props('shouldCaption')).toBe(true);
   });
 
+  it('does not render captions when multiple declarations have the same platforms', () => {
+    const declarations = [
+      propsData.declarations[0],
+      {
+        platforms: [
+          'macOS',
+        ],
+        tokens: [
+          {
+            kind: TokenKind.keyword,
+            text: 'let',
+          },
+          ...propsData.declarations[0].tokens.slice(1),
+        ],
+      },
+    ];
+
+    wrapper.setProps({ declarations });
+
+    const labels = wrapper.findAll(DeclarationGroup);
+    expect(labels.length).toBe(declarations.length);
+    expect(labels.at(0).props('shouldCaption')).toBe(false);
+    expect(labels.at(1).props('shouldCaption')).toBe(false);
+  });
+
   it('renders a `DeclarationDiff` when there are API changes for current and previous', () => {
     // no DeclarationDiff if no changes
     expect(wrapper.find(DeclarationDiff).exists()).toBe(false);


### PR DESCRIPTION
Bug/issue #, if applicable: None (yet)

## Summary

This is an experiment to accompany https://github.com/apple/swift-docc/pull/654 - That PR and its SymbolKit dependency change the Declarations section to potentially include multiple declarations from the same platform. This PR updates the Declaration component to drop the platform caption if all the declaration groups have the same platform sets.

Before this change, this is what this situation would look like:

<img width="779" alt="image" src="https://github.com/apple/swift-docc-render/assets/5217170/c5544e84-6066-452f-b83c-2c22fd250805">

With this PR, the symbol looks like this: (this screenshot is using a local Swift-DocC-Render build on my machine, but the above screenshot is using the Swift-DocC-Render that shipped with Xcode 14.3.1, which hopefully explains the padding and heading differences)

<img width="800" alt="image" src="https://github.com/apple/swift-docc-render/assets/5217170/cb2a1b16-5be1-4183-9797-f1d482dad88e">

## Dependencies

This can land without it, but it's only useful with https://github.com/apple/swift-docc/pull/654.

## Testing

Use the branch from https://github.com/apple/swift-docc/pull/654, then, in the Swift-DocC repo:

Steps:
1. `DOCC_HTML_DIR=/path/to/swift-docc-render/dist swift run docc preview 'Tests/SwiftDocCTests/Test Bundles/AlternateDeclarations.docc'`
2. Ensure that the `MyClass/present(completion:)` page doesn't print the "macOS" caption on its declarations.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
