### PR TITLE
Disable list of other declarations in minimized mode

### DIFF
--- a/bin/check-source
+++ b/bin/check-source
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][789012]-20[12][890123]/YEARS/' -e 's/20[12][890123]/YEARS/'
+    sed -e 's/20[12][78901234]-20[12][8901234]/YEARS/' -e 's/20[12][8901234]/YEARS/'
 }
 
 printf "=> Checking license headers… "

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -539,9 +539,12 @@ export default {
     declarations({ primaryContentSections = [] }) {
       return primaryContentSections.filter(({ kind }) => kind === SectionKind.declarations);
     },
-    hasOtherDeclarations({ declarations = [] }) {
-      // there's always only 1 `declaration` at this level
-      return declarations.length ? declarations[0].declarations.some(decl => Object.prototype.hasOwnProperty.call(decl, 'otherDeclarations')) : false;
+    hasOtherDeclarations({ declarations = [], enableMinimized }) {
+      // disable otherDeclarations in minimized mode
+      return declarations.length && !enableMinimized
+        // there's always only 1 `declaration` at this level
+        ? declarations[0].declarations.some(decl => Object.prototype.hasOwnProperty.call(decl, 'otherDeclarations'))
+        : false;
     },
     declListToggleText({ declListExpanded }) {
       return declListExpanded ? this.$t('declarations.hide-other-declarations')

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -673,7 +673,7 @@ describe('DocumentationTopic', () => {
     });
   });
 
-  it('render an declaration list menu if has other declarations', () => {
+  it('render a declaration list menu if has other declarations', () => {
     let declListMenu = wrapper.find('.declaration-list-menu');
     expect(declListMenu.exists()).toBe(false);
 
@@ -685,6 +685,22 @@ describe('DocumentationTopic', () => {
     });
     declListMenu = wrapper.find('.declaration-list-menu');
     expect(declListMenu.exists()).toBe(true);
+  });
+
+  it('does not render a declaration list menu in minimized mode', () => {
+    wrapper.setProps({
+      primaryContentSections: [
+        ...propsData.primaryContentSections,
+        hasOtherDeclSection,
+      ],
+    });
+    let declListMenu = wrapper.find('.declaration-list-menu');
+    expect(declListMenu.exists()).toBe(true);
+
+    wrapper.setProps({ enableMinimized: true });
+
+    declListMenu = wrapper.find('.declaration-list-menu');
+    expect(declListMenu.exists()).toBe(false);
   });
 
   it('renders correct declaration list toggle, text, and icon', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 121218746

## Summary
Disable the dropdown UI for other declarations in minimized mode

## Testing
Manual testing

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
