### PR TITLE
[5.10] Underline inline links

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -174,7 +174,7 @@ $content-margin: 4px;
     text-decoration: none;
 
     .link {
-      text-decoration: underline;
+      @include underline-text;
     }
   }
 

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -449,7 +449,10 @@ function renderNode(createElement, references) {
     }
     case InlineType.link:
       // Note: `InlineType.link` has been deprecated, but may still be found in old JSON.
-      return createElement('a', { attrs: { href: node.destination } }, (
+      return createElement('a', {
+        attrs: { href: node.destination },
+        class: 'inline-link',
+      }, (
         node.title
       ));
     case InlineType.reference: {
@@ -468,6 +471,7 @@ function renderNode(createElement, references) {
           titleStyle: reference.titleStyle,
           hasInlineFormatting: !!titleInlineContent,
         },
+        class: 'inline-link',
       }, (
         titleInlineContent ? renderChildren(titleInlineContent) : titlePlainText
       ));

--- a/src/components/LocaleSelector.vue
+++ b/src/components/LocaleSelector.vue
@@ -68,7 +68,7 @@ select {
   cursor: pointer;
 
   &:hover {
-    text-decoration: underline;
+    @include underline-text;
   }
 }
 

--- a/src/components/Navigator/BaseNavigatorCard.vue
+++ b/src/components/Navigator/BaseNavigatorCard.vue
@@ -14,15 +14,6 @@
       <div class="navigator-card-inner">
         <div class="head-wrapper">
           <div class="head-inner">
-            <button
-              :id="SIDEBAR_HIDE_BUTTON_ID"
-              class="close-card"
-              :class="{ 'hide-on-large': !allowHiding }"
-              :aria-label="$t('navigator.close-navigator')"
-              @click="handleHideClick"
-            >
-              <SidenavIcon class="icon-inline close-icon" />
-            </button>
             <Reference
               :id="INDEX_ROOT_KEY"
               :url="technologyPath"
@@ -34,6 +25,15 @@
               </h2>
               <Badge v-if="isTechnologyBeta" variant="beta" />
             </Reference>
+            <button
+              :id="SIDEBAR_HIDE_BUTTON_ID"
+              class="close-card"
+              :class="{ 'hide-on-large': !allowHiding }"
+              :aria-label="$t('navigator.close-navigator')"
+              @click="handleHideClick"
+            >
+              <SidenavIcon class="icon-inline close-icon" />
+            </button>
           </div>
         </div>
         <slot name="body" className="card-body"/>
@@ -170,6 +170,12 @@ $close-icon-padding: 5px;
     &:hover {
       background: var(--color-navigator-item-hover);
       text-decoration: none;
+    }
+
+    &:focus .card-link {
+      .fromkeyboard & {
+        @include focus-outline();
+      }
     }
 
     @include safe-area-left-set(padding-left, var(--card-horizontal-spacing));

--- a/src/components/Navigator/BaseNavigatorCardItem.vue
+++ b/src/components/Navigator/BaseNavigatorCardItem.vue
@@ -67,6 +67,9 @@ $nesting-spacing: $nav-card-horizontal-spacing + $nav-card-horizontal-spacing-sm
 
   @include on-keyboard-focus-within() {
     @include focus-outline(-4px);
+    &:not(.is-group) {
+      background: var(--color-navigator-item-hover);
+    }
   }
 
   &.active {

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -10,7 +10,6 @@
 
 <template>
   <BaseNavigatorCardItem
-    class="navigator-card-item"
     :class="{ expanded, active: isActive, 'is-group': isGroupMarker }"
     :style="{ '--nesting-index': item.depth }"
     :data-nesting-index="item.depth"

--- a/src/components/TutorialsOverview/ChapterTopicList.vue
+++ b/src/components/TutorialsOverview/ChapterTopicList.vue
@@ -178,7 +178,7 @@ $circle-diameter: $circle-radius * 2;
     text-decoration: none;
 
     .link {
-      text-decoration: underline;
+      @include underline-text;
     }
   }
 }

--- a/src/components/TutorialsOverview/ResourcesTile.vue
+++ b/src/components/TutorialsOverview/ResourcesTile.vue
@@ -153,6 +153,11 @@ a, .content :deep(a) {
   }
 }
 
+:deep(.inline-link) {
+  // prevent underline in Tile links
+  text-decoration: none;
+}
+
 :deep(.content) {
   ul {
     list-style-type: none;

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -137,8 +137,10 @@ a {
     text-decoration: none;
   }
 
-  &:hover {
-    text-decoration: underline;
+  // Inline links need to be underline under WCAG 2.2 compliance
+  // More info: https://www.w3.org/WAI/WCAG22/Techniques/failures/F73
+  &:hover, &.inline-link {
+    @include underline-text;
   }
 
   &:active {

--- a/src/styles/core/_typography.scss
+++ b/src/styles/core/_typography.scss
@@ -11,6 +11,12 @@
 // Used to calculate `em()`s and to set the default `font-size` on `html`.
 $body-font-size: 17px;
 
+@mixin underline-text() {
+  text-decoration: underline;
+  // prevent underscore characters to be covered by the underline style
+  text-underline-position: under;
+}
+
 @import "typography/font-style-utils";
 @import "typography/font-styles";
 @import "typography/font-attribute-utils";


### PR DESCRIPTION
- Explanation: Inline links need to be underline under WCAG 2.2 compliance
- Scope: All project
- Issue: rdar://115116961
- Risk: Low
- Testing: Tested manually since they are style changes
- Reviewer: @hqhhuang @dobromir-hristov 
- Original PR: https://github.com/apple/swift-docc-render/pull/733