### PR TITLE
[6.0] Prevent icons in Navigator from being smooshed

### DIFF
--- a/src/components/TopicTypeIcon.vue
+++ b/src/components/TopicTypeIcon.vue
@@ -150,7 +150,6 @@ export default {
     display: block;
     width: 100%;
     height: 100%;
-    object-fit: contain;
   }
 }
 </style>


### PR DESCRIPTION
- **Explanation:** Prevent icons in Navigator from being smooshed
- **Scope:** only sidebar icons
- **Issue:** rdar://127621275
- **Risk:** Low, styles changes only in the sidebar icons
- **Testing:** Manually verified
- **Reviewer:** @mportiz08 @SamLanier 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/848