### PR TITLE
[5.10] Fix broken import for non-custom syntax langs

### DIFF
--- a/src/utils/syntax-highlight.js
+++ b/src/utils/syntax-highlight.js
@@ -90,7 +90,7 @@ async function importHighlightFileForLanguage(language) {
         languageFile = await import(
           // See bug https://github.com/webpack/webpack/issues/13865
           /* webpackChunkName: "highlight-js-[request]" */
-          `highlight-js-alias/lib/languages/${file}`
+          `highlight-js-alias/lib/languages/${file}.js`
         );
       }
 


### PR DESCRIPTION
Cherry-pick #730 