### PR TITLE
Fix issue where code listings in columns can obscure subsequent content

### DIFF
--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -184,7 +184,6 @@ code {
 
 .code-listing {
   flex-direction: column;
-  min-height: 100%;
   border-radius: var(--code-border-radius, $border-radius);
   overflow: hidden;
   // we need to establish a new stacking context to resolve a Safari bug where


### PR DESCRIPTION
Bug/issue #, if applicable: 112272083

## Summary

Removes an unnecessary `min-height` rule for code listing containers.

This rule causes an issue when a listing is in a DocC `@Col` directive where the listing is rendered too big and on top of the content below it.

Example before/after screenshots:

**Before**
<img width="717" alt="Screenshot 2023-07-14 at 11 06 23 AM" src="https://github.com/apple/swift-docc-render/assets/212918/b5f5d6bb-c76b-4b88-9ffe-7d46ec2e0bfc">

**After**
<img width="777" alt="Screenshot 2023-07-14 at 11 09 00 AM" src="https://github.com/apple/swift-docc-render/assets/212918/a9d83a24-3a86-467c-84a2-e7a8eb48642f">

## Testing

Steps:
1. Add a `@Row` with 2 `@Col` above some existing content where each column has a code listing. As an example, you can apply this [patch][1] to add some example content to the `SwiftDocCRender.docc` docs in this repo.
2. Verify that the code listings get rendered as expected, without covering up the content below it. If you're using the example patch, you can test this with `DOCC_HTML_DIR=/path/to/swift-docc-render/dist npm run docs:preview` (remember to build this branch first)
3. Check for any possible regressions with code listings in other situations, especially related to overflow scrolling.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary

[1]: https://github.com/apple/swift-docc-render/files/12052969/cols-with-code.patch