### PR TITLE
Quick Navigation user should be able to tab from list of results to preview and use arrow keys within the list

### DIFF
--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -70,6 +70,7 @@
                 :key="symbol.uid"
                 :url="symbol.path"
                 :tabindex="focusedIndex === index ? '0' : '-1'"
+                :data-index="index"
                 @click.native="closeQuickNavigationModal"
                 ref="match"
               >
@@ -252,7 +253,12 @@ export default {
       }
       return filteredSymbols[nextIndex];
     },
-    focusedMatchElement: ({ $refs, focusedIndex }) => $refs.match[focusedIndex].$el,
+    focusedMatchElement: ({
+      $refs,
+      focusedIndex,
+      // We need to find the item with the same `data-index`,
+      // as the order of items in `$refs` is not guaranteed to match the DOM
+    }) => $refs.match.find(({ $el }) => parseInt($el.dataset.index, 10) === focusedIndex).$el,
     previewJSON: ({
       cachedSymbolResults,
       selectedSymbol,

--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -69,7 +69,7 @@
                 class="quick-navigation__reference"
                 :key="symbol.uid"
                 :url="symbol.path"
-                :tabindex="focusedIndex === index ? '0' : '-1'"
+                :tabindex="isFocused(index) ? '0' : '-1'"
                 @click.native="closeQuickNavigationModal"
                 @focus.native="focusIndex(index)"
                 ref="match"
@@ -278,13 +278,9 @@ export default {
   },
   watch: {
     userInput: 'debounceInput',
+    focusedIndex: 'scrollIntoView',
     selectedSymbol: 'fetchSelectedSymbolData',
     $route: 'closeQuickNavigationModal',
-    async focusedIndex(newVal) {
-      await this.$nextTick();
-      this.scrollIntoView(newVal);
-      this.focusReference(newVal);
-    },
   },
   methods: {
     closeQuickNavigationModal() {
@@ -310,6 +306,11 @@ export default {
     },
     formatSymbolTitle(symbolTitle, symbolStart, symbolEnd) {
       return symbolTitle.slice(symbolStart, symbolEnd);
+    },
+    isFocused(index) {
+      if (this.focusedInput || this.focusedIndex !== index) return false;
+      this.focusReference(index);
+      return true;
     },
     fuzzyMatch({
       inputLength, symbols, processedInputRegex, childrenMap,

--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -17,10 +17,6 @@
   >
     <div
       class="quick-navigation"
-      @keydown.down.exact.prevent="focusNext"
-      @keydown.up.exact.prevent="focusPrev"
-      @keydown.enter.exact="handleKeyEnter"
-      @click.self="closeQuickNavigationModal"
     >
       <div
         class="quick-navigation__container"
@@ -34,7 +30,7 @@
           focusInputWhenEmpty
           preventBorderStyle
           selectInputOnFocus
-          @input="focusedIndex = 0"
+          @keydown.down.exact.native.prevent="handleDownKeyInput"
           @focus="focusedInput = true"
           @blur="focusedInput = false"
         >
@@ -63,6 +59,10 @@
             <div
               v-bind="{[SCROLL_LOCK_DISABLE_ATTR]: true}"
               class="quick-navigation__refs"
+              @keydown.down.exact.prevent="focusNext"
+              @keydown.up.exact.prevent="focusPrev"
+              @keydown.enter.exact="handleKeyEnter"
+              @click.self="closeQuickNavigationModal"
             >
               <Reference
                 v-for="(symbol, index) in filteredSymbols"
@@ -358,6 +358,10 @@ export default {
     },
     focusReference(index) {
       this.$refs.match[index].$el.focus();
+    },
+    handleDownKeyInput() {
+      this.focusedIndex = 0;
+      this.focusReference(0);
     },
     scrollIntoView(index) {
       this.$refs.match[index].$el.scrollIntoView({

--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -69,14 +69,14 @@
                 class="quick-navigation__reference"
                 :key="symbol.uid"
                 :url="symbol.path"
+                :tabindex="focusedIndex === index ? '0' : '-1'"
                 @click.native="closeQuickNavigationModal"
                 @focus.native="focusIndex(index)"
+                ref="match"
               >
                 <div
                   class="quick-navigation__symbol-match"
-                  ref="match"
                   role="list"
-                  :class="{ 'selected' : index == focusedIndex }"
                 >
                   <div class="symbol-info">
                     <div class="symbol-name">
@@ -278,9 +278,13 @@ export default {
   },
   watch: {
     userInput: 'debounceInput',
-    focusedIndex: 'scrollIntoView',
     selectedSymbol: 'fetchSelectedSymbolData',
     $route: 'closeQuickNavigationModal',
+    async focusedIndex(newVal) {
+      await this.$nextTick();
+      this.scrollIntoView(newVal);
+      this.focusReference(newVal);
+    },
   },
   methods: {
     closeQuickNavigationModal() {
@@ -351,8 +355,11 @@ export default {
         return 0;
       });
     },
-    scrollIntoView() {
-      this.$refs.match[this.focusedIndex].scrollIntoView({
+    focusReference(index) {
+      this.$refs.match[index].$el.focus();
+    },
+    scrollIntoView(index) {
+      this.$refs.match[index].$el.scrollIntoView({
         block: 'nearest',
       });
     },
@@ -495,9 +502,6 @@ $input-horizontal-spacing: rem(15px);
       margin: rem(15px) auto;
       width: fit-content;
     }
-    .selected {
-      background-color: var(--color-navigator-item-hover);
-    }
   }
   &__refs {
     flex: 1;
@@ -510,17 +514,25 @@ $input-horizontal-spacing: rem(15px);
     position: sticky;
     top: 0;
   }
-  &__reference:hover {
-    text-decoration: none;
+  &__reference {
+    display: block;
+    padding: rem(10px) rem(15px);
+
+    &:hover {
+      text-decoration: none;
+      background-color: var(--color-navigator-item-hover);
+    }
+
+    &:focus {
+      margin: 0 rem(5px);
+      padding: rem(10px) rem(10px);
+      background-color: var(--color-navigator-item-hover);
+    }
   }
   &__symbol-match {
     display: flex;
     height: rem(40px);
-    padding: rem(10px) rem(15px);
     color: var(--color-figure-gray);
-    &:hover {
-      background-color: var(--color-navigator-item-hover);
-    }
     .symbol-info {
       margin: auto;
       width: 100%;

--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -71,7 +71,6 @@
                 :url="symbol.path"
                 :tabindex="focusedIndex === index ? '0' : '-1'"
                 @click.native="closeQuickNavigationModal"
-                @focus.native="focusIndex(index)"
                 ref="match"
               >
                 <div
@@ -357,7 +356,7 @@ export default {
       });
     },
     focusReference() {
-      return this.focusedMatchElement.focus();
+      this.focusedMatchElement.focus();
     },
     handleDownKeyInput() {
       this.focusedIndex = 0;

--- a/tests/unit/components/Navigator/QuickNavigationModal.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationModal.spec.js
@@ -38,11 +38,6 @@ describe('QuickNavigationModal', () => {
     $router: {
       push: jest.fn(),
     },
-    $refs: {
-      match: {
-        scrollIntoView: jest.fn(),
-      },
-    },
   };
   const symbols = [
     {
@@ -300,16 +295,13 @@ describe('QuickNavigationModal', () => {
     expect(wrapper.find(QuickNavigationHighlighter).props().text).toBe('fooxyzbar');
   });
 
-  it('access a symbol on `enter` key', async () => {
+  it('access a symbol on `enter` key', () => {
     const handleKeyEnter = jest.spyOn(wrapper.vm, 'handleKeyEnter');
     wrapper.setData({
       debouncedInput: inputValue,
     });
-    await wrapper.find('.quick-navigation').trigger('keydown.enter');
-    wrapper.setData({
-      debouncedInput: inputValue,
-    });
-    await wrapper.find(FilterInput).trigger('keydown.enter');
+    wrapper.find('.quick-navigation__refs').trigger('keydown.enter');
+    wrapper.find(FilterInput).trigger('keydown.enter');
     expect(handleKeyEnter).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/unit/components/Navigator/QuickNavigationModal.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationModal.spec.js
@@ -112,11 +112,11 @@ describe('QuickNavigationModal', () => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
   });
 
-  it('it renders the Quick navigation modal', () => {
+  it('renders the Quick navigation modal', () => {
     expect(wrapper.find('.quick-navigation').exists()).toBe(true);
   });
 
-  it('add the focus class on container if filter input is focused', () => {
+  it('adds the focus class on container if filter input is focused', () => {
     wrapper.find(FilterInput).vm.$emit('focus');
     expect(wrapper.find('.quick-navigation__container.focus').exists()).toBe(true);
   });
@@ -126,7 +126,7 @@ describe('QuickNavigationModal', () => {
     expect(wrapper.find('.quick-navigation__container.focus').exists()).toBe(false);
   });
 
-  it('it filters the symbols according to debouncedInput value', async () => {
+  it('filters the symbols according to debouncedInput value', async () => {
     wrapper.setData({
       debouncedInput: inputValue,
     });
@@ -138,7 +138,7 @@ describe('QuickNavigationModal', () => {
     expect(wrapper.findAll(QuickNavigationHighlighter).length).toBe(filteredSymbols.length);
   });
 
-  it('it renders the filter input', () => {
+  it('renders the filter input', () => {
     expect(wrapper.find('.quick-navigation__filter').exists()).toBe(true);
     const filter = wrapper.find(FilterInput);
     expect(filter.props()).toEqual({
@@ -159,7 +159,7 @@ describe('QuickNavigationModal', () => {
     });
   });
 
-  it('it renders the match list on user input', async () => {
+  it('renders the match list on user input', async () => {
     wrapper.setData({
       debouncedInput: inputValue,
     });
@@ -169,7 +169,7 @@ describe('QuickNavigationModal', () => {
     expect(wrapper.find('.quick-navigation__refs').attributes(SCROLL_LOCK_DISABLE_ATTR)).toBeTruthy();
   });
 
-  it('it renders the `no results found` string when no symbols are found given an input', () => {
+  it('renders the `no results found` string when no symbols are found given an input', () => {
     wrapper.setData({
       debouncedInput: nonResultsInputValue,
     });
@@ -180,7 +180,7 @@ describe('QuickNavigationModal', () => {
     expect(noResultsWrapper.text()).toBe('No results found.');
   });
 
-  it('it renders symbol matches with the corresponding symbol icon', () => {
+  it('renders symbol matches with the corresponding symbol icon', () => {
     wrapper.setData({
       debouncedInput: inputValue,
     });
@@ -191,7 +191,7 @@ describe('QuickNavigationModal', () => {
     expect(matchWrapper.at(1).find(TopicTypeIcon).props().type).toBe(filteredSymbols[1].type);
   });
 
-  it('it renders a symbol match with the corresponding symbol title', () => {
+  it('renders a symbol match with the corresponding symbol title', () => {
     wrapper.setData({
       debouncedInput: inputValue,
     });
@@ -208,7 +208,7 @@ describe('QuickNavigationModal', () => {
     ).toBe(filteredSymbols[1].title);
   });
 
-  it('it redirects to the symbol path on symbol-match selection', async () => {
+  it('redirects to the symbol path on symbol-match selection', async () => {
     wrapper.setData({
       debouncedInput: inputValue,
     });
@@ -217,7 +217,7 @@ describe('QuickNavigationModal', () => {
     expect(referencesWrapper.at(1).props().url).toBe(filteredSymbols[1].path);
   });
 
-  it('it highlights the matching substring of the symbol title', async () => {
+  it('highlights the matching substring of the symbol title', async () => {
     wrapper.setData({
       debouncedInput: inputValue,
     });
@@ -242,7 +242,16 @@ describe('QuickNavigationModal', () => {
     ).toBe(symbolsMatchBlueprint[3].subMatchString);
   });
 
-  it('it debounces user input before filtering the symbols', () => {
+  it('adds tabindex="0" when reference index is equal to focusedIndex', () => {
+    wrapper.setData({
+      debouncedInput: inputValue,
+      focusedIndex: 1,
+    });
+    expect(wrapper.findAll({ ref: 'match' }).at(0).attributes('tabindex')).toBe('-1');
+    expect(wrapper.findAll({ ref: 'match' }).at(1).attributes('tabindex')).toBe('0');
+  });
+
+  it('debounces user input before filtering the symbols', () => {
     wrapper.setData({
       debouncedInput: inputValue,
     });
@@ -253,7 +262,7 @@ describe('QuickNavigationModal', () => {
     expect(wrapper.vm.debouncedInput).toBe(inputValue);
   });
 
-  it('it triggers new filtering on every debounce input change', () => {
+  it('triggers new filtering on every debounce input change', () => {
     const fuzzyMatch = jest.spyOn(wrapper.vm, 'fuzzyMatch');
     wrapper.setData({
       debouncedInput: inputValue,
@@ -270,7 +279,7 @@ describe('QuickNavigationModal', () => {
     expect(fuzzyMatch).toHaveBeenCalledTimes(4);
   });
 
-  it('it matches the smallest matching substring from a symbol title', () => {
+  it('matches the smallest matching substring from a symbol title', () => {
     const customSymbols = [
       {
         title: 'foofooxyzbarbar',
@@ -291,7 +300,7 @@ describe('QuickNavigationModal', () => {
     expect(wrapper.find(QuickNavigationHighlighter).props().text).toBe('fooxyzbar');
   });
 
-  it('it access a symbol on `enter` key', async () => {
+  it('access a symbol on `enter` key', async () => {
     const handleKeyEnter = jest.spyOn(wrapper.vm, 'handleKeyEnter');
     wrapper.setData({
       debouncedInput: inputValue,
@@ -304,7 +313,7 @@ describe('QuickNavigationModal', () => {
     expect(handleKeyEnter).toHaveBeenCalledTimes(2);
   });
 
-  it('it renders the symbol tree of the resulting symbol', async () => {
+  it('renders the symbol tree of the resulting symbol', async () => {
     wrapper = shallowMount(QuickNavigationModal, {
       propsData: {
         children: [
@@ -331,13 +340,13 @@ describe('QuickNavigationModal', () => {
     expect(symbolTree.text()).toBe('bar');
   });
 
-  it('it removes space characters from the debounced input string', () => {
+  it('removes space characters from the debounced input string', () => {
     wrapper.setData({
       debouncedInput: 'bar foo',
     });
     expect(wrapper.vm.processedUserInput).toBe('barfoo');
   });
-  it('it removes filtered symbols with duplicate paths', () => {
+  it('removes filtered symbols with duplicate paths', () => {
     const symbolsWithRepeatedPaths = [
       {
         title: 'foo',


### PR DESCRIPTION
Bug/issue #111742596, if applicable: 

## Summary

Quick Navigation user should be able to tab from list of results to preview and use arrow keys within the list, to avoid tabbing all the list

## Dependencies

NA

## Testing

Steps:
1. Go to any documentation page
2. Open Quick Navigation
3. Assert that you can tab from the list of results to the preview without tabbing all the list
4. Assert that you can move in the list of results using your arrow keys

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
