### PR TITLE
Expose answer content to VoiceOver in Tutorials' Quiz

### DIFF
--- a/src/components/Tutorial/Assessments/Quiz.vue
+++ b/src/components/Tutorial/Assessments/Quiz.vue
@@ -26,22 +26,21 @@
             <p class="answer" v-if="choice.reaction">{{ choice.reaction }}</p>
           </template>
       </label>
-      <i18n
-        v-if="checkedIndex != null"
-        path="tutorials.assessment.answer-result"
-        tag="div"
-        aria-live="assertive"
-        class="visuallyhidden"
-      >
-        <template #answer>
-          <ContentNode class="question" :content="choices[checkedIndex].content" />
-        </template>
-        <template #result>{{ choices[checkedIndex].isCorrect
-          ? $t('tutorials.assessment.correct')
-          : $t('tutorials.assessment.incorrect')
-        }}</template>
-      </i18n>
-      <div v-else aria-live="assertive" class="visuallyhidden"></div>
+      <div aria-live="assertive" class="visuallyhidden">
+        <i18n
+          v-if="checkedIndex != null"
+          path="tutorials.assessment.answer-result"
+          tag="span"
+        >
+          <template #answer>
+            <ContentNode class="question" :content="choices[checkedIndex].content" />
+          </template>
+          <template #result>{{ choices[checkedIndex].isCorrect
+            ? $t('tutorials.assessment.correct')
+            : $t('tutorials.assessment.incorrect')
+          }}</template>
+        </i18n>
+      </div>
     </div>
     <div class="controls">
       <ButtonLink

--- a/src/components/Tutorial/Assessments/Quiz.vue
+++ b/src/components/Tutorial/Assessments/Quiz.vue
@@ -26,9 +26,23 @@
             <p class="answer" v-if="choice.reaction">{{ choice.reaction }}</p>
           </template>
       </label>
-      <div aria-live="assertive" class="visuallyhidden">
-        {{ ariaLiveText }}
-      </div>
+      <i18n
+        v-if="checkedIndex != null"
+        path="tutorials.assessment.answer-result"
+        tag="div"
+        aria-live="assertive"
+        class="visuallyhidden"
+      >
+        <template #answer>
+          <ContentNode class="question" :content="choices[checkedIndex].content" />
+        </template>
+        <template #result>
+          {{ choices[checkedIndex].isCorrect
+            ? $t('tutorials.assessment.correct')
+            : $t('tutorials.assessment.incorrect')
+          }}
+        </template>
+      </i18n>
     </div>
     <div class="controls">
       <ButtonLink
@@ -113,18 +127,6 @@ export default {
       return Array.from(this.correctChoices).every(correctChoice => (
         this.userChoices[correctChoice].checked
       ));
-    },
-    ariaLiveText() {
-      if (this.checkedIndex === null) return '';
-      const { isCorrect } = this.choices[this.checkedIndex];
-      return `${
-          this.$t('tutorials.assessment.answer-number-is', { index: this.checkedIndex + 1 })
-        } ${
-          isCorrect
-            ? this.$t('tutorials.assessment.correct')
-            : this.$t('tutorials.assessment.incorrect')
-        }
-      `;
     },
   },
   methods: {

--- a/src/components/Tutorial/Assessments/Quiz.vue
+++ b/src/components/Tutorial/Assessments/Quiz.vue
@@ -36,13 +36,12 @@
         <template #answer>
           <ContentNode class="question" :content="choices[checkedIndex].content" />
         </template>
-        <template #result>
-          {{ choices[checkedIndex].isCorrect
-            ? $t('tutorials.assessment.correct')
-            : $t('tutorials.assessment.incorrect')
-          }}
-        </template>
+        <template #result>{{ choices[checkedIndex].isCorrect
+          ? $t('tutorials.assessment.correct')
+          : $t('tutorials.assessment.incorrect')
+        }}</template>
       </i18n>
+      <div v-else aria-live="assertive" class="visuallyhidden"></div>
     </div>
     <div class="controls">
       <ButtonLink

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -24,7 +24,7 @@
     "assessment": {
       "check-your-understanding": "Check Your Understanding",
       "success-message": "Great job, you've answered all the questions for this tutorial.",
-      "answer-number-is": "Answer number {index} is",
+      "answer-result": "Answer {answer} is {result}",
       "correct": "correct",
       "incorrect": "incorrect",
       "next-question": "Next question"

--- a/tests/unit/components/Tutorial/Assessments/Quiz.spec.js
+++ b/tests/unit/components/Tutorial/Assessments/Quiz.spec.js
@@ -14,7 +14,7 @@ import Quiz from 'docc-render/components/Tutorial/Assessments/Quiz.vue';
 
 const i18nStub = {
   name: 'i18n',
-  template: '<div aria-live="assertive" class="visuallyhidden">Answer is <slot name="result"/></div>',
+  template: '<span>Answer is <slot name="result"/></span>',
 };
 
 const textContent = str => ([{
@@ -215,14 +215,14 @@ describe('Quiz', () => {
       choice.trigger('click');
       submit.trigger('click');
 
-      ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
+      ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden > span');
       expect(ariaLive.text()).toBe('Answer is tutorials.assessment.incorrect');
 
       choice = choices.at(0);
       choice.trigger('click');
       submit.trigger('click');
 
-      ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
+      ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden > span');
       expect(ariaLive.text()).toBe('Answer is tutorials.assessment.correct');
     });
   });

--- a/tests/unit/components/Tutorial/Assessments/Quiz.spec.js
+++ b/tests/unit/components/Tutorial/Assessments/Quiz.spec.js
@@ -12,6 +12,11 @@ import { shallowMount } from '@vue/test-utils';
 import ContentNode from 'docc-render/components/ContentNode.vue';
 import Quiz from 'docc-render/components/Tutorial/Assessments/Quiz.vue';
 
+const i18nStub = {
+  name: 'i18n',
+  template: '<div aria-live="assertive" class="visuallyhidden">Answer is <slot name="result"/></div>',
+};
+
 const textContent = str => ([{
   type: 'text',
   text: str,
@@ -105,7 +110,10 @@ describe('Quiz', () => {
 
   describe('default', () => {
     beforeEach(() => {
-      wrapper = shallowMount(Quiz, { propsData });
+      wrapper = shallowMount(Quiz, {
+        propsData,
+        stubs: { i18n: i18nStub },
+      });
     });
 
     it('renders a div.quiz root', () => {
@@ -160,7 +168,11 @@ describe('Quiz', () => {
     let submit;
 
     beforeEach(() => {
-      wrapper = shallowMount(Quiz, { propsData, attachToDocument: true });
+      wrapper = shallowMount(Quiz, {
+        propsData,
+        stubs: { i18n: i18nStub },
+        attachToDocument: true,
+      });
       choices = wrapper.findAll('.choice');
       submit = wrapper.find('.check');
     });
@@ -195,7 +207,7 @@ describe('Quiz', () => {
     });
 
     it('updates the aria live text telling the user if the answer chosen is correct or incorrect', () => {
-      const ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
+      let ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
       expect(ariaLive.exists()).toBe(true);
       expect(ariaLive.text()).toBe('');
 
@@ -203,13 +215,15 @@ describe('Quiz', () => {
       choice.trigger('click');
       submit.trigger('click');
 
-      expect(ariaLive.text()).toBe('tutorials.assessment.answer-number-is 2 tutorials.assessment.incorrect');
+      ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
+      expect(ariaLive.text()).toBe('Answer is tutorials.assessment.incorrect');
 
       choice = choices.at(0);
       choice.trigger('click');
       submit.trigger('click');
 
-      expect(ariaLive.text()).toBe('tutorials.assessment.answer-number-is 1 tutorials.assessment.correct');
+      ariaLive = wrapper.find('[aria-live="assertive"].visuallyhidden');
+      expect(ariaLive.text()).toBe('Answer is tutorials.assessment.correct');
     });
   });
 });


### PR DESCRIPTION
Bug/issue #115116964, if applicable: 

## Summary

Expose answer content to VoiceOver in Tutorials' Quiz

## Dependencies

NA

## Testing

Steps:
0. Turn VoiceOver on
1. Go to a page with a Quiz
2. Select an incorrect answer
3. Submit
4. Assert that VoiceOver reads: "Answer [content of the answer] is [result]"

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
