### PR TITLE
Expose "Web Service Endpoints" as new filter tag in navigator

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -135,12 +135,14 @@ const FILTER_TAGS = {
   sampleCode: 'sampleCode',
   tutorials: 'tutorials',
   articles: 'articles',
+  webServiceEndpoints: 'webServiceEndpoints',
 };
 
 const FILTER_TAGS_TO_LABELS = {
   [FILTER_TAGS.sampleCode]: 'Sample Code',
   [FILTER_TAGS.tutorials]: 'Tutorials',
   [FILTER_TAGS.articles]: 'Articles',
+  [FILTER_TAGS.webServiceEndpoints]: 'Web Service Endpoints',
 };
 
 const FILTER_LABELS_TO_TAGS = Object.fromEntries(
@@ -158,6 +160,7 @@ const TOPIC_TYPE_TO_TAG = {
   [TopicTypes.section]: FILTER_TAGS.tutorials,
   [TopicTypes.tutorial]: FILTER_TAGS.tutorials,
   [TopicTypes.project]: FILTER_TAGS.tutorials,
+  [TopicTypes.httpRequest]: FILTER_TAGS.webServiceEndpoints,
 };
 
 const NO_RESULTS = 'navigator.no-results';

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -1775,6 +1775,30 @@ describe('NavigatorCard', () => {
     expect(filter.props('tags')).toEqual(['Sample Code', ChangeNames.modified]);
   });
 
+  it('shows a "Web Service Endpoints" tag when relevant', async () => {
+    sessionStorage.get.mockImplementation((key, def) => def);
+    const httpReq = {
+      type: 'httpRequest',
+      path: '/documentation/footkit/blah',
+      title: 'GET /blah',
+      uid: 42,
+      parent: INDEX_ROOT_KEY,
+      depth: 0,
+      index: 0,
+      childUIDs: [],
+    };
+    const wrapper = createWrapper({
+      propsData: {
+        children: [httpReq],
+        activePath: [httpReq.path],
+      },
+    });
+
+    await flushPromises();
+    const filter = wrapper.find(FilterInput);
+    expect(filter.props('tags')).toEqual(['Web Service Endpoints']);
+  });
+
   describe('with groupMarker', () => {
     it('shows "Hide Deprecated" tag, if there are deprecated items', async () => {
       const updatedChild = {


### PR DESCRIPTION
Bug/issue #, if applicable: 110732384

## Summary

Adds a new "Web Service Endpoints" tag to filter navigator items in REST API projects. This can be used to more easily narrow down all the REST HTTP endpoint pages in a given project.

## Testing

Steps:
1. Use this branch to render any REST API project with endpoint documentation pages
2. Open any documentation page and verify that the navigator now has a "Web Service Endpoints" tag in the navigator filter and that it properly filters the navigator to only show endpoint pages
3. Ensure the new tag doesn't show up for projects without endpoint pages
4. Check for any other regressions with existing navigator filter behavior

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
