### PR TITLE
Match for generic item in the navigator

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -169,7 +169,7 @@ export default {
       // eslint-disable-next-line no-param-reassign
       path = path.replace(/\/$/, '').toLowerCase();
       const hash = isSymbol ? last(path.split('-')) : '';
-      return hash.length && hash.length <= 5 && /^[a-z0-9]*$/.test(hash);
+      return !!hash.length && hash.length <= 5 && /^[a-z0-9]*$/.test(hash);
     },
     /**
      * The root item is always a module

--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -170,7 +170,7 @@ export default {
       // eslint-disable-next-line no-param-reassign
       path = path.replace(/\/$/, '');
       const hash = isSymbol ? last(path.split('-')) : '';
-      return /^[a-z0-9]{1, 5}$/.test(hash);
+      return /^[a-z0-9]{1,5}$/.test(hash);
     },
     /**
      * The root item is always a module

--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -25,6 +25,7 @@
       :api-changes="apiChanges"
       :allow-hiding="allowHiding"
       :navigator-references="navigatorReferences"
+      :hasValidHash="hasValidHash"
       @close="$emit('close')"
     >
       <template #filter><slot name="filter" /></template>
@@ -47,6 +48,7 @@ import NavigatorCard from 'theme/components/Navigator/NavigatorCard.vue';
 import LoadingNavigatorCard from 'theme/components/Navigator/LoadingNavigatorCard.vue';
 import { INDEX_ROOT_KEY } from 'docc-render/constants/sidebar';
 import { TopicTypes } from 'docc-render/constants/TopicTypes';
+import { last } from 'docc-render/utils/arrays';
 
 /**
  * @typedef NavigatorFlatItem
@@ -126,6 +128,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    symbolKind: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     // gets the paths for each parent in the breadcrumbs
@@ -151,6 +157,20 @@ export default {
         itemsToSlice = 2;
       }
       return parentTopicReferences.slice(itemsToSlice).map(r => r.url).concat(path);
+    },
+    /**
+     * Symbol pages always have a symbolKind
+     */
+    isSymbol: ({ symbolKind }) => !!symbolKind,
+    /**
+     * Only symbol pages can have a valid hash:
+     * less than 5 char, only lower case letter and number
+     */
+    hasValidHash({ $route: { path }, isSymbol }) {
+      // eslint-disable-next-line no-param-reassign
+      path = path.replace(/\/$/, '').toLowerCase();
+      const hash = isSymbol ? last(path.split('-')) : '';
+      return hash.length && hash.length <= 5 && /^[a-z0-9]*$/.test(hash);
     },
     /**
      * The root item is always a module

--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -162,7 +162,7 @@ export default {
      */
     isSymbol: ({ symbolKind }) => !!symbolKind,
     /**
-     * Only symbol pages can have a valid hash:
+     * Only symbol pages with overloads can have a valid hash:
      * less than 5 char, only lower case letter and number
      */
     hasValidHash({ $route: { path }, isSymbol }) {
@@ -170,7 +170,7 @@ export default {
       // eslint-disable-next-line no-param-reassign
       path = path.replace(/\/$/, '');
       const hash = isSymbol ? last(path.split('-')) : '';
-      return !!hash.length && hash.length <= 5 && /^[a-z0-9]*$/.test(hash);
+      return /^[a-z0-9]{1, 5}$/.test(hash);
     },
     /**
      * The root item is always a module

--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -166,8 +166,9 @@ export default {
      * less than 5 char, only lower case letter and number
      */
     hasValidHash({ $route: { path }, isSymbol }) {
+      // Ensure the path does not have a trailing slash
       // eslint-disable-next-line no-param-reassign
-      path = path.replace(/\/$/, '').toLowerCase();
+      path = path.replace(/\/$/, '');
       const hash = isSymbol ? last(path.split('-')) : '';
       return !!hash.length && hash.length <= 5 && /^[a-z0-9]*$/.test(hash);
     },

--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -25,7 +25,7 @@
       :api-changes="apiChanges"
       :allow-hiding="allowHiding"
       :navigator-references="navigatorReferences"
-      :hasValidHash="hasValidHash"
+      :isSpecificOverload="isSpecificOverload"
       @close="$emit('close')"
     >
       <template #filter><slot name="filter" /></template>
@@ -165,7 +165,7 @@ export default {
      * Only symbol pages with overloads can have a valid hash:
      * less than 5 char, only lower case letter and number
      */
-    hasValidHash({ $route: { path }, isSymbol }) {
+    isSpecificOverload({ $route: { path }, isSymbol }) {
       // Ensure the path does not have a trailing slash
       // eslint-disable-next-line no-param-reassign
       path = path.replace(/\/$/, '');

--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -129,8 +129,7 @@ export default {
       default: true,
     },
     symbolKind: {
-      type: Boolean,
-      default: false,
+      default: () => undefined,
     },
   },
   computed: {

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1010,7 +1010,6 @@ export default {
       const currentActiveItem = this.childrenMap[this.activeUID];
       // get the current path
       const lastActivePathItem = last(activePath);
-
       // check if there is an active item to start looking from
       if (currentActiveItem) {
         // Return early, if the current path matches the current active node.
@@ -1019,36 +1018,38 @@ export default {
         if (lastActivePathItem === currentActiveItem.path) {
           return;
         }
-        // try to match current open item in its surroundings
+        // try to match current open item in its surroundings, starting with active item
         if (this.matchSurroundingItems(this.activeUID, lastActivePathItem)) return;
 
-        // try to match with generic item
-        // needed for symbols curated in multiple places when selecting an overload from dropdown
         if (this.hasValidHash) {
+          // if no match, try again to match with generic item
+          // Needed for continuing to highlight current generic page
+          // when selecting an overload from dropdown that's also specifically curated in elsewhere
           const genericItem = lastActivePathItem.split('-')[0];
           if (this.matchSurroundingItems(this.activeUID, genericItem)) return;
         }
       }
-      // There is no match to base upon, so we need to search
-      // across the activePath for the active item.
+      // There is no match to base upon, so we need to search the whole tree
+      // by matching each level of the hierachy in activePath
       const activePathChildren = this.pathsToFlatChildren(activePath);
       // if there are items, set new active UID
       if (activePathChildren.length) {
-        // TODO: What exactly is `activePathChildren`??
         const lastChildrenUID = last(activePathChildren).uid;
 
-        if (this.hasValidHash && last(activePathChildren).path !== lastActivePathItem) {
-          // try to match with generic item
+        if (last(activePathChildren).path !== lastActivePathItem && this.hasValidHash) {
+          // if item is not found in the tree and its a specific overloaded symbol page
+          // try to match with its generics page instead
           const genericItem = lastActivePathItem.split('-')[0];
           if (this.matchSurroundingItems(lastChildrenUID, genericItem)) return;
         }
 
-        // TODO: What exactly is `activePathChildren`??
-        // last resort: set last path as new active UID
+        // Set new active UID to the last matched item
+        // Note: if a match is not found, last matched ancestor is highlighted
         this.setActiveUID(lastChildrenUID);
         return;
       }
-      // if there is an activeUID, unset it, as we probably navigated back to the root
+      // if there is an activeUID, but still no match found in tree
+      // unset it, as we probably navigated back to the root
       if (this.activeUID) {
         this.setActiveUID(null);
         return;

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -232,6 +232,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    hasValidHash: {
+      type: Boolean,
+      default: false,
+    },
   },
   mixins: [
     keyboardNavigation,
@@ -1007,11 +1011,8 @@ export default {
       // get the current path
       const lastActivePathItem = last(activePath);
 
-      // get hash
-      const hash = lastActivePathItem ? last(lastActivePathItem.split('-')) : '';
-      // valid hash is less than 5 char, lower case letter and number only
-      const validHash = hash.length <= 5 ? /^[a-z0-9]*$/.test(hash) : false;
-      const genericItem = (validHash && lastActivePathItem) ? lastActivePathItem.split('-')[0] : lastActivePathItem;
+      const genericItem = (this.hasValidHash && lastActivePathItem)
+        ? lastActivePathItem.split('-')[0] : lastActivePathItem;
 
       // check if there is an active item to start looking from
       if (currentActiveItem) {
@@ -1026,7 +1027,7 @@ export default {
 
         // try to match with generic item
         // needed for symbols curated in multiple places when selecting an overload from dropdown
-        if (validHash) {
+        if (this.hasValidHash) {
           if (this.matchSurroundingItems(this.activeUID, genericItem)) return;
         }
       }
@@ -1038,7 +1039,7 @@ export default {
         // TODO: What exactly is `activePathChildren`??
         const lastChildrenUID = last(activePathChildren).uid;
 
-        if (validHash) {
+        if (this.hasValidHash) {
           // try to match with generic item
           if (this.matchSurroundingItems(lastChildrenUID, genericItem)) return;
         }

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -232,7 +232,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    hasValidHash: {
+    isSpecificOverload: {
       type: Boolean,
       default: false,
     },
@@ -1021,7 +1021,7 @@ export default {
         // try to match current open item in its surroundings, starting with active item
         if (this.matchSurroundingItems(this.activeUID, lastActivePathItem)) return;
 
-        if (this.hasValidHash) {
+        if (this.isSpecificOverload) {
           // if no match, try again to match with generic item
           // Needed for continuing to highlight current generic page
           // when selecting an overload from dropdown that's also specifically curated in elsewhere
@@ -1036,7 +1036,7 @@ export default {
       if (activePathChildren.length) {
         const lastChildrenUID = last(activePathChildren).uid;
 
-        if (last(activePathChildren).path !== lastActivePathItem && this.hasValidHash) {
+        if (last(activePathChildren).path !== lastActivePathItem && this.isSpecificOverload) {
           // if item is not found in the tree and its a specific overloaded symbol page
           // try to match with its generics page instead
           const genericItem = lastActivePathItem.slice(0, lastActivePathItem.lastIndexOf('-'));

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1011,9 +1011,6 @@ export default {
       // get the current path
       const lastActivePathItem = last(activePath);
 
-      const genericItem = (this.hasValidHash && lastActivePathItem)
-        ? lastActivePathItem.split('-')[0] : lastActivePathItem;
-
       // check if there is an active item to start looking from
       if (currentActiveItem) {
         // Return early, if the current path matches the current active node.
@@ -1028,6 +1025,7 @@ export default {
         // try to match with generic item
         // needed for symbols curated in multiple places when selecting an overload from dropdown
         if (this.hasValidHash) {
+          const genericItem = lastActivePathItem.split('-')[0];
           if (this.matchSurroundingItems(this.activeUID, genericItem)) return;
         }
       }
@@ -1039,8 +1037,9 @@ export default {
         // TODO: What exactly is `activePathChildren`??
         const lastChildrenUID = last(activePathChildren).uid;
 
-        if (this.hasValidHash) {
+        if (this.hasValidHash && last(activePathChildren).path !== lastActivePathItem) {
           // try to match with generic item
+          const genericItem = lastActivePathItem.split('-')[0];
           if (this.matchSurroundingItems(lastChildrenUID, genericItem)) return;
         }
 

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1025,7 +1025,7 @@ export default {
           // if no match, try again to match with generic item
           // Needed for continuing to highlight current generic page
           // when selecting an overload from dropdown that's also specifically curated in elsewhere
-          const genericItem = lastActivePathItem.split('-')[0];
+          const genericItem = lastActivePathItem.slice(0, lastActivePathItem.lastIndexOf('-'));
           if (this.matchSurroundingItems(this.activeUID, genericItem)) return;
         }
       }
@@ -1039,7 +1039,7 @@ export default {
         if (last(activePathChildren).path !== lastActivePathItem && this.hasValidHash) {
           // if item is not found in the tree and its a specific overloaded symbol page
           // try to match with its generics page instead
-          const genericItem = lastActivePathItem.split('-')[0];
+          const genericItem = lastActivePathItem.slice(0, lastActivePathItem.lastIndexOf('-'));
           if (this.matchSurroundingItems(lastChildrenUID, genericItem)) return;
         }
 

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -43,6 +43,7 @@
                     :error-fetching="slotProps.errorFetching"
                     :api-changes="slotProps.apiChanges"
                     :references="topicProps.references"
+                    :symbolKind="topicProps.symbolKind"
                     :navigator-references="slotProps.references"
                     :scrollLockID="scrollLockID"
                     :render-filter-on-top="breakpoint !== BreakpointName.large"

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -150,7 +150,7 @@ describe('Navigator', () => {
       allowHiding: true,
       navigatorReferences,
       hideAvailableTags: false,
-      hasValidHash: false,
+      isSpecificOverload: false,
     });
   });
 
@@ -191,7 +191,7 @@ describe('Navigator', () => {
       allowHiding: true,
       navigatorReferences,
       hideAvailableTags: false,
-      hasValidHash: false,
+      isSpecificOverload: false,
     });
   });
 
@@ -251,18 +251,18 @@ describe('Navigator', () => {
     expect(errorSpy).toHaveBeenCalledWith(`Reference for "${identifier}" is missing`);
   });
 
-  it('correctly computes `hasValidHash` if hash does not exist', () => {
+  it('correctly computes `isSpecificOverload` if hash does not exist', () => {
     // non-symbol pages don't have valid hash
     const wrapper = createWrapper({
       propsData: {
         symbolKind: undefined,
       },
     });
-    expect(wrapper.find(NavigatorCard).props('hasValidHash')).toBe(false);
+    expect(wrapper.find(NavigatorCard).props('isSpecificOverload')).toBe(false);
 
     // symbol page with no hash
     wrapper.setProps({ symbolKind: 'method' });
-    expect(wrapper.find(NavigatorCard).props('hasValidHash')).toBe(false);
+    expect(wrapper.find(NavigatorCard).props('isSpecificOverload')).toBe(false);
   });
 
   it('correctly identifies whether a hash is valid', () => {
@@ -274,7 +274,7 @@ describe('Navigator', () => {
         },
       },
     });
-    expect(wrapper.find(NavigatorCard).props('hasValidHash')).toBe(true);
+    expect(wrapper.find(NavigatorCard).props('isSpecificOverload')).toBe(true);
 
     // capitalized letter, invalid hash
     wrapper = createWrapper({
@@ -284,7 +284,7 @@ describe('Navigator', () => {
         },
       },
     });
-    expect(wrapper.find(NavigatorCard).props('hasValidHash')).toBe(false);
+    expect(wrapper.find(NavigatorCard).props('isSpecificOverload')).toBe(false);
   });
 
   it('removes any parent topic identifiers, which dont have a reference', () => {

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -104,6 +104,7 @@ const defaultProps = {
   renderFilterOnTop: false,
   navigatorReferences,
   flatChildren: [],
+  symbolKind: 'method',
 };
 
 const fauxAnchor = document.createElement('DIV');
@@ -248,6 +249,42 @@ describe('Navigator', () => {
     expect(wrapper.find(NavigatorCard).props('activePath')).toEqual([mocks.$route.path]);
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(`Reference for "${identifier}" is missing`);
+  });
+
+  it('correctly computes `hasValidHash` if hash does not exist', () => {
+    // non-symbol pages don't have valid hash
+    const wrapper = createWrapper({
+      propsData: {
+        symbolKind: undefined,
+      },
+    });
+    expect(wrapper.find(NavigatorCard).props('hasValidHash')).toBe(false);
+
+    // symbol page with no hash
+    wrapper.setProps({ symbolKind: 'method' });
+    expect(wrapper.find(NavigatorCard).props('hasValidHash')).toBe(false);
+  });
+
+  it('correctly identifies whether a hash is valid', () => {
+    // symbol with valid hash
+    let wrapper = createWrapper({
+      mocks: {
+        $route: {
+          path: '/documentation/Foo-abc12',
+        },
+      },
+    });
+    expect(wrapper.find(NavigatorCard).props('hasValidHash')).toBe(true);
+
+    // capitalized letter, invalid hash
+    wrapper = createWrapper({
+      mocks: {
+        $route: {
+          path: '/documentation/Foo-Bar',
+        },
+      },
+    });
+    expect(wrapper.find(NavigatorCard).props('hasValidHash')).toBe(false);
   });
 
   it('removes any parent topic identifiers, which dont have a reference', () => {

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -276,6 +276,15 @@ describe('Navigator', () => {
     });
     expect(wrapper.find(NavigatorCard).props('isSpecificOverload')).toBe(true);
 
+    wrapper = createWrapper({
+      mocks: {
+        $route: {
+          path: '/documentation/Foo-Bar-abc12',
+        },
+      },
+    });
+    expect(wrapper.find(NavigatorCard).props('isSpecificOverload')).toBe(true);
+
     // capitalized letter, invalid hash
     wrapper = createWrapper({
       mocks: {

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -149,6 +149,7 @@ describe('Navigator', () => {
       allowHiding: true,
       navigatorReferences,
       hideAvailableTags: false,
+      hasValidHash: false,
     });
   });
 
@@ -189,6 +190,7 @@ describe('Navigator', () => {
       allowHiding: true,
       navigatorReferences,
       hideAvailableTags: false,
+      hasValidHash: false,
     });
   });
 

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1037,6 +1037,27 @@ describe('NavigatorCard', () => {
     });
   });
 
+  it('highlights the generic page', async () => {
+    const wrapper = createWrapper();
+    wrapper.setProps({
+      activePath: ['/documentation/testkit-ab1c2'],
+    });
+    await flushPromises();
+    const all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(4); // assert all are rendered, except the grandchild
+    expect(all.at(0).props()).toMatchObject({
+      item: root0, // the first item
+      isBold: true,
+      isActive: true,
+      expanded: true,
+    });
+    expect(all.at(1).props()).toMatchObject({
+      item: root0Child0,
+      isBold: false,
+      isActive: false,
+    });
+  });
+
   it('keeps the open/closed state when navigating while filtering, except when the current page not visible, in which case we open those items', async () => {
     const wrapper = createWrapper();
     await flushPromises();

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1037,7 +1037,7 @@ describe('NavigatorCard', () => {
     });
   });
 
-  it('highlights the generic page', async () => {
+  it('highlights the generic page when an overloaded page is not in the tree', async () => {
     const wrapper = createWrapper();
     wrapper.setProps({
       activePath: ['/documentation/testkit-ab1c2'],
@@ -1048,14 +1048,59 @@ describe('NavigatorCard', () => {
     expect(all).toHaveLength(4); // assert all are rendered, except the grandchild
     expect(all.at(0).props()).toMatchObject({
       item: root0,
-      isBold: true, // <- highlighted
-      isActive: true,
+      isBold: true,
+      isActive: true, // <- highlighted
       expanded: true,
     });
+  });
+
+  it('highlights the specific page when both generic and specific overloaded pages are in the tree', async () => {
+    const overloadedPage = {
+      type: TopicTypes.struct,
+      path: '/documentation/testkit-ab1c2',
+      title: 'Third Child, Depth 1',
+      uid: 100,
+      parent: INDEX_ROOT_KEY,
+      depth: 0,
+      index: 2,
+      childUIDs: [],
+    };
+
+    const wrapper = createWrapper({
+      propsData: {
+        children: [
+          root0,
+          root0Child0,
+          root0Child1,
+          root0Child1GrandChild0,
+          root1,
+          overloadedPage,
+        ],
+        activePath: ['/documentation/testkit-ab1c2'],
+        hasValidHash: true,
+      },
+    });
+
+    await flushPromises();
+    const all = wrapper.findAll(NavigatorCardItem);
+    expect(all).toHaveLength(3); // assert only first level pages are rendered
+    expect(all.at(0).props()).toMatchObject({
+      item: root0,
+      isBold: false,
+      isActive: false, // <- not highlighted
+      expanded: false,
+    });
     expect(all.at(1).props()).toMatchObject({
-      item: root0Child0,
-      isBold: false, // <- not highlighted
-      isActive: false,
+      item: root1,
+      isBold: false,
+      isActive: false, // <- not highlighted
+      expanded: false,
+    });
+    expect(all.at(2).props()).toMatchObject({
+      item: overloadedPage,
+      isBold: true,
+      isActive: true, // <- highlighted
+      expanded: true,
     });
   });
 

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1041,19 +1041,20 @@ describe('NavigatorCard', () => {
     const wrapper = createWrapper();
     wrapper.setProps({
       activePath: ['/documentation/testkit-ab1c2'],
+      hasValidHash: true,
     });
     await flushPromises();
     const all = wrapper.findAll(NavigatorCardItem);
     expect(all).toHaveLength(4); // assert all are rendered, except the grandchild
     expect(all.at(0).props()).toMatchObject({
-      item: root0, // the first item
-      isBold: true,
+      item: root0,
+      isBold: true, // <- highlighted
       isActive: true,
       expanded: true,
     });
     expect(all.at(1).props()).toMatchObject({
       item: root0Child0,
-      isBold: false,
+      isBold: false, // <- not highlighted
       isActive: false,
     });
   });

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1041,7 +1041,7 @@ describe('NavigatorCard', () => {
     const wrapper = createWrapper();
     wrapper.setProps({
       activePath: ['/documentation/testkit-ab1c2'],
-      hasValidHash: true,
+      isSpecificOverload: true,
     });
     await flushPromises();
     const all = wrapper.findAll(NavigatorCardItem);
@@ -1077,7 +1077,7 @@ describe('NavigatorCard', () => {
           overloadedPage,
         ],
         activePath: ['/documentation/testkit-ab1c2'],
-        hasValidHash: true,
+        isSpecificOverload: true,
       },
     });
 

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -225,6 +225,7 @@ describe('DocumentationTopic', () => {
       // assert we are passing the first set of paths always
       parentTopicIdentifiers: topicData.hierarchy.paths[0],
       references: topicData.references,
+      symbolKind: topicData.metadata.symbolKind,
       scrollLockID: AdjustableSidebarWidth.constants.SCROLL_LOCK_ID,
       // assert we are passing the default technology, if we dont have the children yet
       technology,
@@ -243,6 +244,7 @@ describe('DocumentationTopic', () => {
       renderFilterOnTop: false,
       parentTopicIdentifiers: topicData.hierarchy.paths[0],
       references: topicData.references,
+      symbolKind: topicData.metadata.symbolKind,
       technology: TechnologyWithChildren,
       apiChanges: null,
       allowHiding: true,


### PR DESCRIPTION
Bug/issue #, if applicable: 117442044

## Summary
If we are on a specific overload page and it doesn't exist in the navigator, we should attempt to match for its generic item as well.

## Dependencies
Branch: [combine-overloads-navigator](https://github.com/hqhhuang/swift-docc-render/tree/combine-overloads-navigator)

## Testing
Test manually

Steps:
1. Verify if the specific overload page is not curated in the navigator, generic page is highlighted
2. If it is curated, then it should be highlighted as usual. (No behavior change)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
