### PR TITLE
Remove Card's shadow when hovering

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -171,13 +171,7 @@ export default {
     border-radius: $big-border-radius;
 
     &:hover {
-      box-shadow: 0 5px 10px var(--color-card-shadow);
       transform: scale(1.007);
-
-      @media (prefers-reduced-motion: reduce) {
-        box-shadow: none;
-        transform: none;
-      }
     }
   }
 


### PR DESCRIPTION
Bug/issue #128943066, if applicable: 

## Summary

Remove Card's shadow when hovering

## Dependencies

NA

## Testing

Steps:
1. Assert that cards don't have shadow when hovering

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
