### PR TITLE
Links to other declarations should include query params

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationGroup.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationGroup.vue
@@ -53,6 +53,7 @@ import Language from 'docc-render/constants/Language';
 import TransitionExpand from 'docc-render/components/TransitionExpand.vue';
 import { APIChangesMultipleLines } from 'docc-render/mixins/apiChangesHelpers';
 import { waitFor } from 'docc-render/utils/loading';
+import { buildUrl } from 'docc-render/utils/url-helper';
 
 /**
  * Renders a code source with an optional caption.
@@ -162,7 +163,8 @@ export default {
       await this.$nextTick(); // wait for identifier to update
       this.isExpanded = false; // collapse the list
       await waitFor(500); // wait for animation to finish
-      this.$router.push(this.references[identifier].url);
+      const url = buildUrl(this.references[identifier].url, this.$route.query);
+      this.$router.push(url);
     },
     getWrapperComponent(decl) {
       return (!this.isExpanded || decl.identifier === this.identifier)

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationGroup.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationGroup.spec.js
@@ -19,6 +19,12 @@ import { flushPromises } from '../../../../../test-utils';
 jest.mock('docc-render/utils/loading');
 
 const mocks = {
+  $route: {
+    path: '/documentation/foo',
+    query: {
+      context: 'foo',
+    },
+  },
   $router: {
     push: jest.fn(),
   },
@@ -192,7 +198,7 @@ describe('DeclarationGroup with otherDeclarations', () => {
     expect(sourceWrapper.at(1).find('button').exists()).toBe(false);
   });
 
-  it('clicking on a pill from the expanded list selects that declaration', async () => {
+  it('clicking on a pill from the expanded list selects that declaration with query param', async () => {
     const buttons = wrapper.findAll('.declaration-pill--expanded');
     const button = buttons.at(0).find('button');
     button.trigger('click');
@@ -203,6 +209,7 @@ describe('DeclarationGroup with otherDeclarations', () => {
     expect(wrapper.vm.selectedIdentifier).toEqual(identifier);
     expect(wrapper.emitted('update:declListExpanded')).toEqual([[false]]);
     expect(waitFor).toHaveBeenCalledWith(500); // wait for animation to be finish
-    expect(mocks.$router.push).toHaveBeenCalledWith(store.state.references[identifier].url);
+    const url = `${store.state.references[identifier].url}?context=foo`;
+    expect(mocks.$router.push).toHaveBeenCalledWith(url);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://124041300

## Summary
The links pushed to the router when users click on the pill for another declaration should include query parameters.

## Dependencies
NA

## Testing
Manual testing and run updated unit test 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
