### PR TITLE
[6.0] Add prop to DocumentationLayout to be able to modify the Navigator's fixed width

### DIFF
--- a/src/components/DocumentationLayout.vue
+++ b/src/components/DocumentationLayout.vue
@@ -139,6 +139,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    navigatorFixedWidth: {
+      type: Number,
+      default: null,
+    },
   },
   data() {
     return {
@@ -152,11 +156,14 @@ export default {
     enableQuickNavigation: ({ isTargetIDE }) => (
       !isTargetIDE && getSetting(['features', 'docs', 'quickNavigation', 'enable'], true)
     ),
-    sidebarProps: ({ sidenavVisibleOnMobile, enableNavigator, sidenavHiddenOnLarge }) => (
+    sidebarProps: ({
+      sidenavVisibleOnMobile, enableNavigator, sidenavHiddenOnLarge, navigatorFixedWidth,
+    }) => (
       enableNavigator
         ? {
           shownOnMobile: sidenavVisibleOnMobile,
           hiddenOnLarge: sidenavHiddenOnLarge,
+          fixedWidth: navigatorFixedWidth,
         }
         : {
           enableNavigator,

--- a/tests/unit/components/DocumentationLayout.spec.js
+++ b/tests/unit/components/DocumentationLayout.spec.js
@@ -92,6 +92,7 @@ const propsData = {
   objcPath: 'documentation/objc',
   swiftPath: 'documentation/swift',
   selectedAPIChangesVersion: '',
+  navigatorFixedWidth: 400,
 };
 
 const AdjustableSidebarWidthSmallStub = {
@@ -157,7 +158,7 @@ describe('DocumentationLayout', () => {
       shownOnMobile: false,
       hiddenOnLarge: false,
       enableNavigator: true,
-      fixedWidth: null,
+      fixedWidth: propsData.navigatorFixedWidth,
     });
     const {
       technology,


### PR DESCRIPTION
- **Explanation:** Add prop to DocumentationLayout to be able to modify the Navigator's fixed width
- **Scope:** S, adding a prop to a component
- **Issue:** rdar://126869289
- **Risk:** Small
- **Testing:** Unit testing
- **Reviewer:** @hqhhuang 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/822