### PR TITLE
Ensure dark colors are always used in tutorial hero

### DIFF
--- a/src/components/Tutorial/Hero.vue
+++ b/src/components/Tutorial/Hero.vue
@@ -193,6 +193,20 @@ export default {
   background-color: var(--color-tutorial-hero-background);
   color: var(--color-tutorial-hero-text);
   position: relative;
+
+  &.dark {
+    @media screen {
+      // ensure dark colors are always used, regardless of the selected
+      // light/dark/auto color scheme preference
+      //
+      // unfortunately the order of the property declaration matters here due
+      // to the way that some properties refer to others, which is why both the
+      // light and the dark vars are included here, even though the dark ones
+      // override the light ones...
+      @include color-vars-light;
+      @include color-vars-dark;
+    }
+  }
 }
 
 .bg {


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Since this component is meant to always be rendered with a dark color scheme regardless of the user chosen setting, there may be some elements (like asides) that may look broken in light mode since they are trying to use light color scheme colors on the dark background.

### Example

**Before**
![screenshot showing the issue on the main branch](https://github.com/apple/swift-docc-render/assets/212918/8ff810b3-ba50-465f-b2bb-68be3b0bc822)

**After**
![screenshot showing the resolved issue on this branch](https://github.com/apple/swift-docc-render/assets/212918/101f42cd-43a1-4019-b5b6-1fe83f7face9)

## Testing

Steps:
1. Create or update a tutorial with a warning aside in the tutorial intro section
2. Using this branch, open that tutorial page and verify that the warning aside uses the dark colors, _even when you choose the "Light" color scheme option_
3. Ensure there are no regressions with other colors in this element

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
