### PR TITLE
[6.0] Add `disableHeroBackground` property to `DocumentationTopic` view

### DIFF
--- a/src/components/DocumentationTopic/Hero/Title.vue
+++ b/src/components/DocumentationTopic/Hero/Title.vue
@@ -34,6 +34,12 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .topictitle {
+  margin-bottom: rem(12px);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
   @include breakpoint(small) {
     margin: 0;
   }
@@ -51,7 +57,6 @@ export default {
   @include font-styles(headline-reduced);
   color: var(--color-documentation-intro-title,
     var(--colors-header-text, var(--color-header-text)));
-  margin-bottom: rem(12px);
 }
 
 small {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -27,6 +27,7 @@
         <Topic
           v-bind="topicProps"
           :key="topicKey"
+          :disableHeroBackground="disableHeroBackground"
           :objcPath="objcPath"
           :swiftPath="swiftPath"
           :isSymbolDeprecated="isSymbolDeprecated"
@@ -93,6 +94,7 @@ export default {
     };
   },
   computed: {
+    disableHeroBackground: () => false,
     documentationLayoutProps: ({
       topicProps: {
         diffAvailability,


### PR DESCRIPTION
- **Explanation:** Adds a configurable property to disable documentation hero background
- **Scope:** Impacts documentation pages
- **Issue:** rdar://127009817
- **Risk:** Low, minor JS property addition with sensible default
- **Testing:** Verified that existing hero background behavior persists and can be overwritten by changing default value.
- **Reviewer:** @hqhhuang 
- **Original PR:** #816 