### PR TITLE
Remove rounding from device frame calculations

### DIFF
--- a/src/components/ContentNode/DeviceFrame.vue
+++ b/src/components/ContentNode/DeviceFrame.vue
@@ -26,7 +26,6 @@ import DeviceFrames from 'theme/constants/DeviceFrames';
 import { getSetting } from 'docc-render/utils/theme-settings';
 
 const isTruthy = val => val && val !== Infinity;
-const round = (v, dec = 4) => (isTruthy(v) ? +(`${Math.round(`${v}e+${dec}`)}e-${dec}`) : null);
 
 export default {
   name: 'DeviceFrame',
@@ -42,7 +41,7 @@ export default {
   computed: {
     currentDeviceAttrs: ({ device }) => getSetting(['theme', 'device-frames', device], DeviceFrames[device]),
     styles: ({
-      toPixel, toUrl, toPct, currentDeviceAttrs: attrs = {},
+      toPixel, toUrl, toPct, currentDeviceAttrs: attrs = {}, toVal,
     }) => {
       const {
         screenTop, screenLeft, screenWidth, frameWidth,
@@ -54,10 +53,10 @@ export default {
         '--screen-left': toPct(screenLeft / frameWidth),
         '--screen-width': toPct(screenWidth / frameWidth),
         '--screen-height': toPct(screenHeight / frameHeight),
-        '--screen-aspect': round(screenWidth / screenHeight) || null,
+        '--screen-aspect': toVal(screenWidth / screenHeight),
 
         '--frame-width': toPixel(frameWidth),
-        '--frame-aspect': round(frameWidth / frameHeight) || null,
+        '--frame-aspect': toVal(frameWidth / frameHeight),
 
         '--device-light-url': toUrl(lightUrl),
         '--device-dark-url': toUrl(darkUrl),
@@ -70,7 +69,8 @@ export default {
   methods: {
     toPixel: val => (isTruthy(val) ? `${val}px` : null),
     toUrl: val => (isTruthy(val) ? `url(${val})` : null),
-    toPct: val => (isTruthy(val) ? `${round(val * 100)}%` : null),
+    toPct: val => (isTruthy(val) ? `${val * 100}%` : null),
+    toVal: val => (isTruthy(val) ? val : null),
   },
 };
 </script>

--- a/tests/unit/components/ContentNode/DeviceFrame.spec.js
+++ b/tests/unit/components/ContentNode/DeviceFrame.spec.js
@@ -79,23 +79,23 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(DeviceFram
 const phoneStyles = {
   '--device-dark-url': null,
   '--device-light-url': 'url(path/to/phone.svg)',
-  '--frame-aspect': 0.4898,
+  '--frame-aspect': 0.4897959183673469,
   '--frame-width': '240px',
-  '--screen-aspect': 0.4565,
-  '--screen-height': '93.8776%',
+  '--screen-aspect': 0.45652173913043476,
+  '--screen-height': '93.87755102040816%',
   '--screen-left': '6.25%',
-  '--screen-top': '3.0612%',
+  '--screen-top': '3.061224489795918%',
   '--screen-width': '87.5%',
 };
 const tabletStyles = {
   '--device-dark-url': null,
   '--device-light-url': 'url(path/to/tablet.svg)',
-  '--frame-aspect': 1.3913,
+  '--frame-aspect': 1.391304347826087,
   '--frame-width': '640px',
-  '--screen-aspect': 1.439,
-  '--screen-height': '89.1304%',
-  '--screen-left': '3.4375%',
-  '--screen-top': '4.7826%',
+  '--screen-aspect': 1.4390243902439024,
+  '--screen-height': '89.13043478260869%',
+  '--screen-left': '3.4375000000000004%',
+  '--screen-top': '4.782608695652174%',
   '--screen-width': '92.1875%',
 };
 


### PR DESCRIPTION
Bug/issue #, if applicable: 115480995

## Summary

Removes the rounding from the DeviceFrames screen calcs, because they are causing weird rounding issues in browsers, while resizing. 

The percentages are never visually rendered, so it does not matter how many decimals there are.

## Dependencies

NA

## Testing

Steps:
1. Load a page with device frames
2. Ensure frames from leak background colors, are off positioned, etc.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
