### PR TITLE
Fix edge case issue where tutorials-overview bg may appear light

### DIFF
--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -121,6 +121,8 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .tutorials-overview {
+  background: dark-color(fill);
+  flex: 1;
   height: 100%;
 
   .radial-gradient {


### PR DESCRIPTION
Bug/issue #, if applicable: 108634043

## Summary

In situations with no footer and a long viewport height and little actual content, the background of the empty space will be white.

It should be a darker fill color in any light/dark/auto appearance since that page purposefully has an "always-dark" design theme.

## Testing

Steps:
1. Open an existing tutorials overview page and remove any chapters it has, if any.
2. Render that page with this branch using `VUE_APP_TARGET=ide` and verify that the empty space in a tall viewport appears dark instead of light, regardless of the user's overall light/dark/auto preference.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~ (CSS-only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
