### PR TITLE
Add alt text for screen readers to describe video content

### DIFF
--- a/src/components/Asset.vue
+++ b/src/components/Asset.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information

--- a/src/components/Asset.vue
+++ b/src/components/Asset.vue
@@ -110,6 +110,8 @@ export default {
         autoplays: this.prefersReducedMotion ? false : this.videoAutoplays,
         posterVariants: this.videoPoster ? this.videoPoster.variants : [],
         deviceFrame: this.deviceFrame,
+        alt: this.asset.alt,
+        id: this.asset.alt ? this.identifier : null,
       };
     },
     assetListeners() {

--- a/src/components/Asset.vue
+++ b/src/components/Asset.vue
@@ -105,13 +105,13 @@ export default {
     videoProps() {
       return {
         variants: this.asset.variants,
-        showsControls: this.showsVideoControls,
+        showsDefaultControls: this.showsVideoControls,
         muted: this.videoMuted,
         autoplays: this.prefersReducedMotion ? false : this.videoAutoplays,
         posterVariants: this.videoPoster ? this.videoPoster.variants : [],
         deviceFrame: this.deviceFrame,
         alt: this.asset.alt,
-        id: this.asset.alt ? this.identifier : null,
+        id: this.identifier,
       };
     },
     assetListeners() {

--- a/src/components/ReplayableVideoAsset.vue
+++ b/src/components/ReplayableVideoAsset.vue
@@ -14,7 +14,7 @@
       ref="asset"
       :variants="variants"
       :autoplays="autoplays"
-      :showsControls="showsControls"
+      :showsDefaultControls="showsDefaultControls"
       :muted="muted"
       :posterVariants="posterVariants"
       :deviceFrame="deviceFrame"
@@ -25,10 +25,10 @@
       @ended="onVideoEnd"
     />
     <a
-      v-if="!showsControls"
+      v-if="!showsDefaultControls"
       class="control-button"
       href="#"
-      :aria-describedby="alt ? id : null"
+      :aria-controls="id"
       @click.prevent="togglePlayStatus"
     >
       {{ text }}
@@ -64,9 +64,9 @@ export default {
     },
     id: {
       type: String,
-      required: false,
+      required: true,
     },
-    showsControls: {
+    showsDefaultControls: {
       type: Boolean,
       default: () => false,
     },
@@ -121,7 +121,7 @@ export default {
     onPause() {
       const { video } = this.$refs.asset.$refs;
       // if the video pauses, and we are hiding the controls, show the replay button
-      if (!this.showsControls && this.isPlaying) {
+      if (!this.showsDefaultControls && this.isPlaying) {
         this.isPlaying = false;
       }
       this.videoEnded = video.ended;

--- a/src/components/ReplayableVideoAsset.vue
+++ b/src/components/ReplayableVideoAsset.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information

--- a/src/components/ReplayableVideoAsset.vue
+++ b/src/components/ReplayableVideoAsset.vue
@@ -28,6 +28,7 @@
       v-if="!showsControls"
       class="control-button"
       href="#"
+      :aria-describedby="id || null"
       @click.prevent="togglePlayStatus"
     >
       {{ text }}

--- a/src/components/ReplayableVideoAsset.vue
+++ b/src/components/ReplayableVideoAsset.vue
@@ -18,6 +18,8 @@
       :muted="muted"
       :posterVariants="posterVariants"
       :deviceFrame="deviceFrame"
+      :alt="alt"
+      :id="id"
       @pause="onPause"
       @playing="onVideoPlaying"
       @ended="onVideoEnd"
@@ -54,6 +56,14 @@ export default {
     variants: {
       type: Array,
       required: true,
+    },
+    alt: {
+      type: String,
+      required: false,
+    },
+    id: {
+      type: String,
+      required: false,
     },
     showsControls: {
       type: Boolean,

--- a/src/components/ReplayableVideoAsset.vue
+++ b/src/components/ReplayableVideoAsset.vue
@@ -28,7 +28,7 @@
       v-if="!showsControls"
       class="control-button"
       href="#"
-      :aria-describedby="id || null"
+      :aria-describedby="alt ? id : null"
       @click.prevent="togglePlayStatus"
     >
       {{ text }}

--- a/src/components/VideoAsset.vue
+++ b/src/components/VideoAsset.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information

--- a/src/components/VideoAsset.vue
+++ b/src/components/VideoAsset.vue
@@ -18,7 +18,7 @@
     <div>
       <span
         v-if="alt"
-        :id="id || null"
+        :id="alt ? id : null"
         class="visuallyhidden"
       >
         {{ alt }}
@@ -31,7 +31,7 @@
         :poster="normalisedPosterPath"
         :muted="muted"
         :width="optimalWidth"
-        :aria-describedby="id || null"
+        :aria-describedby="alt ? id : null"
         playsinline
         @loadedmetadata="setOrientation"
         @playing="$emit('playing')"

--- a/src/components/VideoAsset.vue
+++ b/src/components/VideoAsset.vue
@@ -15,28 +15,37 @@
     :should-wrap="!!deviceFrame"
     :device="deviceFrame"
   >
-    <video
-      ref="video"
-      :controls="showsControls"
-      :data-orientation="orientation"
-      :autoplay="autoplays"
-      :poster="normalisedPosterPath"
-      :muted="muted"
-      :width="optimalWidth"
-      playsinline
-      @loadedmetadata="setOrientation"
-      @playing="$emit('playing')"
-      @pause="$emit('pause')"
-      @ended="$emit('ended')"
-    >
-      <!--
-        Many browsers do not support the `media` attribute for `<source>` tags
-        within a video specifically, so this implementation for dark theme assets
-        is handled with JavaScript media query listeners unlike the `<source>`
-        based implementation being used for image assets.
-      -->
-      <source :src="normalizePath(videoAttributes.url)">
-    </video>
+    <div>
+      <span
+        v-if="alt"
+        :id="id || null"
+        class="visuallyhidden"
+      >
+        {{ alt }}
+      </span>
+      <video
+        ref="video"
+        :controls="showsControls"
+        :data-orientation="orientation"
+        :autoplay="autoplays"
+        :poster="normalisedPosterPath"
+        :muted="muted"
+        :width="optimalWidth"
+        playsinline
+        @loadedmetadata="setOrientation"
+        @playing="$emit('playing')"
+        @pause="$emit('pause')"
+        @ended="$emit('ended')"
+      >
+        <!--
+          Many browsers do not support the `media` attribute for `<source>` tags
+          within a video specifically, so this implementation for dark theme assets
+          is handled with JavaScript media query listeners unlike the `<source>`
+          based implementation being used for image assets.
+        -->
+        <source :src="normalizePath(videoAttributes.url)">
+      </video>
+    </div>
   </ConditionalWrapper>
 </template>
 
@@ -79,6 +88,14 @@ export default {
       default: false,
     },
     deviceFrame: {
+      type: String,
+      required: false,
+    },
+    alt: {
+      type: String,
+      required: false,
+    },
+    id: {
       type: String,
       required: false,
     },

--- a/src/components/VideoAsset.vue
+++ b/src/components/VideoAsset.vue
@@ -31,6 +31,7 @@
         :poster="normalisedPosterPath"
         :muted="muted"
         :width="optimalWidth"
+        :aria-describedby="id || null"
         playsinline
         @loadedmetadata="setOrientation"
         @playing="$emit('playing')"

--- a/src/components/VideoAsset.vue
+++ b/src/components/VideoAsset.vue
@@ -18,20 +18,25 @@
     <div>
       <span
         v-if="alt"
-        :id="alt ? id : null"
+        :id="alt ? altTextId : null"
         class="visuallyhidden"
       >
-        {{ alt }}
+        {{ $t('formats.colon', {
+          content: $t('video.description')
+        }) + alt }}
       </span>
       <video
         ref="video"
-        :controls="showsControls"
+        :id="id"
+        :controls="showsDefaultControls"
         :data-orientation="orientation"
         :autoplay="autoplays"
         :poster="normalisedPosterPath"
         :muted="muted"
         :width="optimalWidth"
-        :aria-describedby="alt ? id : null"
+        :aria-roledescription="$t('video.title')"
+        :aria-label="!showsDefaultControls ? $t('video.custom-controls') : null"
+        :aria-describedby="alt ? altTextId : null"
         playsinline
         @loadedmetadata="setOrientation"
         @playing="$emit('playing')"
@@ -71,7 +76,7 @@ export default {
       type: Array,
       required: true,
     },
-    showsControls: {
+    showsDefaultControls: {
       type: Boolean,
       default: () => false,
     },
@@ -98,7 +103,7 @@ export default {
     },
     id: {
       type: String,
-      required: false,
+      required: true,
     },
   },
   data: () => ({
@@ -110,6 +115,7 @@ export default {
     DeviceFrameComponent: () => DeviceFrame,
     preferredColorScheme: ({ appState }) => appState.preferredColorScheme,
     systemColorScheme: ({ appState }) => appState.systemColorScheme,
+    altTextId: ({ id }) => `${id}-alt`,
     userPrefersDark: ({
       preferredColorScheme,
       systemColorScheme,

--- a/src/components/VideoAsset.vue
+++ b/src/components/VideoAsset.vue
@@ -16,13 +16,6 @@
     :device="deviceFrame"
   >
     <div>
-      <span
-        v-if="alt"
-        :id="altTextId"
-        class="visuallyhidden"
-      >
-        {{ $t('video.description', { alt }) }}
-      </span>
       <video
         ref="video"
         :key="videoAttributes.url"
@@ -50,6 +43,13 @@
         -->
         <source :src="normalizePath(videoAttributes.url)">
       </video>
+      <span
+        v-if="alt"
+        :id="altTextId"
+        class="visuallyhidden"
+      >
+        {{ $t('video.description', { alt }) }}
+      </span>
     </div>
   </ConditionalWrapper>
 </template>

--- a/src/components/VideoAsset.vue
+++ b/src/components/VideoAsset.vue
@@ -18,12 +18,10 @@
     <div>
       <span
         v-if="alt"
-        :id="alt ? altTextId : null"
+        :id="altTextId"
         class="visuallyhidden"
       >
-        {{ $t('formats.colon', {
-          content: $t('video.description')
-        }) + alt }}
+        {{ $t('video.description', { alt }) }}
       </span>
       <video
         ref="video"

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -8,7 +8,7 @@
     "play": "Play",
     "pause": "Pause",
     "watch": "Watch intro video",
-    "description": "Content description of this video",
+    "description": "Content description of this video: {alt}",
     "custom-controls": "Custom replay button is available below"
   },
   "tutorials": {

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -3,10 +3,13 @@
   "continue-viewing": "Continue viewing in English",
   "language": "Language",
   "video": {
+    "title": "Video",
     "replay": "Replay",
     "play": "Play",
     "pause": "Pause",
-    "watch": "Watch intro video"
+    "watch": "Watch intro video",
+    "description": "Content description of this video",
+    "custom-controls": "Custom replay button is available below"
   },
   "tutorials": {
     "title": "Tutorial | Tutorials",

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -9,7 +9,7 @@
     "pause": "Pause",
     "watch": "Watch intro video",
     "description": "Content description of this video: {alt}",
-    "custom-controls": "Custom replay button is available below"
+    "custom-controls": "Custom controls are available below"
   },
   "tutorials": {
     "title": "Tutorial | Tutorials",

--- a/tests/unit/components/Asset.spec.js
+++ b/tests/unit/components/Asset.spec.js
@@ -111,11 +111,6 @@ describe('Asset', () => {
     expect(videoAsset.props('alt')).toBe(video.alt);
   });
 
-  it('renders a `ReplayableVideoAsset` without id if video does not provides an alt text', () => {
-    const videoAsset = mountAsset('video', { video: { ...video, alt: null } }).find(ReplayableVideoAsset);
-    expect(videoAsset.props('id')).not.toBe(video.id);
-  });
-
   it('passes down `deviceFrame` to `ReplayableVideoAsset`', () => {
     const wrapper = mountAsset('video', { video });
     let videoAsset = wrapper.find(ReplayableVideoAsset);

--- a/tests/unit/components/Asset.spec.js
+++ b/tests/unit/components/Asset.spec.js
@@ -17,6 +17,7 @@ import ReplayableVideoAsset from 'docc-render/components/ReplayableVideoAsset.vu
 const video = {
   type: 'video',
   poster: 'image',
+  alt: 'Text describing this video',
   variants: [
     {
       url: 'foo.mp4',
@@ -102,9 +103,17 @@ describe('Asset', () => {
   });
 
   it('renders a `ReplayableVideoAsset` without poster variants', () => {
-    const videoAsset = mountAsset('video', { video }).find(ReplayableVideoAsset);
+    const identifier = 'video';
+    const videoAsset = mountAsset(identifier, { video }).find(ReplayableVideoAsset);
     expect(videoAsset.props('variants')).toBe(video.variants);
     expect(videoAsset.props('posterVariants')).toEqual([]);
+    expect(videoAsset.props('id')).toBe(identifier);
+    expect(videoAsset.props('alt')).toBe(video.alt);
+  });
+
+  it('renders a `ReplayableVideoAsset` without id if video does not provides an alt text', () => {
+    const videoAsset = mountAsset('video', { video: { ...video, alt: null } }).find(ReplayableVideoAsset);
+    expect(videoAsset.props('id')).not.toBe(video.id);
   });
 
   it('passes down `deviceFrame` to `ReplayableVideoAsset`', () => {
@@ -119,29 +128,57 @@ describe('Asset', () => {
   });
 
   it('renders a `VideoAsset` for video with `showsReplayButton=false`', () => {
+    const identifier = 'video';
+
     const wrapper = shallowMount(Asset, {
       propsData: {
-        identifier: 'video',
+        identifier,
         showsReplayButton: false,
         showsVideoControls: true,
       },
       provide: {
         store: {
-          state: { references: { video } },
+          state: { references: { [identifier]: video } },
         },
       },
     });
 
     const videoAsset = wrapper.find(VideoAsset);
-    expect(videoAsset.props('variants')).toBe(video.variants);
-    expect(videoAsset.props('showsControls')).toBe(true);
-    expect(videoAsset.props('muted')).toBe(false);
+    expect(videoAsset.props()).toEqual(expect.objectContaining({
+      variants: video.variants,
+      showsControls: true,
+      muted: false,
+      id: identifier,
+      alt: video.alt,
+    }));
+  });
+
+  it('renders a `VideoAsset` without id if video does not provides an alt text', () => {
+    const identifier = 'video';
+
+    const wrapper = shallowMount(Asset, {
+      propsData: {
+        identifier,
+        showsReplayButton: false,
+        showsVideoControls: true,
+      },
+      provide: {
+        store: {
+          state: { references: { [identifier]: { ...video, alt: null } } },
+        },
+      },
+    });
+
+    const videoAsset = wrapper.find(VideoAsset);
+    expect(videoAsset.props('id')).not.toBe(identifier);
   });
 
   it('renders a `ReplayableVideoAsset` with deviceFrame', () => {
+    const identifier = 'video';
+
     const wrapper = shallowMount(Asset, {
       propsData: {
-        identifier: 'video',
+        identifier,
         showsReplayButton: true,
         showsVideoControls: true,
         deviceFrame: 'phone',
@@ -161,6 +198,8 @@ describe('Asset', () => {
       posterVariants: [],
       showsControls: true,
       variants: video.variants,
+      id: identifier,
+      alt: video.alt,
     });
   });
 

--- a/tests/unit/components/Asset.spec.js
+++ b/tests/unit/components/Asset.spec.js
@@ -94,7 +94,7 @@ describe('Asset', () => {
     const videoAsset = wrapper.find(ReplayableVideoAsset);
     expect(videoAsset.props('variants')).toBe(video.variants);
     expect(videoAsset.props('posterVariants')).toBe(image.variants);
-    expect(videoAsset.props('showsControls')).toBe(false);
+    expect(videoAsset.props('showsDefaultControls')).toBe(false);
     expect(videoAsset.props('autoplays')).toBe(false);
 
     // Check that 'ended' events emitted by a `VideoAsset` are re-emitted.
@@ -146,31 +146,11 @@ describe('Asset', () => {
     const videoAsset = wrapper.find(VideoAsset);
     expect(videoAsset.props()).toEqual(expect.objectContaining({
       variants: video.variants,
-      showsControls: true,
+      showsDefaultControls: true,
       muted: false,
       id: identifier,
       alt: video.alt,
     }));
-  });
-
-  it('renders a `VideoAsset` without id if video does not provides an alt text', () => {
-    const identifier = 'video';
-
-    const wrapper = shallowMount(Asset, {
-      propsData: {
-        identifier,
-        showsReplayButton: false,
-        showsVideoControls: true,
-      },
-      provide: {
-        store: {
-          state: { references: { [identifier]: { ...video, alt: null } } },
-        },
-      },
-    });
-
-    const videoAsset = wrapper.find(VideoAsset);
-    expect(videoAsset.props('id')).not.toBe(identifier);
   });
 
   it('renders a `ReplayableVideoAsset` with deviceFrame', () => {
@@ -196,7 +176,7 @@ describe('Asset', () => {
       deviceFrame: 'phone',
       muted: false,
       posterVariants: [],
-      showsControls: true,
+      showsDefaultControls: true,
       variants: video.variants,
       id: identifier,
       alt: video.alt,
@@ -220,7 +200,7 @@ describe('Asset', () => {
 
     const videoAsset = wrapper.find(ReplayableVideoAsset);
     expect(videoAsset.props('variants')).toBe(video.variants);
-    expect(videoAsset.props('showsControls')).toBe(true);
+    expect(videoAsset.props('showsDefaultControls')).toBe(true);
     expect(videoAsset.props('muted')).toBe(false);
     expect(videoAsset.props('autoplays')).toBe(true);
   });
@@ -241,7 +221,7 @@ describe('Asset', () => {
     });
 
     const videoAsset = wrapper.find(ReplayableVideoAsset);
-    expect(videoAsset.props('showsControls')).toBe(true);
+    expect(videoAsset.props('showsDefaultControls')).toBe(true);
     expect(videoAsset.props('muted')).toBe(false);
   });
 

--- a/tests/unit/components/Asset.spec.js
+++ b/tests/unit/components/Asset.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/tests/unit/components/ReplayableVideoAsset.spec.js
+++ b/tests/unit/components/ReplayableVideoAsset.spec.js
@@ -22,7 +22,7 @@ const posterVariants = [{ traits: ['dark', '1x'], url: 'https://www.example.com/
 const propsData = {
   variants,
   posterVariants,
-  showsControls: false,
+  showsDefaultControls: false,
   alt: 'Text describing this video',
   id: 'video.mp4',
 };
@@ -66,30 +66,30 @@ describe('ReplayableVideoAsset', () => {
     const video = wrapper.find(VideoAsset);
     expect(video.props('variants')).toBe(variants);
     expect(video.props('posterVariants')).toBe(posterVariants);
-    expect(video.props('showsControls')).toBe(false);
+    expect(video.props('showsDefaultControls')).toBe(false);
     expect(video.props('autoplays')).toBe(false);
     expect(video.props('id')).toBe(propsData.id);
     expect(video.props('alt')).toBe(propsData.alt);
     expect(wrapper.find('.control-button').exists()).toBe(true);
   });
 
-  it('does not show the `.control-button` if `showsControls` is `true`', () => {
+  it('does not show the `.control-button` if `showsDefaultControls` is `true`', () => {
     const wrapper = mountWithProps({
-      showsControls: true,
+      showsDefaultControls: true,
     });
     const video = wrapper.find(VideoAsset);
-    expect(video.props('showsControls')).toBe(true);
+    expect(video.props('showsDefaultControls')).toBe(true);
     expect(wrapper.find('.control-button').exists()).toBe(false);
   });
 
-  it('adds a description reference to `.control-button` if id is provided', () => {
+  it('adds an aria-controls referring to the video id in `.control-button`', () => {
     const wrapper = mountWithProps();
     const controlButton = wrapper.find('.control-button');
-    expect(controlButton.attributes('aria-describedby')).toBe(propsData.id);
+    expect(controlButton.attributes('aria-controls')).toBe(propsData.id);
   });
 
-  it('does not add a description reference to `.control-button` if id is not provided', () => {
-    const wrapper = mountWithProps({ id: null });
+  it('does not add a description reference to `.control-button` if alt is not provided', () => {
+    const wrapper = mountWithProps({ alt: null });
     const controlButton = wrapper.find('.control-button');
     expect(controlButton.attributes()).not.toHaveProperty('aria-describedby');
   });

--- a/tests/unit/components/ReplayableVideoAsset.spec.js
+++ b/tests/unit/components/ReplayableVideoAsset.spec.js
@@ -82,6 +82,18 @@ describe('ReplayableVideoAsset', () => {
     expect(wrapper.find('.control-button').exists()).toBe(false);
   });
 
+  it('adds a description reference to `.control-button` if id is provided', () => {
+    const wrapper = mountWithProps();
+    const controlButton = wrapper.find('.control-button');
+    expect(controlButton.attributes('aria-describedby')).toBe(propsData.id);
+  });
+
+  it('does not add a description reference to `.control-button` if id is not provided', () => {
+    const wrapper = mountWithProps({ id: null });
+    const controlButton = wrapper.find('.control-button');
+    expect(controlButton.attributes()).not.toHaveProperty('aria-describedby');
+  });
+
   it('changes the control button text, while the video is changing states', async () => {
     const wrapper = mountWithProps();
 

--- a/tests/unit/components/ReplayableVideoAsset.spec.js
+++ b/tests/unit/components/ReplayableVideoAsset.spec.js
@@ -23,6 +23,8 @@ const propsData = {
   variants,
   posterVariants,
   showsControls: false,
+  alt: 'Text describing this video',
+  id: 'video.mp4',
 };
 describe('ReplayableVideoAsset', () => {
   const mountWithProps = props => shallowMount(ReplayableVideoAsset, {
@@ -66,6 +68,8 @@ describe('ReplayableVideoAsset', () => {
     expect(video.props('posterVariants')).toBe(posterVariants);
     expect(video.props('showsControls')).toBe(false);
     expect(video.props('autoplays')).toBe(false);
+    expect(video.props('id')).toBe(propsData.id);
+    expect(video.props('alt')).toBe(propsData.alt);
     expect(wrapper.find('.control-button').exists()).toBe(true);
   });
 

--- a/tests/unit/components/ReplayableVideoAsset.spec.js
+++ b/tests/unit/components/ReplayableVideoAsset.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/tests/unit/components/VideoAsset.spec.js
+++ b/tests/unit/components/VideoAsset.spec.js
@@ -42,6 +42,8 @@ const propsData = {
   id: 'video.mp4',
 };
 
+const altTextId = `${propsData.id}-alt`;
+
 describe('VideoAsset', () => {
   let wrapper;
 
@@ -54,22 +56,25 @@ describe('VideoAsset', () => {
     const video = wrapper.find('video');
     expect(video.exists()).toBe(true);
     expect(video.element.muted).toBe(false);
+    expect(video.attributes('id')).toBe(propsData.id);
+    expect(video.attributes('aria-roledescription')).toBe('video.title');
   });
 
   it('renders a hidden description with unique id for AX purposes if video provides an alt text', () => {
     const hiddenDesc = wrapper.find('span.visuallyhidden');
     expect(hiddenDesc.exists()).toBe(true);
-    expect(hiddenDesc.attributes('id')).toMatch(propsData.id);
-    expect(hiddenDesc.text()).toBe(propsData.alt);
+    expect(hiddenDesc.attributes('id')).toBe(altTextId);
+    const preDescription = 'formats.colon video.description';
+    expect(hiddenDesc.text()).toBe(preDescription + propsData.alt);
   });
 
-  it('adds a description reference to the `video` if id is provided', () => {
+  it('adds a description reference to the `video` with altTextId', () => {
     const video = wrapper.find('video');
-    expect(video.attributes('aria-describedby')).toBe(propsData.id);
+    expect(video.attributes('aria-describedby')).toBe(altTextId);
   });
 
-  it('does not add a description reference to the `video` if id is not provided', () => {
-    wrapper.setProps({ id: null });
+  it('does not add a description reference to the `video` if alt is not provided', () => {
+    wrapper.setProps({ alt: null });
     const video = wrapper.find('video');
     expect(video.attributes()).not.toHaveProperty('aria-describedby');
   });
@@ -146,12 +151,20 @@ describe('VideoAsset', () => {
     expect(wrapper.attributes('height')).toBeFalsy();
   });
 
-  it('does not show controls when `showsControls=false`', () => {
+  it('does not show controls when `showsDefaultControls=false`', () => {
     wrapper.setProps({
       showControls: false,
     });
     const source = wrapper.find('video source');
     expect(source.attributes('controls')).toBe(undefined);
+  });
+
+  it('renders an aria-label to indicate how the user should interact with custom controls when `showsDefaultControls=false`', () => {
+    wrapper.setProps({
+      showControls: false,
+    });
+    const video = wrapper.find('video');
+    expect(video.attributes('aria-label')).toBe('video.custom-controls');
   });
 
   it('forwards `playing`, `pause` and `ended` events', () => {
@@ -175,10 +188,10 @@ describe('VideoAsset', () => {
     expect(video.attributes('autoplay')).toBe('autoplay');
   });
 
-  it('sets `controls` using `showsControls`', () => {
+  it('sets `controls` using `showsDefaultControls`', () => {
     const video = wrapper.find('video');
     expect(video.attributes('controls')).toBe(undefined);
-    wrapper.setProps({ showsControls: true });
+    wrapper.setProps({ showsDefaultControls: true });
     expect(video.attributes('controls')).toBe('controls');
   });
 

--- a/tests/unit/components/VideoAsset.spec.js
+++ b/tests/unit/components/VideoAsset.spec.js
@@ -63,6 +63,17 @@ describe('VideoAsset', () => {
     expect(hiddenDesc.text()).toBe(propsData.alt);
   });
 
+  it('adds a description reference to the `video` if id is provided', () => {
+    const video = wrapper.find('video');
+    expect(video.attributes('aria-describedby')).toBe(propsData.id);
+  });
+
+  it('does not add a description reference to the `video` if id is not provided', () => {
+    wrapper.setProps({ id: null });
+    const video = wrapper.find('video');
+    expect(video.attributes()).not.toHaveProperty('aria-describedby');
+  });
+
   it('adds a poster to the `video`, using light by default', async () => {
     const video = wrapper.find('video');
     expect(video.attributes('poster')).toEqual(propsData.posterVariants[0].url);

--- a/tests/unit/components/VideoAsset.spec.js
+++ b/tests/unit/components/VideoAsset.spec.js
@@ -104,7 +104,7 @@ describe('VideoAsset', () => {
     expect(getIntrinsicDimensionsSpy).toHaveBeenNthCalledWith(2, propsData.posterVariants[1].url);
     await flushPromises();
     // dark image is 2x, so the width is half
-    expect(video.attributes()).toMatchObject({
+    expect(wrapper.find('video').attributes()).toMatchObject({
       width: '50',
     });
   });

--- a/tests/unit/components/VideoAsset.spec.js
+++ b/tests/unit/components/VideoAsset.spec.js
@@ -64,8 +64,7 @@ describe('VideoAsset', () => {
     const hiddenDesc = wrapper.find('span.visuallyhidden');
     expect(hiddenDesc.exists()).toBe(true);
     expect(hiddenDesc.attributes('id')).toBe(altTextId);
-    const preDescription = 'formats.colon video.description';
-    expect(hiddenDesc.text()).toBe(preDescription + propsData.alt);
+    expect(hiddenDesc.text()).toBe(`video.description ${propsData.alt}`);
   });
 
   it('adds a description reference to the `video` with altTextId', () => {

--- a/tests/unit/components/VideoAsset.spec.js
+++ b/tests/unit/components/VideoAsset.spec.js
@@ -38,6 +38,8 @@ const propsData = {
     { traits: ['light', '1x'], url: 'https://www.example.com/video.mp4' },
     { traits: ['dark', '1x'], url: 'https://www.example.com/video~dark.mp4' },
   ],
+  alt: 'Text describing this video',
+  id: 'video.mp4',
 };
 
 describe('VideoAsset', () => {
@@ -52,6 +54,13 @@ describe('VideoAsset', () => {
     const video = wrapper.find('video');
     expect(video.exists()).toBe(true);
     expect(video.element.muted).toBe(false);
+  });
+
+  it('renders a hidden description with unique id for AX purposes if video provides an alt text', () => {
+    const hiddenDesc = wrapper.find('span.visuallyhidden');
+    expect(hiddenDesc.exists()).toBe(true);
+    expect(hiddenDesc.attributes('id')).toMatch(propsData.id);
+    expect(hiddenDesc.text()).toBe(propsData.alt);
   });
 
   it('adds a poster to the `video`, using light by default', async () => {

--- a/tests/unit/components/VideoAsset.spec.js
+++ b/tests/unit/components/VideoAsset.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
Bug/issue #120903895, if applicable: 

## Summary

Add aria tags to improve AX in videos.

A visually hidden text is being referenced as description for the video and its custom controls using `aria-describedby` tag.
More info: https://www.w3.org/WAI/PF/HTML/wiki/Media_Alt_Technologies 

- Add `aria-describedby` to the video element: it describes the content video using a visually hidden text that is being referenced in the video element. In case an screen reader cannot read the description, it will still read the text content.
- Add `aria-label` to the video element: it indicates how the user should interact when there are custom controls. This is not added if video uses the default controls because it's not needed.
- Add `aria-roledescription` to the video element: it describes that the element is a video element, in case a screen reader don't tell.
- Add `aria-controls` to the custom controls: it links the video to custom controls when there are. This is not added if video uses the default controls because it's not needed.

## Dependencies

NA

## Testing

[videoTutorial.doccarchive.zip](https://github.com/apple/swift-docc-render/files/14448921/videoTutorial.doccarchive.zip)

Steps:
1. Download the attached .doccarchive above
2. Run: `VUE_APP_DEV_SERVER_PROXY=[path-to-doccarchive] npm run serve` 
3. Go to http://localhost:8080/tutorials/slothcreator/page-01
4. Assert that the video element has the `aria-describedby` tag referring to a span element which contains the alt text.
5. Assert that the control-button element has the `aria-describedby` tag referring to a span element which contains the alt text.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
