### PR TITLE
[5.10] Add QuickNav and View More strings to i18n

### DIFF
--- a/src/components/DocumentationTopic/ViewMore.vue
+++ b/src/components/DocumentationTopic/ViewMore.vue
@@ -14,7 +14,7 @@
       :to="url"
       class="base-link"
     >
-      <slot>View more</slot>
+      <slot>{{ $t('documentation.view-more')}}</slot>
     </router-link>
   </div>
 </template>

--- a/src/components/Navigator/QuickNavigationModal.vue
+++ b/src/components/Navigator/QuickNavigationModal.vue
@@ -56,7 +56,7 @@
             class="no-results"
           >
             <p>
-              No results found.
+              {{ $t('navigator.no-results') }}
             </p>
           </div>
           <template v-else>

--- a/src/components/Navigator/QuickNavigationPreview.vue
+++ b/src/components/Navigator/QuickNavigationPreview.vue
@@ -29,7 +29,7 @@
     </div>
     <!-- error, unavailable message -->
     <div v-else-if="state === STATE.error" class="unavailable">
-      <p>Preview unavailable</p>
+      <p>{{ $t('quicknav.preview-unavailable') }}</p>
     </div>
   </div>
 </template>

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -65,7 +65,8 @@
       "view-api": "View API collection",
       "view-symbol": "View symbol",
       "view-sample-code": "View sample code"
-    }
+    },
+    "view-more": "View more"
   },
   "aside-kind": {
     "beta": "Beta",
@@ -200,6 +201,7 @@
     "button": {
       "label": "Open Quick Navigation",
       "title": "Click or type / for quick navigation"
-    }
+    },
+    "preview-unavailable": "Preview unavailable"
   }
 }

--- a/tests/unit/components/DocumentationTopic/ViewMore.spec.js
+++ b/tests/unit/components/DocumentationTopic/ViewMore.spec.js
@@ -20,7 +20,7 @@ describe('ViewMore', () => {
     const link = wrapper.find(RouterLinkStub);
     expect(link.exists()).toBe(true);
     expect(link.props('to')).toBe('/foo/bar');
-    expect(link.text()).toBe('View more');
+    expect(link.text()).toBe('documentation.view-more');
     expect(link.classes()).toContain('base-link');
   });
 

--- a/tests/unit/components/Navigator/QuickNavigationModal.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationModal.spec.js
@@ -177,7 +177,7 @@ describe('QuickNavigationModal', () => {
     expect(wrapper.vm.debouncedInput).toBe(nonResultsInputValue);
     expect(wrapper.findAll('.quick-navigation__symbol-match').length).toBe(0);
     expect(noResultsWrapper.exists()).toBe(true);
-    expect(noResultsWrapper.text()).toBe('No results found.');
+    expect(noResultsWrapper.text()).toBe('navigator.no-results');
   });
 
   it('it renders symbol matches with the corresponding symbol icon', () => {

--- a/tests/unit/components/Navigator/QuickNavigationPreview.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationPreview.spec.js
@@ -83,7 +83,7 @@ describe('QuickNavigationPreview', () => {
     expect(wrapper.contains('.loading')).toBe(false);
 
     const unavailable = wrapper.find('.unavailable p');
-    expect(unavailable.text()).toBe('Preview unavailable');
+    expect(unavailable.text()).toBe('quicknav.preview-unavailable');
   });
 
   it('renders loading UI when loading slowly', () => {


### PR DESCRIPTION
- Explanation: Add QuickNav and View More strings to i18n
- Scope: Quick Navigation
- Issue: rdar://106379419
- Risk: Low
- Testing: Tested manually and updated unit tests
- Reviewer: @mportiz08 
- Original PR: https://github.com/apple/swift-docc-render/pull/747