### PR TITLE
Add legend and fieldset to Quiz assessment and Color scheme Toggle

### DIFF
--- a/src/components/ColorSchemeToggle.vue
+++ b/src/components/ColorSchemeToggle.vue
@@ -9,11 +9,11 @@
 -->
 
 <template>
-  <div
-    :aria-label="$t('color-scheme.select')"
+  <fieldset
     class="color-scheme-toggle"
     role="radiogroup"
   >
+    <legend class="visuallyhidden">{{ $t('color-scheme.select') }}</legend>
     <label
       v-for="option in options"
       :key="option"
@@ -26,7 +26,7 @@
       />
       <div class="text">{{ $t(`color-scheme.${option}`) }}</div>
     </label>
-  </div>
+  </fieldset>
 </template>
 
 <script>

--- a/src/components/Tutorial/Assessments/Quiz.vue
+++ b/src/components/Tutorial/Assessments/Quiz.vue
@@ -12,7 +12,8 @@
   <div class="quiz">
     <ContentNode class="title" :content="title" />
     <ContentNode class="question-content" v-if="content" :content="content" />
-    <div class="choices">
+    <fieldset class="choices">
+      <legend class="visuallyhidden">{{ $t('tutorials.assessment.legend') }}</legend>
       <label
         v-for="(choice, index) in choices"
         :key="index"
@@ -26,9 +27,9 @@
             <p class="answer" v-if="choice.reaction">{{ choice.reaction }}</p>
           </template>
       </label>
-      <div aria-live="assertive" class="visuallyhidden">
-        {{ ariaLiveText }}
-      </div>
+    </fieldset>
+    <div aria-live="assertive" class="visuallyhidden">
+      {{ ariaLiveText }}
     </div>
     <div class="controls">
       <ButtonLink

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -27,7 +27,8 @@
       "answer-number-is": "Answer number {index} is",
       "correct": "correct",
       "incorrect": "incorrect",
-      "next-question": "Next question"
+      "next-question": "Next question",
+      "legend": "Possible answers"
     },
     "project-files": "Project files",
     "estimated-time": "Estimated Time",

--- a/tests/unit/components/ColorSchemeToggle.spec.js
+++ b/tests/unit/components/ColorSchemeToggle.spec.js
@@ -38,8 +38,14 @@ describe('ColorSchemeToggle', () => {
     });
   });
 
-  it('renders a .color-scheme-toggle', () => {
-    expect(wrapper.is('.color-scheme-toggle'));
+  it('renders a fieldset .color-scheme-toggle', () => {
+    expect(wrapper.is('fieldset.color-scheme-toggle'));
+  });
+
+  it('renders a legend for fieldset', () => {
+    const legend = wrapper.find('legend');
+    expect(legend.exists()).toBe(true);
+    expect(legend.text()).toBe('color-scheme.select');
   });
 
   it('renders a label for "Light/Dark/Auto"', () => {

--- a/tests/unit/components/Tutorial/Assessments/Quiz.spec.js
+++ b/tests/unit/components/Tutorial/Assessments/Quiz.spec.js
@@ -124,9 +124,13 @@ describe('Quiz', () => {
       expect(node.props('content')).toEqual(propsData.content);
     });
 
-    it('renders a ul.choices', () => {
-      const choices = wrapper.find('div.choices');
+    it('renders a fieldset element with choices', () => {
+      const choices = wrapper.find('fieldset.choices');
       expect(choices.exists()).toBe(true);
+
+      const legend = choices.find('legend');
+      expect(legend.exists()).toBe(true);
+      expect(legend.text()).toBe('tutorials.assessment.legend');
 
       const items = choices.findAll('label.choice');
       expect(items.length).toBe(propsData.choices.length);


### PR DESCRIPTION
Bug/issue #115116952, if applicable: 

## Summary

Add legend and fieldset to Quiz assessment and Color scheme Toggle

## Dependencies

NA

## Testing

Steps:
1. Go to a page with a Quiz assessment
2. Open VO
3. Assert that before going into the answers of the quiz, VO describes "Possible answers"
4. Go to the bottom of the page
5. Assert that before the color schemes, VO reads "Select a color scheme preference"

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
