### PR TITLE
[5.10] Adjust on-this-page spacing in IDE targets

### DIFF
--- a/src/components/DocumentationTopic/OnThisPageStickyContainer.vue
+++ b/src/components/DocumentationTopic/OnThisPageStickyContainer.vue
@@ -8,7 +8,7 @@
   See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 -->
 <template>
-  <div class="OnThisPageStickyContainer">
+  <div class="OnThisPageStickyContainer" :class="classes">
     <slot />
   </div>
 </template>
@@ -17,6 +17,14 @@
 
 export default {
   name: 'OnThisPageStickyContainer',
+  inject: {
+    isTargetIDE: {
+      default: false,
+    },
+  },
+  computed: {
+    classes: ({ isTargetIDE }) => ({ ide: isTargetIDE }),
+  },
 };
 </script>
 
@@ -31,12 +39,15 @@ export default {
   align-self: flex-start;
   flex: 0 0 auto;
   width: $on-this-page-aside-width;
-  padding-left: $nav-padding;
   padding-right: $nav-padding;
   box-sizing: border-box;
   padding-bottom: var(--spacing-stacked-margin-small);
   max-height: calc(100vh - #{$top});
   overflow: auto;
+
+  &.ide {
+    margin-left: $nav-padding;
+  }
 
   @media print {
     display: none;

--- a/src/components/DocumentationTopic/OnThisPageStickyContainer.vue
+++ b/src/components/DocumentationTopic/OnThisPageStickyContainer.vue
@@ -8,7 +8,7 @@
   See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 -->
 <template>
-  <div class="OnThisPageStickyContainer" :class="classes">
+  <div class="OnThisPageStickyContainer">
     <slot />
   </div>
 </template>
@@ -17,14 +17,6 @@
 
 export default {
   name: 'OnThisPageStickyContainer',
-  inject: {
-    isTargetIDE: {
-      default: false,
-    },
-  },
-  computed: {
-    classes: ({ isTargetIDE }) => ({ ide: isTargetIDE }),
-  },
 };
 </script>
 
@@ -45,7 +37,7 @@ export default {
   max-height: calc(100vh - #{$top});
   overflow: auto;
 
-  &.ide {
+  @include inTargetIde {
     margin-left: $nav-padding;
   }
 

--- a/src/components/DocumentationTopic/OnThisPageStickyContainer.vue
+++ b/src/components/DocumentationTopic/OnThisPageStickyContainer.vue
@@ -31,6 +31,7 @@ export default {
   align-self: flex-start;
   flex: 0 0 auto;
   width: $on-this-page-aside-width;
+  padding-left: $nav-padding;
   padding-right: $nav-padding;
   box-sizing: border-box;
   padding-bottom: var(--spacing-stacked-margin-small);

--- a/tests/unit/components/DocumentationTopic/OnThisPageStickyContainer.spec.js
+++ b/tests/unit/components/DocumentationTopic/OnThisPageStickyContainer.spec.js
@@ -11,28 +11,16 @@
 import OnThisPageStickyContainer from '@/components/DocumentationTopic/OnThisPageStickyContainer.vue';
 import { shallowMount } from '@vue/test-utils';
 
-const createWrapper = ({ ...opts } = {}) => shallowMount(OnThisPageStickyContainer, {
+const createWrapper = ({ provide, ...others } = {}) => shallowMount(OnThisPageStickyContainer, {
   slots: {
     default: '<div class="default">Default Content</div>',
   },
-  ...opts,
+  ...others,
 });
 
 describe('OnThisPageStickyContainer', () => {
   it('renders the default slot', () => {
     const wrapper = createWrapper();
     expect(wrapper.find('.default').text()).toBe('Default Content');
-  });
-
-  it('adds an "ide" class for IDE targets', () => {
-    let wrapper = createWrapper();
-    expect(wrapper.classes('ide')).toBe(false);
-
-    wrapper = createWrapper({
-      provide: {
-        isTargetIDE: true,
-      },
-    });
-    expect(wrapper.classes('ide')).toBe(true);
   });
 });

--- a/tests/unit/components/DocumentationTopic/OnThisPageStickyContainer.spec.js
+++ b/tests/unit/components/DocumentationTopic/OnThisPageStickyContainer.spec.js
@@ -11,16 +11,28 @@
 import OnThisPageStickyContainer from '@/components/DocumentationTopic/OnThisPageStickyContainer.vue';
 import { shallowMount } from '@vue/test-utils';
 
-const createWrapper = ({ provide, ...others } = {}) => shallowMount(OnThisPageStickyContainer, {
+const createWrapper = ({ ...opts } = {}) => shallowMount(OnThisPageStickyContainer, {
   slots: {
     default: '<div class="default">Default Content</div>',
   },
-  ...others,
+  ...opts,
 });
 
 describe('OnThisPageStickyContainer', () => {
   it('renders the default slot', () => {
     const wrapper = createWrapper();
     expect(wrapper.find('.default').text()).toBe('Default Content');
+  });
+
+  it('adds an "ide" class for IDE targets', () => {
+    let wrapper = createWrapper();
+    expect(wrapper.classes('ide')).toBe(false);
+
+    wrapper = createWrapper({
+      provide: {
+        isTargetIDE: true,
+      },
+    });
+    expect(wrapper.classes('ide')).toBe(true);
   });
 });


### PR DESCRIPTION
- **Explanation:** Fixes issue where there sometimes isn't enough space between doc content and the on-this-page element in IDE targets at certain viewport widths
- **Scope:** CSS-only change that impacts doc pages w/ on-this-page enabled
- **Issue:** rdar://109407291
- **Risk:** Low, minor/scoped CSS-only change
- **Testing:** Visually tested that there is always space between doc content and on-this-page at any viewport width in IDE targets and ensured that there are no styling changes for on-this-page in other environments
- **Reviewer:** @dobromir-hristov 
- **Original PR:** #768 