### PR TITLE
Prevent programmatic focus change from bubbling in handleFocusIn

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -815,8 +815,10 @@ export default {
       if (!this.$refs.scroller) return false;
       return this.$refs.scroller.$el.contains(element);
     },
-    handleFocusIn({ target }) {
+    handleFocusIn({ target, relatedTarget }) {
       this.lastFocusTarget = target;
+      // prevent scroll when focus is programmatic
+      if (!relatedTarget) return;
       const positionIndex = this.getChildPositionInScroller(target);
       // if multiplier is 0, the item is inside the scrollarea, no need to scroll
       if (positionIndex === 0) return;

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -2355,7 +2355,9 @@ describe('NavigatorCard', () => {
 
       const fourthItem = items.at(3);
       setOffsetParent(fourthItem.element, { offsetHeight: SIDEBAR_ITEM_SIZE });
-      fourthItem.trigger('focusin');
+      fourthItem.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       await flushPromises();
       expect(scrollBySpy).toHaveBeenCalledTimes(1);
       expect(scrollBySpy).toHaveBeenCalledWith({
@@ -2366,7 +2368,9 @@ describe('NavigatorCard', () => {
       getChildPositionInScroller.mockReturnValueOnce(-1);
       const firstItem = items.at(0);
       setOffsetParent(firstItem.element, { offsetHeight: SIDEBAR_ITEM_SIZE + 50 });
-      firstItem.trigger('focusin');
+      firstItem.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       await flushPromises();
       expect(scrollBySpy).toHaveBeenCalledTimes(2);
       expect(scrollBySpy).toHaveBeenCalledWith({
@@ -2382,7 +2386,9 @@ describe('NavigatorCard', () => {
       await flushPromises();
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       await wrapper.vm.$nextTick();
       expect(wrapper.vm.lastFocusTarget).toEqual(button.element);
     });
@@ -2392,7 +2398,9 @@ describe('NavigatorCard', () => {
       await flushPromises();
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       await wrapper.vm.$nextTick();
       button.trigger('focusout', {
         relatedTarget: document.body,
@@ -2405,7 +2413,9 @@ describe('NavigatorCard', () => {
       await flushPromises();
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: null,
+      });
       await wrapper.vm.$nextTick();
       button.trigger('focusout', {
         relatedTarget: null,
@@ -2430,7 +2440,9 @@ describe('NavigatorCard', () => {
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       const focusSpy = jest.spyOn(button.element, 'focus');
       await flushPromises();
       // now make the component go away
@@ -2455,7 +2467,9 @@ describe('NavigatorCard', () => {
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       button.element.focus();
       // move the spy below the manual focus, so we dont count it
       const focusSpy = jest.spyOn(button.element, 'focus');
@@ -2475,7 +2489,9 @@ describe('NavigatorCard', () => {
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
       const focusSpy = jest.spyOn(button.element, 'focus');
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       await flushPromises();
       // trigger an update
       wrapper.find(DynamicScroller).vm.$emit('update');
@@ -2491,7 +2507,9 @@ describe('NavigatorCard', () => {
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       const focusSpy = jest.spyOn(button.element, 'focus');
       await flushPromises();
       // initiate a filter


### PR DESCRIPTION
Bug/issue #128559835, if applicable: 

## Summary

We have a function called `getChildPositionInScroller` that was meant to scroll items in the navigator into little by little, when focused, instead of jumping to the middle of the navigator scrollarea. More info: https://github.com/apple/swift-docc-render/pull/247

This function was being called in programmatic focus changes, instead of the initial keyboard navigation purpose, so I'm preventing it from happening.

## Dependencies

NA

## Testing

Steps:
1. Run a doccarchive with a navigator
2. Assert that you can open and close nested symbols using the arrow keys without the navigator changing your focus
3. Assert that you can scroll long lists of symbols using keyboard navigation (arrow keys)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
