### PR TITLE
Delete card hover effect in small viewports

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -178,6 +178,11 @@ export default {
         box-shadow: none;
         transform: none;
       }
+
+      @include breakpoint(small) {
+        box-shadow: none;
+        transform: none;
+      }
     }
   }
 


### PR DESCRIPTION
Bug/issue #127050375, if applicable: 

## Summary

Delete card hover effect in small viewports. Hover effects in small viewports are only triggered when the link is active and we don't need this effect for active states.

## Dependencies

NA

## Testing

Steps:
1. Run a .doccarchive that has Cards on it
2. Use a small viewport
3. Click in the Card
4. Assert that there is no effect in its active state 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
