### PR TITLE
[5.10] Ensure dark colors are always used in tutorial hero

### DIFF
--- a/src/components/Tutorial/Hero.vue
+++ b/src/components/Tutorial/Hero.vue
@@ -193,6 +193,20 @@ export default {
   background-color: var(--color-tutorial-hero-background);
   color: var(--color-tutorial-hero-text);
   position: relative;
+
+  &.dark {
+    @media screen {
+      // ensure dark colors are always used, regardless of the selected
+      // light/dark/auto color scheme preference
+      //
+      // unfortunately the order of the property declaration matters here due
+      // to the way that some properties refer to others, which is why both the
+      // light and the dark vars are included here, even though the dark ones
+      // override the light ones...
+      @include color-vars-light;
+      @include color-vars-dark;
+    }
+  }
 }
 
 .bg {


### PR DESCRIPTION
- **Explanation:** Fixes issue where the colors for some elements like asides look broken in the tutorial intro in light mode
- **Scope:** CSS-only change that impacts the tutorial intro element
- **Issue:** rdar://118359891
- **Risk:** Low, minor CSS-only change
- **Testing:** Visually tested that asides are using the right colors in all color scheme modes and checked for any regressions with other colors in the tutorial intro
- **Reviewer:** @dobromir-hristov 
- **Original PR:** #760 