### PR TITLE
Allow external links in "Relationships" section

### DIFF
--- a/src/components/ContentNode/Reference.vue
+++ b/src/components/ContentNode/Reference.vue
@@ -19,6 +19,7 @@ import { buildUrl } from 'docc-render/utils/url-helper';
 import { TopicRole } from 'docc-render/constants/roles';
 
 import { notFoundRouteName } from 'docc-render/constants/router';
+import ReferenceExternalSymbol from './ReferenceExternalSymbol.vue';
 import ReferenceExternal from './ReferenceExternal.vue';
 import ReferenceInternalSymbol from './ReferenceInternalSymbol.vue';
 import ReferenceInternal from './ReferenceInternal.vue';
@@ -49,14 +50,11 @@ export default {
     isDisplaySymbol({ isSymbolReference, titleStyle, ideTitle }) {
       return ideTitle ? (isSymbolReference && titleStyle === 'symbol') : isSymbolReference;
     },
-    refComponent() {
-      if (!this.isInternal) {
-        return ReferenceExternal;
+    refComponent({ isInternal, isDisplaySymbol }) {
+      if (isInternal) {
+        return isDisplaySymbol ? ReferenceInternalSymbol : ReferenceInternal;
       }
-      if (this.isDisplaySymbol) {
-        return ReferenceInternalSymbol;
-      }
-      return ReferenceInternal;
+      return isDisplaySymbol ? ReferenceExternalSymbol : ReferenceExternal;
     },
     urlWithParams({ isInternal }) {
       return isInternal ? buildUrl(this.url, this.$route.query) : this.url;

--- a/src/components/ContentNode/ReferenceExternalSymbol.vue
+++ b/src/components/ContentNode/ReferenceExternalSymbol.vue
@@ -1,0 +1,28 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2023 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <ReferenceExternal v-bind="$props">
+    <CodeVoice>
+      <slot />
+    </CodeVoice>
+  </ReferenceExternal>
+</template>
+
+<script>
+import ReferenceExternal from './ReferenceExternal.vue';
+import CodeVoice from './CodeVoice.vue';
+
+export default {
+  name: 'ReferenceExternalSymbol',
+  props: ReferenceExternal.props,
+  components: { ReferenceExternal, CodeVoice },
+};
+</script>

--- a/src/components/DocumentationTopic/RelationshipsList.vue
+++ b/src/components/DocumentationTopic/RelationshipsList.vue
@@ -21,9 +21,7 @@
         :role="symbol.role"
         :kind="symbol.kind"
         :url="symbol.url"
-      >
-        {{symbol.title}}
-      </Reference>
+      >{{symbol.title}}</Reference>
       <WordBreak v-else tag="code">{{symbol.title}}</WordBreak>
       <ConditionalConstraints
         v-if="symbol.conformance"

--- a/src/components/DocumentationTopic/RelationshipsList.vue
+++ b/src/components/DocumentationTopic/RelationshipsList.vue
@@ -15,9 +15,15 @@
       :key="symbol.identifier"
       class="relationships-item"
     >
-      <router-link v-if="symbol.url" class="link" :to="buildUrl(symbol.url, $route.query)">
-        <WordBreak tag="code">{{symbol.title}}</WordBreak>
-      </router-link>
+      <Reference
+        v-if="symbol.url"
+        class="link"
+        :role="symbol.role"
+        :kind="symbol.kind"
+        :url="symbol.url"
+      >
+        {{symbol.title}}
+      </Reference>
       <WordBreak v-else tag="code">{{symbol.title}}</WordBreak>
       <ConditionalConstraints
         v-if="symbol.conformance"
@@ -32,7 +38,7 @@
 import WordBreak from 'docc-render/components/WordBreak.vue';
 import { getAPIChanges, APIChangesMultipleLines } from 'docc-render/mixins/apiChangesHelpers';
 import { ChangeTypes } from 'docc-render/constants/Changes';
-import { buildUrl } from 'docc-render/utils/url-helper';
+import Reference from 'docc-render/components/ContentNode/Reference.vue';
 import ConditionalConstraints from './ConditionalConstraints.vue';
 
 const MaxInlineItems = 3;
@@ -48,6 +54,7 @@ export default {
   name: 'RelationshipsList',
   components: {
     ConditionalConstraints,
+    Reference,
     WordBreak,
   },
   inject: ['store', 'identifier'],
@@ -115,9 +122,6 @@ export default {
       const { hasAvailabilityConstraints, symbols } = this;
       return symbols.length <= MaxInlineItems && !hasAvailabilityConstraints;
     },
-  },
-  methods: {
-    buildUrl,
   },
 };
 </script>

--- a/tests/unit/components/ContentNode/Reference.spec.js
+++ b/tests/unit/components/ContentNode/Reference.spec.js
@@ -10,6 +10,8 @@
 
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
+import ReferenceExternalSymbol
+  from 'docc-render/components/ContentNode/ReferenceExternalSymbol.vue';
 import ReferenceExternal from 'docc-render/components/ContentNode/ReferenceExternal.vue';
 import ReferenceInternalSymbol
   from 'docc-render/components/ContentNode/ReferenceInternalSymbol.vue';
@@ -181,6 +183,22 @@ describe('Reference', () => {
     const ref = wrapper.find(ReferenceInternal);
     expect(ref.exists()).toBe(true);
     expect(ref.props('url')).toBe('/documentation/uikit/uiview');
+  });
+
+  it('renders a `ReferenceExternalSymbol` for external symbols', () => {
+    const wrapper = shallowMount(Reference, {
+      localVue,
+      router,
+      propsData: {
+        url: 'https://example.com/foo',
+        kind: 'symbol',
+        role: TopicRole.symbol,
+      },
+      slots: { default: 'Foo' },
+    });
+    const ref = wrapper.find(ReferenceExternalSymbol);
+    expect(ref.exists()).toBe(true);
+    expect(ref.props('url')).toBe('https://example.com/foo');
   });
 
   it('passes the isActive prop', () => {

--- a/tests/unit/components/ContentNode/ReferenceExternalSymbol.spec.js
+++ b/tests/unit/components/ContentNode/ReferenceExternalSymbol.spec.js
@@ -1,0 +1,26 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2023 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import { shallowMount } from '@vue/test-utils';
+import ReferenceExternalSymbol from 'docc-render/components/ContentNode/ReferenceExternalSymbol.vue';
+import CodeVoice from 'docc-render/components/ContentNode/CodeVoice.vue';
+
+describe('ReferenceExternalSymbol', () => {
+  it('renders a link in code voice', () => {
+    const wrapper = shallowMount(ReferenceExternalSymbol, {
+      propsData: { url: 'https://example.com/foo' },
+      slots: { default: 'Foo' },
+    });
+    expect(wrapper.props('url')).toBe('https://example.com/foo');
+    const code = wrapper.find(CodeVoice);
+    expect(code.exists()).toBe(true);
+    expect(code.text()).toBe('Foo');
+  });
+});

--- a/tests/unit/components/DocumentationTopic/RelationshipsList.spec.js
+++ b/tests/unit/components/DocumentationTopic/RelationshipsList.spec.js
@@ -17,6 +17,7 @@ import { multipleLinesClass } from 'docc-render/constants/multipleLines';
 
 const {
   ConditionalConstraints,
+  Reference,
   WordBreak,
 } = RelationshipsList.components;
 
@@ -95,21 +96,15 @@ describe('RelationshipsList', () => {
     expect(wrapper.classes()).toContain(multipleLinesClass);
   });
 
-  it('renders a list item with word-break links for each resolved symbol', () => {
+  it('renders a list item with `Reference` links for each resolved symbol', () => {
     const items = wrapper.findAll('li');
     expect(items.length).toBe(propsData.symbols.length);
 
     items.wrappers.slice(0, items.length - 1).forEach((item, i) => {
-      const link = item.find(RouterLinkStub);
+      const link = item.find(Reference);
       expect(link.exists()).toBe(true);
       expect(link.classes('link')).toBe(true);
-      // prepends the existing query parameters as well
-      expect(link.props('to')).toBe(`${propsData.symbols[i].url}?language=objc`);
-
-      const wb = link.find(WordBreak);
-      expect(wb.exists()).toBe(true);
-      expect(wb.attributes('tag')).toBe('code');
-      expect(wb.text()).toBe(propsData.symbols[i].title);
+      expect(link.props('url')).toBe(propsData.symbols[i].url);
     });
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 112048068

## Summary

This PR allows for handling external links in the "Relationships" section when provided by the compiler.

It also handles the case when an external link has been categorized as a symbol, so these kinds of external links can be rendered with code voice.

## Testing

Steps:
1. Find a page with external links in its "Relationships" section.
2. Verify that a normal `<a>` tag is used to render it, rather than a `<router-link>`.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
