### PR TITLE
Ensure highlight.js builds only the files that are imported

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
   moduleNameMapper: {
     '^docc-render/(.*)$': '<rootDir>/src/$1',
     '^theme/(.*)$': '<rootDir>/src/$1',
+    '^highlight-js-alias/(.*)$': '<rootDir>/node_modules/highlight.js/$1',
   },
   testEnvironment: 'jest-environment-jsdom',
   setupFiles: ['./tests/unit/config.js'],

--- a/src/setup-utils/vue-config-utils.js
+++ b/src/setup-utils/vue-config-utils.js
@@ -53,6 +53,7 @@ function baseChainWebpack(config) {
   // Add theme fallback resolver
   config.resolve.alias.set('theme', themeUtils.getThemePaths());
   config.resolve.alias.set('docc-render', path.resolve(__dirname, '../'));
+  config.resolve.alias.set('highlight-js-alias', path.dirname(require.resolve('highlight.js/package.json')));
 
   // Add license header to built files
   config
@@ -68,7 +69,7 @@ function baseChainWebpack(config) {
     .plugin('LanguagesPlugin')
     .use(webpack.ContextReplacementPlugin, [
       /highlight\.js\/lib\/languages$/,
-      new RegExp(`/(${[builtinLanguages, envLanguages].join('|')})$`),
+      new RegExp(`^./(${[builtinLanguages, envLanguages].filter(Boolean).join('|')}).js$`),
     ]);
 }
 

--- a/src/setup-utils/vue-config-utils.js
+++ b/src/setup-utils/vue-config-utils.js
@@ -69,7 +69,7 @@ function baseChainWebpack(config) {
     .plugin('LanguagesPlugin')
     .use(webpack.ContextReplacementPlugin, [
       /highlight\.js\/lib\/languages$/,
-      new RegExp(`^./(${[builtinLanguages, envLanguages].filter(Boolean).join('|')}).js$`),
+      new RegExp(`^./(${[builtinLanguages, envLanguages].filter(Boolean).join('|')})\\.js$`),
     ]);
 }
 

--- a/src/utils/syntax-highlight.js
+++ b/src/utils/syntax-highlight.js
@@ -90,7 +90,7 @@ async function importHighlightFileForLanguage(language) {
         languageFile = await import(
           // See bug https://github.com/webpack/webpack/issues/13865
           /* webpackChunkName: "highlight-js-[request]" */
-          `@/../node_modules/highlight.js/lib/languages/${file}`
+          `highlight-js-alias/lib/languages/${file}`
         );
       }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 113252221

## Summary

Fixes and issue with webpack pulling in more highlight.js files than it should + fixes the node modules path

## Dependencies

NA

## Testing

Steps:
1. Ensure when building, we build the correct set of language files
2. Ensure the new import path does not cause errors when referenced by extending docc-render

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
