### PR TITLE
[5.9] Fix edge case issue where tutorials-overview bg may appear light

### DIFF
--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -121,6 +121,8 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .tutorials-overview {
+  background: dark-color(fill);
+  flex: 1;
   height: 100%;
 
   .radial-gradient {


### PR DESCRIPTION
- **Explanation:** Fixes edge case issue where background of "always-dark" page may appear white in certain scenarios
- **Scope:** Impacts tutorials-overview page when little/no content has been added and user is viewing the page without a footer on a tall viewport.
- **Issue:** rdar://108634043
- **Risk:** Low, minor CSS change
- **Testing:** Verified that the page background is now dark in the problematic scenario and that there are no other issues introduced with this page in other, more common scenarios.
- **Reviewer:** @hqhhuang 
- **Original PR:** #719 