### PR TITLE
Remove localized "server-error" route

### DIFF
--- a/src/constants/router.js
+++ b/src/constants/router.js
@@ -10,6 +10,8 @@
 
 // The name of the "not found" route.
 export const notFoundRouteName = 'not-found';
+// The name of the "server error" route.
+export const serverErrorRouteName = 'server-error';
 // The dynamic imports with special `webpackChunkName` comments are used to
 // take advantage of webpack's code-splitting functionality to break apart
 // optimized JavaScript bundles for each route on demand.

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,7 +8,11 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { documentationTopicName, notFoundRouteName } from 'docc-render/constants/router';
+import {
+  documentationTopicName,
+  notFoundRouteName,
+  serverErrorRouteName,
+} from 'docc-render/constants/router';
 import ServerError from 'theme/views/ServerError.vue';
 import NotFound from 'theme/views/NotFound.vue';
 
@@ -41,7 +45,7 @@ export default [
   },
   {
     path: '*', // purposefully unreachable without a forced navigation
-    name: 'server-error',
+    name: serverErrorRouteName,
     component: ServerError,
   },
 ];

--- a/src/setup-utils/SwiftDocCRenderRouter.js
+++ b/src/setup-utils/SwiftDocCRenderRouter.js
@@ -10,6 +10,10 @@
 
 import Router from 'vue-router';
 import {
+  notFoundRouteName,
+  serverErrorRouteName,
+} from 'docc-render/constants/router';
+import {
   saveScrollOnReload,
   restoreScrollOnReload,
   scrollBehavior,
@@ -17,9 +21,14 @@ import {
 import routes from 'docc-render/routes';
 import { baseUrl } from 'docc-render/utils/theme-settings';
 import { addPrefixedRoutes } from 'docc-render/utils/route-utils';
-import { notFoundRouteName } from 'docc-render/constants/router';
 
-const defaultRoutes = [...routes, ...addPrefixedRoutes(routes, [notFoundRouteName])];
+const defaultRoutes = [
+  ...routes,
+  ...addPrefixedRoutes(routes, [
+    notFoundRouteName,
+    serverErrorRouteName,
+  ]),
+];
 
 export default function createRouterInstance(routerConfig = {}) {
   const router = new Router({

--- a/tests/unit/components/ContentNode/Reference.spec.js
+++ b/tests/unit/components/ContentNode/Reference.spec.js
@@ -247,4 +247,17 @@ describe('Reference', () => {
     // add query params to url
     expect(wrapper.find(ReferenceExternal).props('url')).toBe('http://website.com');
   });
+
+  it('renders a `ReferenceExternal` for /downloads/ URLs', () => {
+    const wrapper = shallowMount(Reference, {
+      localVue,
+      router,
+      propsData: { url: '/downloads/foo.zip' },
+      slots: { default: 'Foo' },
+    });
+    const ref = wrapper.find(ReferenceExternal);
+    expect(ref.exists()).toBe(true);
+    expect(ref.props('url')).toBe('/downloads/foo.zip');
+    expect(ref.text()).toBe('Foo');
+  });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 115733855

## Summary

This fixes an issue where the `Reference` component is mistakenly using a `<router-link>` to render a `/downloads/` link, which doesn't work since those URLs are used for static file downloads, not Vue routes.

## Testing

Steps:
1. Use the `docc preview` command with a documentation catalog that contains a sample code page or an article with a file download.
2. Verify that the download link works as expected and doesn't result in a server error page

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
