### PR TITLE
Delete max-width in small viewports for Cards

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -281,7 +281,6 @@ export default {
 
       @include inTargetWeb {
         min-width: 280px;
-        max-width: 300px;
         --card-cover-height: 227px;
       }
       @include inTargetIde {


### PR DESCRIPTION
Bug/issue #127050244, if applicable: 

## Summary

Delete max-width in small viewports for Cards

## Dependencies

NA

## Testing

Steps:
1. Go to a technology with Cards
2. Assert that in small viewports they don't have a max-width on it

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
