### PR TITLE
Fix broken import for non-customized syntax languages

### DIFF
--- a/src/utils/syntax-highlight.js
+++ b/src/utils/syntax-highlight.js
@@ -90,7 +90,7 @@ async function importHighlightFileForLanguage(language) {
         languageFile = await import(
           // See bug https://github.com/webpack/webpack/issues/13865
           /* webpackChunkName: "highlight-js-[request]" */
-          `highlight-js-alias/lib/languages/${file}`
+          `highlight-js-alias/lib/languages/${file}.js`
         );
       }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 115169709

## Summary

This fixes a regression mistakenly introduced with [#724][0] that prevents non-custom syntax languages (everything except swift/markdown) from being highlighted as expected due to an `import` call that is throwing an exception.

To fix it, we can simply append the `.js` file extension to ensure that the import continues to work as expected.

[0]: https://github.com/apple/swift-docc-render/pull/724

## Testing

Steps:
1. Build this branch of DocC-Render and use it to render documentation with example code listing content
2. Verify that code listings with languages other than Swift/Markdown appear syntax highlighted and double-check that Swift/Markdown code listings are still highlighted as expected

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
