### PR TITLE
Make sidebar toggle margin more explicit

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -186,6 +186,7 @@ $sidenav-icon-padding-size: 5px;
 
 .sidenav-toggle-wrapper {
   display: flex;
+  margin-right: $nav-padding / 2;
   margin-top: 1px;
 
   // This is a hack to enforce the toggle to be visible when in breakpoint,

--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -186,8 +186,11 @@ $sidenav-icon-padding-size: 5px;
 
 .sidenav-toggle-wrapper {
   display: flex;
-  margin-right: $nav-padding / 2;
   margin-top: 1px;
+
+  @include breakpoints-from(large, nav) {
+    margin-right: $nav-padding / 2;
+  }
 
   // This is a hack to enforce the toggle to be visible when in breakpoint,
   // even if already toggled off on desktop. Conditionally checking the current breakpoint,

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -673,12 +673,6 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   white-space: nowrap;
   box-sizing: border-box;
 
-  @include breakpoints-from(large, nav) {
-    &:not(:first-child) {
-      padding-left: $nav-padding / 2;
-    }
-  }
-
   @include breakpoint(small, $scope: nav) {
     padding-top: 0;
     height: $nav-height-small;


### PR DESCRIPTION
Bug/issue #, if applicable: 123086813

## Summary

This refactors the way that the right-hand-side spacing is applied between the sidebar toggle and other content so that it only applies when the toggle is present and visible.

The previous implementation was done in the more generic nav component, which may not always include a sidebar toggle, so there could be unexpected spacing in those situations.

## Testing

Steps:
1. Checkout this branch and use it to preview any documentation page.
2. Verify that there is still sufficient spacing between the sidebar navigator toggle button and the "Documentation" link/text in all viewport sizes.
3. Preview other kinds of pages and verify that this same spacing is not present if the sidebar navigator toggle is not present.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS-only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
