### PR TITLE
Pager UI updates

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -246,7 +246,7 @@ export default {
 }
 
 .link {
-  bottom: 17px;
+  bottom: $details-padding-card;
   display: flex;
   align-items: center;
   position: absolute;

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -151,17 +151,6 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-$details-padding: 17px;
-$content-margin: 4px;
-
-@mixin static-card-size($card-height, $img-height) {
-  @include inTargetWeb {
-    --card-height: #{$card-height};
-    --card-details-height: #{$card-height - $img-height - ($details-padding * 2)};
-  }
-  --card-cover-height: #{$img-height};
-}
-
 .card {
   overflow: hidden;
   display: block;
@@ -215,7 +204,7 @@ $content-margin: 4px;
 
 .details {
   background-color: var(--color-card-background);
-  padding: $details-padding;
+  padding: $details-padding-card;
   position: relative;
   height: var(--card-details-height);
   @include font-styles(card-content-small);
@@ -226,14 +215,14 @@ $content-margin: 4px;
 
   .floating-style & {
     --color-card-background: transparent;
-    padding: $details-padding 0;
+    padding: $details-padding-card 0;
   }
 }
 
 .eyebrow {
   color: var(--color-card-eyebrow);
   display: block;
-  margin-bottom: $content-margin;
+  margin-bottom: $content-margin-card;
   @include font-styles(card-eyebrow-small);
 
   .large & {
@@ -253,7 +242,7 @@ $content-margin: 4px;
 
 .card-content {
   color: var(--color-card-content-text);
-  margin-top: $content-margin;
+  margin-top: $content-margin-card;
 }
 
 .link {

--- a/src/components/DocumentationTopic/TopicsLinkCardGrid.vue
+++ b/src/components/DocumentationTopic/TopicsLinkCardGrid.vue
@@ -17,7 +17,7 @@
     <template #page="{ page }">
       <Row :columns="{
         large: compactCards ? 3 : 2,
-        medium: 2,
+        medium: compactCards ? 3 : 2,
       }">
         <Column
           v-for="item in page"
@@ -82,7 +82,7 @@ export default {
     }) => (usePager ? {
       [TopicSectionsStyle.compactGrid]: {
         [BreakpointName.large]: 6,
-        [BreakpointName.medium]: 4,
+        [BreakpointName.medium]: 6,
         [BreakpointName.small]: 1,
       },
       [TopicSectionsStyle.detailedGrid]: {

--- a/src/components/Pager.vue
+++ b/src/components/Pager.vue
@@ -343,7 +343,7 @@ export default {
   justify-content: center;
   margin-top: 1rem;
 
-  @include breakpoint(small) {
+  @include breakpoint(medium) {
     display: none;
   }
 }

--- a/src/components/PagerControl.vue
+++ b/src/components/PagerControl.vue
@@ -54,7 +54,11 @@ export default {
   width: var(--control-size, 1rem);
 
   &[disabled] {
-    opacity: 0;
+    opacity: 0.6;
+
+    @include breakpoints-from(large) {
+      opacity: 0;
+    }
   }
 }
 

--- a/src/styles/core/_helpers.scss
+++ b/src/styles/core/_helpers.scss
@@ -33,6 +33,17 @@
 }
 
 ////
+/// Applies size for static cards
+////
+@mixin static-card-size($card-height, $img-height) {
+  @include inTargetWeb {
+    --card-height: #{$card-height};
+    --card-details-height: #{$card-height - $img-height - ($details-padding-card * 2)};
+  }
+  --card-cover-height: #{$img-height};
+}
+
+////
 /// Used to apply the globalish styles that the ".section-content" class
 /// provided on /documentation pages
 ////

--- a/src/styles/core/_helpers.scss
+++ b/src/styles/core/_helpers.scss
@@ -35,10 +35,10 @@
 ////
 /// Applies size for static cards
 ////
-@mixin static-card-size($card-height, $img-height) {
+@mixin static-card-size($card-height, $img-height, $details-padding: $details-padding-card) {
   @include inTargetWeb {
     --card-height: #{$card-height};
-    --card-details-height: #{$card-height - $img-height - ($details-padding-card * 2)};
+    --card-details-height: #{$card-height - $img-height - ($details-padding * 2)};
   }
   --card-cover-height: #{$img-height};
 }

--- a/src/styles/core/_vars.scss
+++ b/src/styles/core/_vars.scss
@@ -90,3 +90,7 @@ $localizedQuotes: (
 
 // Localized Fonts
 $localizedFonts: () !default;
+
+// Cards
+$details-padding-card: 17px;
+$content-margin-card: 4px;

--- a/tests/unit/components/DocumentationTopic/TopicsLinkCardGrid.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkCardGrid.spec.js
@@ -56,7 +56,7 @@ describe('TopicsLinkCardGrid', () => {
       expect(pager.exists()).toBe(true);
       expect(pager.props('pages').length).toBe(2);
 
-      // 10 items => 2 pages at large breakpoint (6 links per page)
+      // 10 items => 2 pages at medium breakpoint (6 links per page)
       wrapper.setData({ breakpoint: BreakpointName.medium });
       pager = wrapper.find(Pager);
       expect(pager.exists()).toBe(true);

--- a/tests/unit/components/DocumentationTopic/TopicsLinkCardGrid.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkCardGrid.spec.js
@@ -56,11 +56,11 @@ describe('TopicsLinkCardGrid', () => {
       expect(pager.exists()).toBe(true);
       expect(pager.props('pages').length).toBe(2);
 
-      // 10 items => 3 pages at medium breakpoint (4 links per page)
+      // 10 items => 2 pages at large breakpoint (6 links per page)
       wrapper.setData({ breakpoint: BreakpointName.medium });
       pager = wrapper.find(Pager);
       expect(pager.exists()).toBe(true);
-      expect(pager.props('pages').length).toBe(3);
+      expect(pager.props('pages').length).toBe(2);
 
       // 10 items => 10 pages at small breakpoint (1 links per page)
       wrapper.setData({ breakpoint: BreakpointName.small });


### PR DESCRIPTION
Bug/issue #122817341, if applicable: 

## Summary

Updates the UI in the medium viewport:

1. There should only be 2 rows max
2. The pagination dots should disappear in this viewport
3. Both of the chevrons should appear at the same time, and one of them should be disabled if there's no more cards in that "direction"

It also moves the `static-card-size` var into a global scope.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
