### PR TITLE
[5.10] Adjust spacing between consecutive asides within steps

### DIFF
--- a/src/components/Tutorial/SectionSteps.vue
+++ b/src/components/Tutorial/SectionSteps.vue
@@ -308,6 +308,10 @@ export default {
     .label {
       @include font-styles(aside-label);
     }
+
+    & + * {
+      margin-top: var(--spacing-stacked-margin-large);
+    }
   }
 }
 


### PR DESCRIPTION
- **Explanation:** Fixes spacing between consecutive asides in a step caption
- **Scope:** Only impacts certain content in tutorial step captions
- **Issue:** rdar://118356255
- **Risk:** Low, minor CSS-only change
- **Testing:** Visually tested that the spacing between consecutive asides looks right now and no regressions with other element spacing in step captions
- **Reviewer:** @dobromir-hristov 
- **Original PR:** #761 