### PR TITLE
Fix issue where backslash newline delimiters in multiline Swift string literals break syntax highlighting

### DIFF
--- a/src/utils/custom-highlight-lang/swift.js
+++ b/src/utils/custom-highlight-lang/swift.js
@@ -65,7 +65,7 @@ export default function swiftOverride(hljs) {
       ...variant,
       contains: variant.contains.map(mode => (isEscapedNewlineMode(mode) ? ({
         className: 'subst',
-        begin: /\\/,
+        begin: /\\#{0,3}/,
         end: /[\t ]*(?:[\r\n]|\r\n)/,
         // same match as the original one but with an explicit start/end match so
         // that the end one can be excluded from the resulting span

--- a/src/utils/custom-highlight-lang/swift.js
+++ b/src/utils/custom-highlight-lang/swift.js
@@ -41,5 +41,20 @@ export default function swiftOverride(hljs) {
     };
   }
 
+  const str = language.contains.find(({ className }) => className === 'string');
+  str.variants = str.variants.map(variant => ({
+    ...variant,
+    // omit the "ESCAPED_NEWLINE"/("subst") highlight.js tokenizers that
+    // highlight.js uses to syntax highlight backslash delimiters in multi-line
+    // string literals to prevent an issue where they interrupt the multi-line
+    // string literal tokenizer
+    contains: variant.contains.reduce((acc, c) => {
+      if (c.className === 'subst' && c.match) {
+        return acc;
+      }
+      return acc.concat(c);
+    }, []),
+  }));
+
   return language;
 }

--- a/src/utils/custom-highlight-lang/swift.js
+++ b/src/utils/custom-highlight-lang/swift.js
@@ -58,20 +58,23 @@ export default function swiftOverride(hljs) {
   // span token that it generates, because this causes issues with our
   // line-number + multi-line string literal logic when the span for the
   // backslash token is split across multiple lines
-  const str = language.contains.find(({ className }) => className === 'string');
-  str.variants = str.variants.map(variant => ({
-    ...variant,
-    contains: variant.contains.map(mode => (isEscapedNewlineMode(mode) ? ({
-      className: 'subst',
-      begin: /\\/,
-      end: /[\t ]*(?:[\r\n]|\r\n)/,
-      // same match as the original one but with an explicit start/end match so
-      // that the end one can be excluded from the resulting span
-      excludeEnd: true,
-    }) : (
-      mode
-    ))),
-  }));
+  const strIndex = language.contains.findIndex(({ className }) => className === 'string');
+  language.contains[strIndex] = {
+    ...language.contains[strIndex],
+    variants: language.contains[strIndex].variants.map(variant => ({
+      ...variant,
+      contains: variant.contains.map(mode => (isEscapedNewlineMode(mode) ? ({
+        className: 'subst',
+        begin: /\\/,
+        end: /[\t ]*(?:[\r\n]|\r\n)/,
+        // same match as the original one but with an explicit start/end match so
+        // that the end one can be excluded from the resulting span
+        excludeEnd: true,
+      }) : (
+        mode
+      ))),
+    })),
+  };
 
   return language;
 }

--- a/tests/unit/utils/syntax-highlight.spec.js
+++ b/tests/unit/utils/syntax-highlight.spec.js
@@ -136,6 +136,29 @@ describe("syntax-highlight", () => {
     `);
   });
 
+  it('keeps escaped newline tokens on the same line for multiline string literals', async () => {
+    const content = [
+      'let multiline = """',
+      'a \\',
+      'b',
+      '',
+      'c \\',
+      'd',
+      '"""',
+    ];
+    const { highlightedCode, sanitizedCode } = await prepare(content, 'swift');
+    expect(sanitizedCode).not.toEqual(highlightedCode);
+    expect(sanitizedCode).toMatchInlineSnapshot(`
+      <span class="syntax-keyword">let</span> multiline <span class="syntax-operator">=</span> <span class="syntax-string">"""</span>
+      <span class="syntax-string">a <span class="syntax-subst">\\</span></span>
+      <span class="syntax-string">b</span>
+      <span class="syntax-string"></span>
+      <span class="syntax-string">c <span class="syntax-subst">\\</span></span>
+      <span class="syntax-string">d</span>
+      <span class="syntax-string">"""</span>
+    `);
+  });
+
   it("wraps multiline nested html elements", () => {
     const code = document.createElement("CODE");
     code.innerHTML = `<span class="syntax-function">function <span class="syntax-title function_">someName</span>(<span class="syntax-params">foo,


### PR DESCRIPTION
Bug/issue #, if applicable: 102993199

## Summary

Fixes an issue demonstrated in the following screenshots where the syntax highlighting looks broken for Swift code listings with multi-line string literals that have backslash newline delimiters.

Before:
![before](https://github.com/apple/swift-docc-render/assets/212918/bfcc9466-bbc6-4dcd-a37e-354bfe30a5b7)

After:
![after](https://github.com/apple/swift-docc-render/assets/212918/5901113a-8d01-4bdd-b65c-4c5ae6f42fc0)

### Details

This happens because the HTML `<span>` for the "subst" token representing the backslash also includes the newline whitespace, and that causes issue when our line-by-line logic for multi-line syntax encounters this span that is broken onto multiple lines.

To fix it, we are simply overriding the default sub-mode from highlight.js for this token to _not_ include the newline characters in the resulting `<span>`.

## Testing

Steps:
1. Checkout this branch and run the dev server with `VUE_APP_DEV_SERVER_PROXY=https://docs.swift.org/swift-book npm run serve`
2. Open http://localhost:8080/documentation/the-swift-programming-language/stringsandcharacters and verify that the broken code listings with backslash delimiters look right now
3. Compare with https://docs.swift.org/swift-book/documentation/the-swift-programming-language/stringsandcharacters and verify that there are no other regressions related to Swift string literal syntax highlighting

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
