### PR TITLE
Transform item's path to lowercase in navigator

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -36,7 +36,7 @@
           v-if="technology"
           :id="INDEX_ROOT_KEY"
           :url="technologyPath"
-          :class="['technology-title', { 'router-link-exact-active': isSameRoute }]"
+          :class="['technology-title', { 'router-link-exact-active': isTechnologyRoute }]"
           @click.alt.native.prevent="toggleAllNodes"
         >
           <h2 class="card-link">
@@ -247,7 +247,7 @@ export default {
     };
   },
   computed: {
-    isSameRoute: ({ technologyPath, $route }) => (
+    isTechnologyRoute: ({ technologyPath, $route }) => (
       technologyPath.toLowerCase() === $route.path.toLowerCase()),
     politeAriaLive() {
       const { hasNodes, navigatorItems } = this;

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -36,7 +36,7 @@
           v-if="technology"
           :id="INDEX_ROOT_KEY"
           :url="technologyPath"
-          class="technology-title"
+          :class="['technology-title', { 'router-link-exact-active': isSameRoute }]"
           @click.alt.native.prevent="toggleAllNodes"
         >
           <h2 class="card-link">
@@ -247,6 +247,8 @@ export default {
     };
   },
   computed: {
+    isSameRoute: ({ technologyPath, $route }) => (
+      technologyPath.toLowerCase() === $route.path.toLowerCase()),
     politeAriaLive() {
       const { hasNodes, navigatorItems } = this;
       if (!hasNodes) return '';

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -89,7 +89,7 @@
         :is="refComponent"
         :id="item.uid"
         :class="{ bolded: isBold }"
-        :url="isGroupMarker ? null : (item.path.toLowerCase() || '')"
+        :url="isGroupMarker ? null : (item.path || '')"
         :tabindex="isFocused ? '0' : '-1'"
         :aria-describedby="`${ariaDescribedBy} ${usageLabel}`"
         class="leaf-link"

--- a/src/components/Navigator/NavigatorCardItem.vue
+++ b/src/components/Navigator/NavigatorCardItem.vue
@@ -89,7 +89,7 @@
         :is="refComponent"
         :id="item.uid"
         :class="{ bolded: isBold }"
-        :url="isGroupMarker ? null : (item.path || '')"
+        :url="isGroupMarker ? null : (item.path.toLowerCase() || '')"
         :tabindex="isFocused ? '0' : '-1'"
         :aria-describedby="`${ariaDescribedBy} ${usageLabel}`"
         class="leaf-link"

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -189,6 +189,7 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(NavigatorC
     BaseNavigatorCard,
   },
   sync: false,
+  mocks: { $route: { path: defaultProps.technologyPath } },
   attachToDocument: true,
   ...others,
 });
@@ -368,6 +369,14 @@ describe('NavigatorCard', () => {
     expect(wrapper.find('.technology-title').find(Badge).props()).toMatchObject({
       variant: 'beta',
     });
+  });
+
+  it('adds the "router-link-exact-active" class for case insensitive version of technologyPath', async () => {
+    const wrapper = createWrapper();
+    wrapper.setProps({
+      technologyPath: '/documentation/Testkit',
+    });
+    expect(wrapper.find('.technology-title').classes()).toContain('router-link-exact-active');
   });
 
   it('focus the first item if there is no active item', async () => {


### PR DESCRIPTION
Bug/issue #122911237, if applicable: 

## Summary

Transform item's path to lowercase in navigator, so if symbols have a path with capital letters, the highlighting of the active element in the navigator continues working

## Dependencies

NA

## Testing

Steps:
1. Run a doccarchive with a navigator
2. Make sure that everything works as expected

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
