### PR TITLE
[6.0] Revert underlined style for decorated topic titles

### DIFF
--- a/src/components/DocumentationTopic/DecoratedTopicTitle.vue
+++ b/src/components/DocumentationTopic/DecoratedTopicTitle.vue
@@ -94,8 +94,4 @@ export default {
     font-size: 1rem;
   }
 }
-
-.decorated-title {
-  @include underline-text;
-}
 </style>


### PR DESCRIPTION
- **Explanation:** Revert underlined style for decorated topic titles
- **Scope:** decorated topic titles
- **Issue:** rdar://128096499
- **Risk:** Low, just affecting style for decorated topic titles
- **Testing:** Manually verify
- **Reviewer:** @mportiz08 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/833