### PR TITLE
Disallow selection of invisible text for linkable headings

### DIFF
--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -95,4 +95,8 @@ $icon-margin: 7px;
     }
   }
 }
+
+.visuallyhidden {
+  user-select: none;
+}
 </style>

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -16,11 +16,11 @@
     <router-link
       v-if="shouldLink"
       :to="{ hash: `#${anchor}` }"
+      :data-after-text="$t('accessibility.in-page-link')"
       class="header-anchor"
       @click="handleFocusAndScroll(anchor)"
     >
       <slot />
-      <span class="visuallyhidden" >{{ $t('accessibility.in-page-link') }}</span>
       <LinkIcon class="icon" aria-hidden="true" />
     </router-link>
     <template v-else>
@@ -79,6 +79,11 @@ $icon-margin: 7px;
   position: relative;
   padding-right: $icon-size-default + $icon-margin;
   display: inline-block;
+
+  &::after {
+    @include visuallyhidden;
+    content: attr(data-after-text);
+  }
 
   .icon {
     position: absolute;

--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -100,8 +100,4 @@ $icon-margin: 7px;
     }
   }
 }
-
-.visuallyhidden {
-  user-select: none;
-}
 </style>

--- a/tests/unit/components/ContentNode/LinkableHeading.spec.js
+++ b/tests/unit/components/ContentNode/LinkableHeading.spec.js
@@ -48,7 +48,8 @@ describe('LinkableHeading', () => {
     expect(wrapper.attributes('id')).toBe('title');
     const headerAnchor = wrapper.find('.header-anchor');
     expect(headerAnchor.props('to')).toEqual({ hash: '#title' });
-    expect(headerAnchor.text()).toBe('Title accessibility.in-page-link');
+    expect(headerAnchor.text()).toBe('Title');
+    expect(headerAnchor.attributes('data-after-text')).toBe('accessibility.in-page-link');
   });
 
   it('does not render anchor if there is no anchor', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 115140459

## Summary

Prevents an issue where the text _"in page link"_ is unexpectedly included when selecting and copy/pasting a linkable heading.

## Testing

Steps:
1. Run `VUE_APP_DEV_SERVER_PROXY=https://mportiz08.github.io/swift-docc npm run serve` and open http://localhost:8080/documentation/docc (or any content with linkable subheadings)
2. Use the mouse to select and copy/paste the text of a linkable heading, like [this one](http://localhost:8080/documentation/docc#structure-and-formatting)
3. Verify that the pasted text matches the heading and does not include the text "in page link" at the end anymore

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
