### PR TITLE
Use localized string format for "other declaration" button

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -544,7 +544,8 @@ export default {
       return declarations.length ? declarations[0].declarations.some(decl => Object.prototype.hasOwnProperty.call(decl, 'otherDeclarations')) : false;
     },
     declListToggleText({ declListExpanded }) {
-      return declListExpanded ? 'Hide other declarations' : 'Show all declarations';
+      return declListExpanded ? `${this.$t('verbs.hide')} ${this.$t('declarations.other-declarations')}`
+        : `${this.$t('verbs.show')} ${this.$t('declarations.all-declarations')}`;
     },
   },
   methods: {

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -544,8 +544,8 @@ export default {
       return declarations.length ? declarations[0].declarations.some(decl => Object.prototype.hasOwnProperty.call(decl, 'otherDeclarations')) : false;
     },
     declListToggleText({ declListExpanded }) {
-      return declListExpanded ? `${this.$t('verbs.hide')} ${this.$t('declarations.other-declarations')}`
-        : `${this.$t('verbs.show')} ${this.$t('declarations.all-declarations')}`;
+      return declListExpanded ? this.$t('declarations.hide-other-declarations')
+        : this.$t('declarations.show-all-declarations');
     },
   },
   methods: {

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -68,6 +68,10 @@
     },
     "view-more": "View more"
   },
+  "declarations": {
+    "other-declarations": "other declarations",
+    "all-declarations": "all declarations"
+  },
   "aside-kind": {
     "beta": "Beta",
     "experiment": "Experiment",

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -69,8 +69,8 @@
     "view-more": "View more"
   },
   "declarations": {
-    "other-declarations": "other declarations",
-    "all-declarations": "all declarations"
+    "hide-other-declarations": "Hide other declarations",
+    "show-all-declarations": "Show all declarations"
   },
   "aside-kind": {
     "beta": "Beta",

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -616,7 +616,7 @@ describe('DocumentationTopic', () => {
       expect(description.classes()).not.toContain('after-enhanced-hero');
     });
 
-    it('does not render the description section if other declaration list iss expanded', () => {
+    it('does not render the description section if other declaration list is expanded', () => {
       wrapper.setData({
         declListExpanded: true,
       });
@@ -695,7 +695,7 @@ describe('DocumentationTopic', () => {
       ],
     });
     let declListMenu = wrapper.find('.declaration-list-menu');
-    expect(declListMenu.text()).toContain('Show all declarations');
+    expect(declListMenu.text()).toContain('verbs.show declarations.all-declarations');
     let icon = wrapper.find(InlinePlusCircleIcon);
     expect(icon.exists()).toBe(true);
 
@@ -705,7 +705,7 @@ describe('DocumentationTopic', () => {
 
     declListMenu = wrapper.find('.declaration-list-menu');
     expect(declListMenu.exists()).toBe(true);
-    expect(declListMenu.text()).toContain('Hide other declarations');
+    expect(declListMenu.text()).toContain('verbs.hide declarations.other-declarations');
     icon = wrapper.find(InlinePlusCircleIcon);
     expect(icon.exists()).toBe(true);
     expect(icon.classes()).toContain('expand');

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -695,7 +695,7 @@ describe('DocumentationTopic', () => {
       ],
     });
     let declListMenu = wrapper.find('.declaration-list-menu');
-    expect(declListMenu.text()).toContain('verbs.show declarations.all-declarations');
+    expect(declListMenu.text()).toContain('declarations.show-all-declarations');
     let icon = wrapper.find(InlinePlusCircleIcon);
     expect(icon.exists()).toBe(true);
 
@@ -705,7 +705,7 @@ describe('DocumentationTopic', () => {
 
     declListMenu = wrapper.find('.declaration-list-menu');
     expect(declListMenu.exists()).toBe(true);
-    expect(declListMenu.text()).toContain('verbs.hide declarations.other-declarations');
+    expect(declListMenu.text()).toContain('declarations.hide-other-declarations');
     icon = wrapper.find(InlinePlusCircleIcon);
     expect(icon.exists()).toBe(true);
     expect(icon.classes()).toContain('expand');


### PR DESCRIPTION
**Explanation:** Use localized string format for "other declaration" button.
**Bug/Issue #**: rdar://119615630
**Scope:** Small
**Risk:** No risk, just 1 string config change for other declarations
**Testing:** Updated unit test and manual testing
**Reviewed By:** @mportiz08

## Dependencies
NA

## Testing
Verify the english version of the string is still rendered correctly, follow testing instructions [here](https://github.com/apple/swift-docc-render/pull/762)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
