### PR TITLE
Remove ability to override icons in "Topics" section

### DIFF
--- a/src/components/DocumentationTopic/TopicLinkBlockIcon.vue
+++ b/src/components/DocumentationTopic/TopicLinkBlockIcon.vue
@@ -45,10 +45,6 @@ export default {
       type: String,
       required: true,
     },
-    imageOverride: {
-      type: Object,
-      default: null,
-    },
   },
 
   computed: {

--- a/src/components/DocumentationTopic/TopicLinkBlockIcon.vue
+++ b/src/components/DocumentationTopic/TopicLinkBlockIcon.vue
@@ -9,9 +9,8 @@
 -->
 
 <template>
-  <div class="topic-icon-wrapper" v-if="imageOverride || icon">
-    <OverridableAsset v-if="imageOverride" :imageOverride="imageOverride" class="topic-icon" />
-    <component v-else-if="icon" :is="icon" class="topic-icon" />
+  <div class="topic-icon-wrapper" v-if="icon">
+    <component :is="icon" class="topic-icon" />
   </div>
 </template>
 
@@ -25,7 +24,6 @@ import TechnologyIcon from 'theme/components/Icons/TechnologyIcon.vue';
 import TutorialIcon from 'theme/components/Icons/TutorialIcon.vue';
 import SVGIcon from 'docc-render/components/SVGIcon.vue';
 import { TopicRole } from 'docc-render/constants/roles';
-import OverridableAsset from 'docc-render/components/OverridableAsset.vue';
 
 const TopicRoleIcons = {
   [TopicRole.article]: ArticleIcon,
@@ -41,7 +39,7 @@ const TopicRoleIcons = {
 };
 
 export default {
-  components: { OverridableAsset, SVGIcon },
+  components: { SVGIcon },
   props: {
     role: {
       type: String,

--- a/src/components/DocumentationTopic/TopicsLinkBlock.vue
+++ b/src/components/DocumentationTopic/TopicsLinkBlock.vue
@@ -20,7 +20,6 @@
       <TopicLinkBlockIcon
         v-if="topic.role && !change"
         :role="topic.role"
-        :imageOverride="references[iconOverride]"
       />
       <DecoratedTopicTitle v-if="topic.fragments" :tokens="topic.fragments" />
       <WordBreak v-else :tag="titleTag">{{ topic.title }}</WordBreak>

--- a/tests/unit/components/DocumentationTopic/TopicLinkBlockIcon.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicLinkBlockIcon.spec.js
@@ -13,7 +13,6 @@ import { mount } from '@vue/test-utils';
 import { TopicRole } from '@/constants/roles';
 import ArticleIcon from '@/components/Icons/ArticleIcon.vue';
 import TechnologyIcon from '@/components/Icons/TechnologyIcon.vue';
-import OverridableAsset from '@/components/OverridableAsset.vue';
 
 const defaultProps = {
   role: TopicRole.article,
@@ -33,30 +32,9 @@ describe('TopicLinkBlockIcon', () => {
     expect(wrapper.find('.topic-icon').is(ArticleIcon)).toBe(true);
   });
 
-  it('renders an override icon from an image override', () => {
-    const imageOverride = {
-      variants: [{
-        url: '/foo/bar',
-        svgID: 'foo',
-      }],
-    };
+  it('renders nothing if no role', () => {
     const wrapper = createWrapper({
       propsData: {
-        imageOverride,
-      },
-    });
-    const icon = wrapper.find('.topic-icon');
-    expect(icon.is(ArticleIcon)).toBe(false);
-    expect(icon.is(OverridableAsset)).toBe(true);
-    expect(icon.props()).toMatchObject({
-      imageOverride,
-    });
-  });
-
-  it('renders nothing if no role or image override', () => {
-    const wrapper = createWrapper({
-      propsData: {
-        imageOverride: null,
         role: TopicRole.devLink, // no icon for this
       },
     });

--- a/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkBlock.spec.js
@@ -32,22 +32,13 @@ describe('TopicsLinkBlock', () => {
   /** @type {import('@vue/test-utils').Wrapper} */
   let wrapper;
 
-  const iconOverride = {
-    type: 'icon',
-    identifier: 'icon-override',
-  };
-
-  const references = {
-    [iconOverride.identifier]: { foo: 'bar' },
-  };
-
   const store = {
     reset: jest.fn(),
     setAPIChanges: jest.fn(),
     state: {
       onThisPageSections: [],
       apiChanges: null,
-      references,
+      references: {},
     },
   };
 
@@ -133,18 +124,6 @@ describe('TopicsLinkBlock', () => {
     const link = wrapper.find(TopicLinkBlockIcon);
     expect(link.exists()).toBe(true);
     expect(link.props('role')).toBe(propsData.topic.role);
-  });
-
-  it('renders a TopicLinkBlockIcon with an override', () => {
-    const icon = wrapper.find(TopicLinkBlockIcon);
-    expect(icon.props('imageOverride')).toBe(null);
-    wrapper.setProps({
-      topic: {
-        ...propsData.topic,
-        images: [iconOverride, { type: 'card', identifier: 'foo' }],
-      },
-    });
-    expect(icon.props('imageOverride')).toBe(references[iconOverride.identifier]);
   });
 
   it('renders a normal `WordBreak` for the link text', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 120670171

## Summary

Due to limitations with remote SVG assets, there can be an issue where the color of a custom icon may be present in multiple locations using the same color, which results in a less than ideal experience.

Current known workarounds for this issue would necessitate server side headers for cross origin resource sharing, which DocC-Render can't control since it is a client-side only tool—with that in mind, it makes more sense to remove the ability for overriding the icon here and leaving it as something to customize in the hero element only for now.

## Testing

Steps:
1. Add the following snippet to an existing documentation catalog, with the referenced icon asset.
```
@Metadata {
  @PageImage(purpose: icon, source: "example-custom-icon.svg", alt: "icon")
}
```
2. Verify that the custom icon still shows up in the hero element for the page, but it no longer appears in the "Topics" section from a parent page.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
