### PR TITLE
[5.10] Improve layout for landscape tutorial step assets

### DIFF
--- a/src/components/Tutorial/SectionSteps.vue
+++ b/src/components/Tutorial/SectionSteps.vue
@@ -438,6 +438,13 @@ $rhs-col-width-max: 921px;
         min-height: $asset-min-height - 40px;
       }
     }
+
+    :deep([data-orientation="landscape"]) {
+      max-width: min(
+         #{$rhs-col-width-max - ($media-spacing * 2)},
+         calc(50vw + #{$rhs-center-overlap} - #{$media-spacing * 2})
+      );
+    }
   }
 
   @include breakpoint(small) {
@@ -457,6 +464,10 @@ $rhs-col-width-max: 921px;
         background-color: var(--background, var(--color-step-background));
       }
     }
+  }
+
+  &:has([data-orientation="landscape"]) {
+    width: unset;
   }
 }
 

--- a/src/components/VideoAsset.vue
+++ b/src/components/VideoAsset.vue
@@ -18,11 +18,13 @@
     <video
       ref="video"
       :controls="showsControls"
+      :data-orientation="orientation"
       :autoplay="autoplays"
       :poster="normalisedPosterPath"
       :muted="muted"
       :width="optimalWidth"
       playsinline
+      @loadedmetadata="setOrientation"
       @playing="$emit('playing')"
       @pause="$emit('pause')"
       @ended="$emit('ended')"
@@ -43,6 +45,7 @@ import {
   separateVariantsByAppearance,
   normalizePath,
   getIntrinsicDimensions,
+  getOrientation,
   extractDensities,
 } from 'docc-render/utils/assets';
 import AppStore from 'docc-render/stores/AppStore';
@@ -83,6 +86,7 @@ export default {
   data: () => ({
     appState: AppStore.state,
     optimalWidth: null,
+    orientation: null,
   }),
   computed: {
     DeviceFrameComponent: () => DeviceFrame,
@@ -170,6 +174,10 @@ export default {
       const currentVariantDensity = parseInt(density.match(/\d+/)[0], 10);
       const { width } = await getIntrinsicDimensions(path);
       this.optimalWidth = width / currentVariantDensity;
+    },
+    setOrientation() {
+      const { videoWidth: width, videoHeight: height } = this.$refs.video;
+      this.orientation = getOrientation(width, height);
     },
   },
 };

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -108,3 +108,33 @@ export function getIntrinsicDimensions(src) {
     });
   });
 }
+
+/**
+ * Represents the orientation of an asset.
+ */
+export const Orientation = {
+  landscape: 'landscape',
+  portrait: 'portrait',
+  square: 'square',
+};
+
+/*
+ * Returns an orientation corresponding to width and height dimensions.
+ * @param {Number} width
+ * @param {Number} height
+ * @returns {Orientation}
+ */
+export function getOrientation(width, height) {
+  if (!width || !height) {
+    return null;
+  }
+
+  if (width < height) {
+    return Orientation.portrait;
+  }
+  if (width > height) {
+    return Orientation.landscape;
+  }
+
+  return Orientation.square;
+}

--- a/tests/unit/components/ImageAsset.spec.js
+++ b/tests/unit/components/ImageAsset.spec.js
@@ -58,6 +58,7 @@ describe('ImageAsset', () => {
     expect(image.attributes('alt')).toBe(alt);
     expect(image.attributes('decoding')).toBe('async');
     expect(image.attributes('loading')).toBe('lazy');
+    expect(image.attributes('data-orientation')).toBeFalsy();
   });
 
   it('renders an image that has one variant with no appearance trait', () => {
@@ -331,6 +332,7 @@ describe('ImageAsset', () => {
     await flushPromises();
     expect(img.attributes('width')).toBe(`${optimalDisplayWidth}`);
     expect(img.attributes('height')).toBe('auto');
+    expect(img.attributes('data-orientation')).toBe('square');
   });
 
   it('does not calculate widths, if the element unmounts just as it gets loaded', async () => {
@@ -350,8 +352,8 @@ describe('ImageAsset', () => {
       },
     });
 
-    const calculateOptimalWidthSpy = jest.spyOn(wrapper.vm, 'calculateOptimalWidth')
-      .mockReturnValue(99);
+    const calculateOptimalDimensionsSpy = jest.spyOn(wrapper.vm, 'calculateOptimalDimensions')
+      .mockReturnValue({ width: 99 });
     const img = wrapper.find('img');
 
     expect(img.attributes('width')).toBeFalsy();
@@ -362,7 +364,7 @@ describe('ImageAsset', () => {
     await flushPromises();
     expect(img.attributes('width')).toBeFalsy();
     expect(img.attributes('height')).toBeFalsy();
-    expect(calculateOptimalWidthSpy).toHaveBeenCalledTimes(0);
+    expect(calculateOptimalDimensionsSpy).toHaveBeenCalledTimes(0);
   });
 
   it('allows disabling the optimal-width calculation', async () => {

--- a/tests/unit/components/VideoAsset.spec.js
+++ b/tests/unit/components/VideoAsset.spec.js
@@ -219,4 +219,14 @@ describe('VideoAsset', () => {
     expect(video.exists()).toBe(true);
     expect(video.find('source').attributes('src')).toBe(propsData.variants[0].url);
   });
+
+  it('sets the orientation after the metadata is loaded', () => {
+    const video = wrapper.find('video');
+    expect(video.attributes('data-orientation')).toBeFalsy();
+
+    wrapper.vm.$refs.video = { videoWidth: 300, videoHeight: 200 };
+
+    video.trigger('loadedmetadata');
+    expect(video.attributes('data-orientation')).toBe('landscape');
+  });
 });

--- a/tests/unit/utils/assets.spec.js
+++ b/tests/unit/utils/assets.spec.js
@@ -7,7 +7,12 @@
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
-import { pathJoin, normalizeRelativePath } from 'docc-render/utils/assets';
+import {
+  Orientation,
+  pathJoin,
+  normalizeRelativePath,
+  getOrientation,
+} from 'docc-render/utils/assets';
 
 let normalizePath;
 const absoluteBaseUrl = 'https://foo.com';
@@ -90,6 +95,28 @@ describe('assets', () => {
 
     it('does not add a `/` if path starts it', () => {
       expect(normalizeRelativePath('/foo')).toBe('/foo');
+    });
+  });
+  describe('getOrientation', () => {
+    it('returns "square" width/height are equal', () => {
+      expect(getOrientation(42, 42)).toBe(Orientation.square);
+    });
+
+    it('returns "portrait" when width is lower than height', () => {
+      expect(getOrientation(200, 300)).toBe(Orientation.portrait);
+    });
+
+    it('returns "landscape" when width is larger than height', () => {
+      expect(getOrientation(300, 200)).toBe(Orientation.landscape);
+    });
+
+    it('returns `null` if not passed a width or height', () => {
+      expect(getOrientation()).toBeNull();
+      expect(getOrientation(42)).toBeNull();
+      expect(getOrientation(42, null)).toBeNull();
+      expect(getOrientation(42, undefined)).toBeNull();
+      expect(getOrientation(undefined, 42)).toBeNull();
+      expect(getOrientation(null, 42)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
- **Explanation:** Adjusts layout of tutorial page to allow for landscape assets to better fill the step preview container when possible, resulting in larger, easier to see images depending on the dimensions.
- **Scope:** Added JS logic that impacts images/videos and CSS that only impacts tutorial step preview container
- **Issue:** rdar://117555171
- **Risk:** Low, minimal logic added for assets, style changes scoped to one component
- **Testing:** Updated unit tests, visually tested tutorials with varying images/videos/viewport sizes, checked that images/videos in other places are unchanged
- **Reviewer:** @dobromir-hristov 
- **Original PR:** #752 