### PR TITLE
Specify how many spaces are displayed for tabs in code listings

### DIFF
--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -166,6 +166,7 @@ pre {
   white-space: pre;
   word-wrap: normal;
   height: 100%;
+  tab-size: var(--code-indentationWidth, 4);
   @include breakpoint(small) {
     padding-top: rem(14px);
   }


### PR DESCRIPTION
Bug/issue #, if applicable: 118562377

## Summary

This changes the number of spaces displayed for tab characters in code listings to 4, which better matches the default Xcode behavior in place of the 8 that are being shown currently.

The number of spaces can also now be customized by DocC users by utilizing the existing `theme.code.indentationWidth` setting.

**main** (8 spaces):
![Screen Shot 2023-11-28 at 11 30 30](https://github.com/apple/swift-docc-render/assets/212918/19dfd648-7325-4229-85ef-6cb89fa87945)

**this branch** (4 spaces):
![Screen Shot 2023-11-28 at 11 31 34](https://github.com/apple/swift-docc-render/assets/212918/526af4d6-dd38-4caf-a49b-c6c6c1278cfe)

**this branch** (with `theme.code.indentationWidth` set to `2` in `theme-settings.json`):
![Screen Shot 2023-11-28 at 11 32 08](https://github.com/apple/swift-docc-render/assets/212918/fff6b212-dc2a-48e5-bbfd-99eb74572641)

## Testing

Steps:
1. Checkout this branch and build it with `npm run build`
2. Add a code listing with a tab* to `SwiftDocCRender.docc/SwiftDocCRender.md` or any other catalog content
3. Run `DOCC_HTML_DIR=/path/to/swift-docc-render/dist npm run docs` (or build your catalog with this build of swift-docc-render)
4. Open http://localhost:8000/documentation/swiftdoccrender/ and verify that the tab displays as 4 spaces in the code listing (or in the URL for your own content)
5. Add a `SwiftDocCRender.docc/theme-settings.json` file with `theme.code.indentationWidth` set to some integer value
6. Verify that the number of spaces in the code listing now matches what was specified above

\* make sure your editor actually inserts a real tab character (some may be configured to replace it with spaces)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
