### PR TITLE
[6.0] Clear filter input when a new tag is selected

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+  Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -207,10 +207,6 @@ export default {
     selectInputOnFocus: {
       type: Boolean,
       default: false,
-    },
-    clearFilterOnTagSelect: {
-      type: Boolean,
-      default: true,
     },
     preventBorderStyle: {
       type: Boolean,

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -106,7 +106,6 @@
               :should-keep-open-on-blur="false"
               :shouldTruncateTags="shouldTruncateTags"
               :position-reversed="!renderFilterOnTop"
-              :clear-filter-on-tag-select="false"
               class="filter-component"
               @clear="clearFilters"
             />

--- a/src/mixins/multipleSelection.js
+++ b/src/mixins/multipleSelection.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2022 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -55,7 +55,6 @@ export default {
 
     selectTag(tag) {
       this.updateSelectedTags([tag]);
-      if (!this.clearFilterOnTagSelect) return;
       this.setFilterInput('');
     },
 

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -648,16 +648,6 @@ describe('FilterInput', () => {
       suggestedTags.vm.$emit('click-tags', { tagName: selectedTag });
       expect(wrapper.emitted('update:selectedTags')).toEqual([[[selectedTag]]]);
       expect(wrapper.emitted('input')).toEqual([['']]);
-    });
-
-    it('adds tag to `selectedTags` when it is clicked, without clearing the filter', () => {
-      wrapper.setProps({
-        clearFilterOnTagSelect: false,
-      });
-      const selectedTag = 'Tag1';
-      suggestedTags.vm.$emit('click-tags', { tagName: selectedTag });
-      expect(wrapper.emitted('update:selectedTags')).toEqual([[[selectedTag]]]);
-      expect(wrapper.emitted('input')).toBeFalsy();
     });
 
     describe('when a tag is selected', () => {

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -307,7 +307,6 @@ describe('NavigatorCard', () => {
       ],
       value: '',
       selectInputOnFocus: false,
-      clearFilterOnTagSelect: false,
     });
   });
 

--- a/tests/unit/components/Navigator/QuickNavigationModal.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationModal.spec.js
@@ -1,7 +1,7 @@
 /**
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+ * Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information
@@ -150,7 +150,6 @@ describe('QuickNavigationModal', () => {
       tags: [],
       translatableTags: [],
       selectInputOnFocus: true,
-      clearFilterOnTagSelect: true,
     });
   });
 


### PR DESCRIPTION
- **Explanation:** Reset filter input in the navigator when a new tag is selected.
- **Scope:** Small, only impacts Navigator
- **Issue:** rdar://124954232
- **Risk:** Low, minor change that basically reverts an earlier PR
- **Testing:** Added/updated unit tests
- **Reviewer:** @mportiz08  
- **Original PR:** #802