### PR TITLE
Support thematic breaks

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -30,6 +30,7 @@ import TabNavigator from './ContentNode/TabNavigator.vue';
 import TaskList from './ContentNode/TaskList.vue';
 import LinksBlock from './ContentNode/LinksBlock.vue';
 import DeviceFrame from './ContentNode/DeviceFrame.vue';
+import ThematicBreak from './ContentNode/ThematicBreak.vue';
 
 const { CaptionPosition, CaptionTag } = Caption.constants;
 
@@ -49,6 +50,7 @@ export const BlockType = {
   row: 'row',
   tabNavigator: 'tabNavigator',
   links: 'links',
+  thematicBreak: 'thematicBreak',
 };
 
 const InlineType = {
@@ -421,6 +423,8 @@ function renderNode(createElement, references) {
         },
       });
     }
+    case BlockType.thematicBreak:
+      return createElement(ThematicBreak);
     case InlineType.codeVoice:
       return createElement(CodeVoice, {}, (
         node.code

--- a/src/components/ContentNode/ThematicBreak.vue
+++ b/src/components/ContentNode/ThematicBreak.vue
@@ -1,0 +1,21 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2024 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+<template>
+  <hr class="thematic-break" />
+</template>
+
+<style scoped lang="scss">
+@import 'docc-render/styles/_core.scss';
+
+.thematic-break {
+  @include space-out-between-siblings(var(--spacing-stacked-margin-xlarge));
+  border-color: var(--color-grid, currentColor);
+}
+</style>

--- a/src/components/ContentNode/ThematicBreak.vue
+++ b/src/components/ContentNode/ThematicBreak.vue
@@ -16,6 +16,8 @@
 
 .thematic-break {
   @include space-out-between-siblings(var(--spacing-stacked-margin-xlarge));
-  border-color: var(--color-grid, currentColor);
+  border-top-color: var(--color-grid, currentColor);
+  border-top-style: solid;
+  border-width: 1px 0 0 0;
 }
 </style>

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ * Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -31,6 +31,7 @@ import TaskList from 'docc-render/components/ContentNode/TaskList.vue';
 import { TopicSectionsStyle } from '@/constants/TopicSectionsStyle';
 import LinksBlock from '@/components/ContentNode/LinksBlock.vue';
 import DeviceFrame from '@/components/ContentNode/DeviceFrame.vue';
+import ThematicBreak from 'docc-render/components/ContentNode/ThematicBreak.vue';
 
 const { TableHeaderStyle, TableColumnAlignments } = ContentNode.constants;
 
@@ -1817,6 +1818,14 @@ describe('ContentNode', () => {
       expect(terms.at(1).text()).toBe('Bar');
       expect(definitions.at(1).contains('p')).toBe(true);
       expect(definitions.at(1).text()).toBe('bar');
+    });
+  });
+
+  describe('with type="thematicBreak"', () => {
+    it('renders a `ThematicBreak`', () => {
+      const wrapper = mountWithItem({ type: ContentNode.BlockType.thematicBreak });
+      const tbreak = wrapper.find(ThematicBreak);
+      expect(tbreak.exists()).toBe(true);
     });
   });
 

--- a/tests/unit/components/ContentNode/ThematicBreak.spec.js
+++ b/tests/unit/components/ContentNode/ThematicBreak.spec.js
@@ -1,0 +1,20 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2024 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+import { shallowMount } from '@vue/test-utils';
+import ThematicBreak from 'docc-render/components/ContentNode/ThematicBreak.vue';
+
+describe('ThematicBreak', () => {
+  it('renders an <hr> element', () => {
+    const wrapper = shallowMount(ThematicBreak);
+    const hr = wrapper.find('hr');
+    expect(hr.exists()).toBe(true);
+    expect(hr.classes('thematic-break')).toBe(true);
+  });
+});


### PR DESCRIPTION
Bug/issue #, if applicable: 125507297

## Summary

Adds support for rendering "thematic breaks" within content using the `<hr>` element.

With the corresponding Swift-DocC PR, the markdown syntax for horizontal rules can be used in content to indicate a thematic break within content, and this PR adds rendering support for this.

**Example Markdown:**

```diff
diff --git a/SwiftDocCRender.docc/contributing/Internals.md b/SwiftDocCRender.docc/contributing/Internals.md
index d3054747..2500a12d 100644
--- a/SwiftDocCRender.docc/contributing/Internals.md
+++ b/SwiftDocCRender.docc/contributing/Internals.md
@@ -6,6 +6,8 @@ Learn how DocC-Render is built internally, the principles behind its structure,
 
 DocC-Render supports rendering reference pages, tutorials, and articles to document your project in a structured manner.
 
+---
+
 Each page fetches its required render JSON asynchronously, from the `/data` directory. To learn more about the types of pages DocC-Render supports, visit the [DocC Docs](https://www.swift.org/documentation/docc).
 
 ### Modular Architecture
```

**Example rendering:**

<img width="852" alt="Screenshot 2024-03-25 at 12 19 20 PM" src="https://github.com/apple/swift-docc-render/assets/212918/de1419d6-90d8-4ec1-a790-7fabd5bf6ca7">

## Dependencies

https://github.com/apple/swift-docc/pull/865

## Testing

Steps:
1. Checkout/build the branch of Swift-DocC from [Support thematic breaks #865](https://github.com/apple/swift-docc/pull/865)
2. Checkout/build the branch of Swift-DocC-Render from this PR
3. Add/modify content with a markdown horizontal rule (like the example above)
4. Preview the docs using `DOCC_HTML_DIR=/path/to/swift-docc-render/dist swift run docc preview ExampleContent.docc` and verify that a horizontal rule is rendered in the appropriate place

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
