### PR TITLE
[6.0] Handle multiple spellings of mime-type JSON data

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/RestResponses.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/RestResponses.vue
@@ -11,7 +11,7 @@
 <template>
   <section>
     <LinkableHeading :anchor="anchor">{{ title }}</LinkableHeading>
-    <ParametersTable :parameters="responses" :changes="propertyChanges" key-by="status">
+    <ParametersTable :parameters="sanitizedResponses" :changes="propertyChanges" key-by="status">
       <template #symbol="{ status, type, reason, content, changes }">
         <div class="response-name">
           <code>
@@ -26,7 +26,7 @@
         />
       </template>
       <template
-        #description="{ content, mimetype, reason, type, status, changes }"
+        #description="{ content, mimeType, reason, type, status, changes }"
       >
         <PossiblyChangedType
           v-if="shouldShiftType({content, reason, status})"
@@ -38,8 +38,8 @@
         </div>
         <ContentNode v-if="content" :content="content" />
         <PossiblyChangedMimetype
-          v-if="mimetype"
-          :mimetype="mimetype"
+          v-if="mimeType"
+          :mimetype="mimeType"
           :changes="changes.mimetype"
           :change="changes.change"
         />
@@ -81,8 +81,15 @@ export default {
   computed: {
     anchor: ({ title }) => anchorize(title),
     propertyChanges: ({ apiChanges }) => ((apiChanges || {}).restResponses),
+    sanitizedResponses: ({ responses, sanitizeResponse }) => responses.map(sanitizeResponse),
   },
   methods: {
+    // ensure that mimetype data gets handled correctly, regardless of its
+    // spelling in the JSON (`mimeType` is the expected spelling, but some
+    // data sources may be encoded as `mimetype` at present)
+    sanitizeResponse: ({ mimetype, ...response }) => (mimetype
+      ? ({ ...response, mimeType: mimetype })
+      : response),
     shouldShiftType:
       ({ content = [], reason, status }) => (!(content.length || reason) && status),
   },

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestResponses.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestResponses.spec.js
@@ -28,7 +28,7 @@ describe('RestResponses', () => {
       {
         status: '200',
         reason: 'OK',
-        mimetype: 'application/json',
+        mimeType: 'application/json',
         type: [
           {
             kind: 'identifier',
@@ -99,7 +99,7 @@ describe('RestResponses', () => {
   });
 
   it('hides mime-type if absent', () => {
-    const { mimetype, ...otherProps } = propsData.responses[0];
+    const { mimeType, ...otherProps } = propsData.responses[0];
     const wrapper = mountComponent({
       propsData: {
         ...propsData,
@@ -261,5 +261,24 @@ describe('RestResponses', () => {
     });
     expect(wrapper.find(PossiblyChangedType).props()).toHaveProperty('changes', changes['200'].type);
     expect(wrapper.find(PossiblyChangedMimetype).props()).toMatchObject({ changes: changes['200'].mimetype, change: changes['200'].change });
+  });
+
+  it('handles data where `mimetype` spelling is used instead of `mimeType`', () => {
+    const { mimetype, mimeType, ...firstResponse } = propsData.responses[0];
+
+    expect(mimeType).not.toBeUndefined();
+    expect(mimetype).toBeUndefined();
+    const wrapper = mountComponent({
+      propsData: {
+        ...propsData,
+        responses: [
+          {
+            ...firstResponse,
+            mimetype: mimeType,
+          },
+        ],
+      },
+    });
+    expect(wrapper.find(PossiblyChangedMimetype).exists()).toBe(true);
   });
 });


### PR DESCRIPTION
- **Explanation:** Adds workaround for situation where data key may be spelled differently
- **Scope:** Impacts pages with HTTP response sections with content-type data
- **Issue:** rdar://124300035
- **Risk:** Low, minor isolated JS changes to handle data presented in any of 2 key names
- **Testing:** Added/updated unit tests, manually tested that the same data is rendered as expected, regardless of whether the JSON key is spelled `mimeType` or `mimetype`
- **Reviewer:** @hqhhuang 
- **Original PR:** #801 