### PR TITLE
[6.0] Delete max-width in small viewports for Cards

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -281,7 +281,6 @@ export default {
 
       @include inTargetWeb {
         min-width: 280px;
-        max-width: 300px;
         --card-cover-height: 227px;
       }
       @include inTargetIde {


### PR DESCRIPTION
- **Explanation:** Removes max-width for cards in small viewports
- **Scope:** Impacts pages with card content viewed in small viewport widths
- **Issue:** rdar://127050244
- **Risk:** Low, single CSS property removal
- **Testing:** Manually tested that pages with card content look good on varying viewport width sizes
- **Reviewer:** @mportiz08
- **Original PR:** #840

\cc @marinaaisa 