### PR TITLE
[6.0] Make sidebar toggle margin more explicit

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -188,6 +188,10 @@ $sidenav-icon-padding-size: 5px;
   display: flex;
   margin-top: 1px;
 
+  @include breakpoints-from(large, nav) {
+    margin-right: $nav-padding / 2;
+  }
+
   // This is a hack to enforce the toggle to be visible when in breakpoint,
   // even if already toggled off on desktop. Conditionally checking the current breakpoint,
   // would trigger animations when switching between breakpoints.

--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -673,12 +673,6 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   white-space: nowrap;
   box-sizing: border-box;
 
-  @include breakpoints-from(large, nav) {
-    &:not(:first-child) {
-      padding-left: $nav-padding / 2;
-    }
-  }
-
   @include breakpoint(small, $scope: nav) {
     padding-top: 0;
     height: $nav-height-small;


### PR DESCRIPTION
- **Explanation:** Fixes an issue where excess spacing may occur when sidebar toggle is not displayed
- **Scope:** Impacts pages where the sidebar toggle is not displayed
- **Issue:** rdar://123086813
- **Risk:** Low, small CSS change to how spacing is applied for isolated button
- **Testing:** Manually tested that the spacing looks correct for variations of the sidebar with/without toggle in varying browser viewport sizes
- **Reviewer:** @hqhhuang 
- **Original PR:** #796 