### PR TITLE
Remove `ConditionalConstraint` from topics section

### DIFF
--- a/src/components/DocumentationTopic/TopicsLinkBlock.vue
+++ b/src/components/DocumentationTopic/TopicsLinkBlock.vue
@@ -44,11 +44,6 @@
         :defaultImplementationsCount="topic.defaultImplementations"
         class="topic-required"
       />
-      <ConditionalConstraints
-        v-if="topic.conformance"
-        :constraints="topic.conformance.constraints"
-        :prefix="topic.conformance.availabilityPrefix"
-      />
     </div>
     <Badge v-if="showDeprecatedBadge" variant="deprecated" />
     <Badge v-else-if="showBetaBadge" variant="beta" />
@@ -70,8 +65,6 @@ import WordBreak from 'docc-render/components/WordBreak.vue';
 import ContentNode from 'docc-render/components/DocumentationTopic/ContentNode.vue';
 import TopicLinkBlockIcon from 'docc-render/components/DocumentationTopic/TopicLinkBlockIcon.vue';
 import DecoratedTopicTitle from 'docc-render/components/DocumentationTopic/DecoratedTopicTitle.vue';
-import ConditionalConstraints
-  from 'docc-render/components/DocumentationTopic/ConditionalConstraints.vue';
 import RequirementMetadata
 
   from 'docc-render/components/DocumentationTopic/Description/RequirementMetadata.vue';
@@ -102,7 +95,6 @@ export default {
     TopicLinkBlockIcon,
     DecoratedTopicTitle,
     RequirementMetadata,
-    ConditionalConstraints,
   },
   mixins: [getAPIChanges, APIChangesMultipleLines, referencesProvider],
   constants: {
@@ -124,8 +116,7 @@ export default {
         && typeof topic.url === 'string'
         && (!('defaultImplementations' in topic)
           || typeof topic.defaultImplementations === 'number')
-        && (!('required' in topic) || typeof topic.required === 'boolean')
-        && (!('conformance' in topic) || typeof topic.conformance === 'object'),
+        && (!('required' in topic) || typeof topic.required === 'boolean'),
     },
   },
   data() {
@@ -206,10 +197,10 @@ export default {
     changeName: ({ change, getChangeName }) => getChangeName(change),
     hasAbstractElements: ({
       topic: {
-        abstract, conformance, required, defaultImplementations,
+        abstract, required, defaultImplementations,
       },
     } = {}) => (
-      (abstract && abstract.length > 0) || conformance || required || defaultImplementations
+      (abstract && abstract.length > 0) || required || defaultImplementations
     ),
     // pick only the first available tag
     tags: ({ topic }) => (topic.tags || []).slice(0, 1),
@@ -281,8 +272,4 @@ export default {
   text-decoration: line-through;
 }
 
-.conditional-constraints {
-  font-size: rem(14px);
-  margin-top: 4px;
-}
 </style>

--- a/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
@@ -19,7 +19,6 @@ const {
   TopicKind,
 } = TopicsLinkBlock.constants;
 const {
-  ConditionalConstraints,
   ContentNode,
   DecoratedTopicTitle,
   RequirementMetadata,
@@ -440,21 +439,6 @@ describe('TopicsLinkBlock', () => {
     node = wrapper.find(RequirementMetadata);
     expect(node.exists()).toBe(true);
     expect(node.attributes('defaultimplementationscount')).toEqual('1');
-  });
-
-  it('renders a `ConditionalConstraints` for availability with `conformance` data', () => {
-    const conformance = {
-      availabilityPrefix: [{ type: 'text', text: 'Available when' }],
-      constraints: [{ type: 'codeVoice', code: 'Foo' }],
-    };
-    wrapper.setProps({ topic: { ...propsData.topic, conformance } });
-
-    const constraints = wrapper.find(ConditionalConstraints);
-    expect(constraints.exists()).toBe(true);
-    expect(constraints.props()).toEqual({
-      constraints: conformance.constraints,
-      prefix: conformance.availabilityPrefix,
-    });
   });
 
   it('does not render plist keyinfo if ideTitle is not provided', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 116418381

## Summary
This PR removes the `ConditionalConstraint` content from the topics section. 
See more reasoning in this [forum's post:](https://forums.swift.org/t/improving-the-presentation-of-overloaded-symbols-in-swift-docc/67713)

## Dependencies
NA

## Testing
Steps:
1. Verify that Conditional Constraint content is no longer rendered in the topics section.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran `npm test`, and it succeeded
- [] Updated documentation if necessary
