### PR TITLE
Prevent icons in Navigator from being smooshed

### DIFF
--- a/src/components/TopicTypeIcon.vue
+++ b/src/components/TopicTypeIcon.vue
@@ -150,7 +150,6 @@ export default {
     display: block;
     width: 100%;
     height: 100%;
-    object-fit: contain;
   }
 }
 </style>


### PR DESCRIPTION
Bug/issue #127621275, if applicable: 

## Summary

Prevent icons in Navigator from being smooshed

## Dependencies

NA

## Testing

Steps:
1. Run a doccarchive that has icons in the navigator
2. Assert that icons aren't being smooshed

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
