### PR TITLE
Ensure articles with the name "Tutorials" render with the right component

### DIFF
--- a/src/setup-utils/SwiftDocCRenderRouter.js
+++ b/src/setup-utils/SwiftDocCRenderRouter.js
@@ -19,7 +19,7 @@ import { baseUrl } from 'docc-render/utils/theme-settings';
 import { addPrefixedRoutes } from 'docc-render/utils/route-utils';
 import { notFoundRouteName } from 'docc-render/constants/router';
 
-const defaultRoutes = [...addPrefixedRoutes(routes, [notFoundRouteName]), ...routes];
+const defaultRoutes = [...routes, ...addPrefixedRoutes(routes, [notFoundRouteName])];
 
 export default function createRouterInstance(routerConfig = {}) {
   const router = new Router({

--- a/tests/unit/setup-utils/SwiftDocCRenderRouter.spec.js
+++ b/tests/unit/setup-utils/SwiftDocCRenderRouter.spec.js
@@ -105,4 +105,93 @@ describe('SwiftDocCRenderRouter', () => {
     window.dispatchEvent(new Event('unload'));
     expect(saveScrollOnReload).toHaveBeenCalledTimes(1);
   });
+
+  describe('route resolving', () => {
+    let router;
+
+    beforeAll(() => {
+      jest.resetModules();
+      jest.unmock('vue-router');
+      // eslint-disable-next-line global-require
+      router = require('docc-render/setup-utils/SwiftDocCRenderRouter').default();
+    });
+
+    const resolve = path => router.resolve(path).route;
+
+    it('resolves paths to the "tutorials-overview" route', () => {
+      const route = 'tutorials-overview';
+
+      expect(resolve('/tutorials/foo').name).toBe(route);
+      expect(resolve('/tutorials/bar').name).toBe(route);
+
+      expect(resolve('/tutorials/foo/bar').name).not.toBe(route);
+
+      expect(resolve('/tutorials/documentation').name).toBe(route);
+    });
+
+    it('resolves paths to the "tutorials-overview-locale" route', () => {
+      const route = 'tutorials-overview-locale';
+
+      expect(resolve('/en-US/tutorials/foobar').name).toBe(route);
+      expect(resolve('/ja-JP/tutorials/foobarbaz').params).toEqual({
+        id: 'foobarbaz',
+        locale: 'ja-JP',
+      });
+      expect(resolve('/zh-CN/tutorials/foo/bar').name).not.toBe(route);
+    });
+
+    it('resolves paths to the "topic" route', () => {
+      const route = 'topic';
+      expect(resolve('/tutorials/foo/bar').name).toBe(route);
+      expect(resolve('/tutorials/foobar/baz').name).toBe(route);
+      expect(resolve('/tutorials/documentation/foo').name).toBe(route);
+    });
+
+    it('resolves paths to the "topic-locale" route', () => {
+      const route = 'topic-locale';
+
+      expect(resolve('/en-US/tutorials/foo/bar').name).toBe(route);
+      expect(resolve('/ja-JP/tutorials/foo/bar').params).toEqual({
+        id: 'foo',
+        locale: 'ja-JP',
+        pathMatch: 'bar',
+      });
+      expect(resolve('/zh-CN/tutorials/foo/bar/baz').params).toEqual({
+        id: 'foo',
+        locale: 'zh-CN',
+        pathMatch: 'bar/baz',
+      });
+    });
+
+    it('resolves paths to the "documentation-topic" route', () => {
+      const route = 'documentation-topic';
+
+      expect(resolve('/documentation/foo').name).toBe(route);
+      expect(resolve('/documentation/bar').name).toBe(route);
+      expect(resolve('/documentation/foobar').params.pathMatch).toBe('foobar');
+
+      expect(resolve('/documentation/tutorials').name).toBe(route);
+      expect(resolve('/documentation/tutorials').params.pathMatch).toBe('tutorials');
+    });
+
+    it('resolves paths to the "documentation-topic-locale" route', () => {
+      const route = 'documentation-topic-locale';
+
+      expect(resolve('/en-US/documentation/foo').name).toBe(route);
+      expect(resolve('/en-US/documentation/foo').params).toEqual({
+        locale: 'en-US',
+        pathMatch: 'foo',
+      });
+      expect(resolve('/ja-JP/documentation/bar').name).toBe(route);
+      expect(resolve('/ja-JP/documentation/bar').params).toEqual({
+        locale: 'ja-JP',
+        pathMatch: 'bar',
+      });
+      expect(resolve('/zh-CN/documentation/baz').name).toBe(route);
+      expect(resolve('/zh-CN/documentation/baz/qux').params).toEqual({
+        locale: 'zh-CN',
+        pathMatch: 'baz/qux',
+      });
+    });
+  });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 113289632 (#722)

## Summary

This fixes an issue where the wrong component is used to render a documentation article if it has the name "Tutorials".

This happens because the locale-specific tutorials-overview route matches the URL for this article before the expected route for documentation topics matches it. To fix it, I simply have re-ordered the routes definition so that the locale-specific versions come after the normal ones instead of before.

\cc @jiachenyee

## Testing

Steps:
1. Checkout this branch and run the dev server with `VUE_APP_DEV_SERVER_PROXY=https://bug.jiachen.app npm run serve`
2. Open http://localhost:8080/documentation/tutorials and verify that it gets rendered as a normal documentation article and doesn't appear to be a blank tutorials-overview page anymore
3. Check that other existing routes still work as expected, including locale-specific ones if possible

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (no setup to test route config)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
