### PR TITLE
[6.0] Prevent programmatic focus change from bubbling in handleFocusIn

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -815,8 +815,10 @@ export default {
       if (!this.$refs.scroller) return false;
       return this.$refs.scroller.$el.contains(element);
     },
-    handleFocusIn({ target }) {
+    handleFocusIn({ target, relatedTarget }) {
       this.lastFocusTarget = target;
+      // prevent scroll when focus is programmatic
+      if (!relatedTarget) return;
       const positionIndex = this.getChildPositionInScroller(target);
       // if multiplier is 0, the item is inside the scrollarea, no need to scroll
       if (positionIndex === 0) return;

--- a/tests/unit/components/Navigator/NavigatorCard.spec.js
+++ b/tests/unit/components/Navigator/NavigatorCard.spec.js
@@ -2355,7 +2355,9 @@ describe('NavigatorCard', () => {
 
       const fourthItem = items.at(3);
       setOffsetParent(fourthItem.element, { offsetHeight: SIDEBAR_ITEM_SIZE });
-      fourthItem.trigger('focusin');
+      fourthItem.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       await flushPromises();
       expect(scrollBySpy).toHaveBeenCalledTimes(1);
       expect(scrollBySpy).toHaveBeenCalledWith({
@@ -2366,7 +2368,9 @@ describe('NavigatorCard', () => {
       getChildPositionInScroller.mockReturnValueOnce(-1);
       const firstItem = items.at(0);
       setOffsetParent(firstItem.element, { offsetHeight: SIDEBAR_ITEM_SIZE + 50 });
-      firstItem.trigger('focusin');
+      firstItem.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       await flushPromises();
       expect(scrollBySpy).toHaveBeenCalledTimes(2);
       expect(scrollBySpy).toHaveBeenCalledWith({
@@ -2382,7 +2386,9 @@ describe('NavigatorCard', () => {
       await flushPromises();
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       await wrapper.vm.$nextTick();
       expect(wrapper.vm.lastFocusTarget).toEqual(button.element);
     });
@@ -2392,7 +2398,9 @@ describe('NavigatorCard', () => {
       await flushPromises();
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       await wrapper.vm.$nextTick();
       button.trigger('focusout', {
         relatedTarget: document.body,
@@ -2405,7 +2413,9 @@ describe('NavigatorCard', () => {
       await flushPromises();
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: null,
+      });
       await wrapper.vm.$nextTick();
       button.trigger('focusout', {
         relatedTarget: null,
@@ -2430,7 +2440,9 @@ describe('NavigatorCard', () => {
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       const focusSpy = jest.spyOn(button.element, 'focus');
       await flushPromises();
       // now make the component go away
@@ -2455,7 +2467,9 @@ describe('NavigatorCard', () => {
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       button.element.focus();
       // move the spy below the manual focus, so we dont count it
       const focusSpy = jest.spyOn(button.element, 'focus');
@@ -2475,7 +2489,9 @@ describe('NavigatorCard', () => {
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
       const focusSpy = jest.spyOn(button.element, 'focus');
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       await flushPromises();
       // trigger an update
       wrapper.find(DynamicScroller).vm.$emit('update');
@@ -2491,7 +2507,9 @@ describe('NavigatorCard', () => {
       // This might happen if it deletes an item, that was in focus
       const button = wrapper.find(NavigatorCardItem).find('button');
       // should be focus, but jsdom does not propagate that
-      button.trigger('focusin');
+      button.trigger('focusin', {
+        relatedTarget: document.body,
+      });
       const focusSpy = jest.spyOn(button.element, 'focus');
       await flushPromises();
       // initiate a filter


### PR DESCRIPTION
- **Explanation:** Fixes navigation issues related to focus events.
- **Scope:** Impacts clicking links in navigator
- **Issue:** rdar://128559835
- **Risk:** Low, single JS event handler change
- **Testing:** Updated unit tests, manually tested navigating across pages using sidebar
- **Reviewer:** @mportiz08, @eango 
- **Original PR:** #835 

\cc @marinaaisa 