### PR TITLE
Add navigator-title slot to NavigatorCard + fix small UI spacing details

### DIFF
--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -1056,6 +1056,9 @@ $navigator-card-vertical-spacing: 8px !default;
   align-items: flex-end;
 
   .filter-on-top & {
+    // negative margin to bring the filter up
+    // while keeping the height and padding as it is
+    margin-top: calc(#{var(--nav-filter-vertical-padding)} * -1);
     border-top: none;
     align-items: flex-start;
   }
@@ -1065,9 +1068,10 @@ $navigator-card-vertical-spacing: 8px !default;
 
   @include breakpoint(medium, nav) {
     --nav-filter-horizontal-padding: 20px;
+    --nav-filter-vertical-padding: 10px;
     border: none;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding-top: var(--nav-filter-vertical-padding);
+    padding-bottom: var(--nav-filter-vertical-padding);
     height: $filter-height-small;
   }
 
@@ -1095,6 +1099,7 @@ $navigator-card-vertical-spacing: 8px !default;
 
 .scroller {
   height: 100%;
+  margin: 0;
   box-sizing: border-box;
   padding-bottom: calc(var(--top-offset, 0px) + var(--card-vertical-spacing));
   transition: padding-bottom ease-in 0.15s;

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -32,18 +32,20 @@
         @keydown.up.exact.capture.prevent="focusPrev"
         @keydown.down.exact.capture.prevent="focusNext"
       >
-        <Reference
-          v-if="technology"
-          :id="INDEX_ROOT_KEY"
-          :url="technologyPath"
-          :class="['technology-title', { 'router-link-exact-active': isTechnologyRoute }]"
-          @click.alt.native.prevent="toggleAllNodes"
-        >
-          <h2 class="card-link">
-            {{ technology }}
-          </h2>
-          <Badge v-if="isTechnologyBeta" variant="beta" />
-        </Reference>
+        <slot name="navigator-title">
+          <Reference
+            v-if="technology"
+            :id="INDEX_ROOT_KEY"
+            :url="technologyPath"
+            :class="['technology-title', { 'router-link-exact-active': isTechnologyRoute }]"
+            @click.alt.native.prevent="toggleAllNodes"
+          >
+            <h2 class="card-link">
+              {{ technology }}
+            </h2>
+            <Badge v-if="isTechnologyBeta" variant="beta" />
+          </Reference>
+        </slot>
         <DynamicScroller
           v-show="hasNodes"
           :id="scrollLockID"


### PR DESCRIPTION
Bug/issue #122909785, if applicable: 

## Summary

- Add navigator-title slot to NavigatorCard
- Add negative margin to bring the filter up while keeping the height and padding as it is

## Dependencies

NA

## Testing

Steps:
1. Assert that everything works well in desktop viewports
2. Assert that the filter is higher up in the small viewports

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
