### PR TITLE
[6.0] Omit Mentioned In section on module pages (#811)

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -171,6 +171,7 @@
 
 <script>
 import Language from 'docc-render/constants/Language';
+import SymbolKind from 'docc-render/constants/SymbolKind';
 import metadata from 'theme/mixins/metadata';
 import { buildUrl } from 'docc-render/utils/url-helper';
 import { normalizeRelativePath } from 'docc-render/utils/assets';
@@ -494,7 +495,7 @@ export default {
       ) {
         return false;
       }
-      return symbolKind ? (symbolKind === 'module') : true;
+      return symbolKind ? (symbolKind === SymbolKind.module) : true;
     },
     shortHero: ({
       roleHeading,
@@ -572,8 +573,13 @@ export default {
       topicState.contentWidth > ON_THIS_PAGE_CONTAINER_BREAKPOINT
     ),
     disableMetadata: ({ enableMinimized }) => enableMinimized,
-    primaryContentSectionsSanitized({ primaryContentSections = [] }) {
-      return primaryContentSections.filter(({ kind }) => kind !== SectionKind.declarations);
+    primaryContentSectionsSanitized({ primaryContentSections = [], symbolKind }) {
+      return primaryContentSections.filter(({ kind }) => {
+        if (kind === SectionKind.mentions) {
+          return symbolKind !== SymbolKind.module;
+        }
+        return kind !== SectionKind.declarations;
+      });
     },
     declarations({ primaryContentSections = [] }) {
       return primaryContentSections.filter(({ kind }) => kind === SectionKind.declarations);

--- a/src/constants/SymbolKind.js
+++ b/src/constants/SymbolKind.js
@@ -17,4 +17,5 @@ export default {
   protocol: 'protocol',
   struct: 'struct',
   uid: 'uid',
+  module: 'module',
 };

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -13,6 +13,7 @@ import DocumentationTopic from 'docc-render/components/DocumentationTopic.vue';
 import Language from 'docc-render/constants/Language';
 import InlinePlusCircleIcon from 'docc-render/components/Icons/InlinePlusCircleIcon.vue';
 import { TopicTypes } from '@/constants/TopicTypes';
+import SymbolKind from '@/constants/SymbolKind';
 import DocumentationHero from '@/components/DocumentationTopic/Hero/DocumentationHero.vue';
 import { TopicSectionsStyle } from '@/constants/TopicSectionsStyle';
 import OnThisPageNav from '@/components/OnThisPageNav.vue';
@@ -366,6 +367,37 @@ describe('DocumentationTopic', () => {
 
     const hierarchy = wrapper.find(Hierarchy);
     expect(hierarchy.exists()).toBe(false);
+  });
+
+  it('only creates a "Mentioned In" section for non-module pages', () => {
+    const mentionSection = {
+      kind: PrimaryContent.constants.SectionKind.mentions,
+      mentions: [
+        'topic://foo',
+        'topic://bar',
+      ],
+    };
+
+    wrapper.setProps({
+      references: hierarchyItemsReferences,
+      role: TopicTypes.symbol,
+      symbolKind: SymbolKind.protocol,
+      primaryContentSections: [
+        mentionSection,
+        foo,
+      ],
+    });
+
+    expect(wrapper.find(PrimaryContent).props()).toHaveProperty('sections', [
+      mentionSection,
+      foo,
+    ]);
+
+    wrapper.setProps({
+      symbolKind: SymbolKind.module,
+    });
+
+    expect(wrapper.find(PrimaryContent).props()).toHaveProperty('sections', [foo]);
   });
 
   it('renders `Hierarchy` without its immediate parent if its within overload group', () => {


### PR DESCRIPTION
rdar://125512559

This is a cherry-pick of #811 to `release/6.0`.

- **Explanation**: Omits the Mentioned In section on module pages. This section might be included in the future as the mention logic changes, so this change is in the renderer for now.
- **Scope**: Impacts all module documentation pages when `--enable-experimental-mentioned-in` is used with DocC.
- **Issue**: rdar://125512559
- **Risk**: Low. This is a small scope change with specific options enabled.
- **Testing**: Added unit test; manual testing with Swift Markdown.
- **Reviewer**: @mportiz08 
- **Original PR**: https://github.com/apple/swift-docc-render/pull/811