### PR TITLE
Don't emit selectedTags if there are no tags to paste

### DIFF
--- a/src/mixins/multipleSelection.js
+++ b/src/mixins/multipleSelection.js
@@ -537,11 +537,15 @@ export default {
       }
 
       this.setFilterInput(input.trim());
-      if (this.allSelectedTagsAreActive) {
-        this.setSelectedTags(tags);
-      } else {
-        this.updateSelectedTags(tags);
+
+      if (tags.length) {
+        if (this.allSelectedTagsAreActive) {
+          this.setSelectedTags(tags);
+        } else {
+          this.updateSelectedTags(tags);
+        }
       }
+
       this.resetActiveTags();
     },
     /**

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -414,8 +414,20 @@ describe('FilterInput', () => {
       // assert the input and tags are emitted
       expect(wrapper.emitted('input')).toHaveLength(1);
       expect(wrapper.emitted('input')[0]).toEqual(['Title']);
-      expect(wrapper.emitted('update:selectedTags')).toHaveLength(1);
-      expect(wrapper.emitted('update:selectedTags')[0]).toEqual([[]]);
+    });
+
+    it('on paste, do not emit selectedTags if there are no tags to paste', () => {
+      clipboardData.getData = jest.fn((param) => {
+        if (param === 'text/plain') return 'Title';
+        return prepareDataForHTMLClipboard({
+          input: 'baz',
+          tags: [],
+        });
+      });
+      clipboardData.types.push('text/html');
+
+      input.trigger('paste', { clipboardData });
+      expect(wrapper.emitted('update:selectedTags')).toBeFalsy();
     });
 
     it('on paste, reads directly from plain text, if json is not available', () => {
@@ -428,8 +440,6 @@ describe('FilterInput', () => {
       // assert the input and tags are emitted
       expect(wrapper.emitted('input')).toHaveLength(1);
       expect(wrapper.emitted('input')[0]).toEqual(['[tag1][tag2] string']);
-      expect(wrapper.emitted('update:selectedTags')).toHaveLength(1);
-      expect(wrapper.emitted('update:selectedTags')[0]).toEqual([[]]);
     });
 
     it('on paste, overwrites all the tags if they are selected', () => {


### PR DESCRIPTION
Bug/issue #125844017, if applicable: 

## Summary

Don't emit selectedTags if there are no tags to paste.
Emitting an empty selected tags array to the NavigatorCard was affecting the filter functionality.

## Dependencies

NA

## Testing

Steps:
1. Go to any documentation page with navigator
2. Copied a text
3. Paste it in the navigator's filter
4. Assert that filtering works well

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
