### PR TITLE
[6.0] Remove Card's shadow when hovering

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -180,11 +180,9 @@ export default {
     border-radius: $big-border-radius;
 
     &:hover {
-      box-shadow: 0 5px 10px var(--color-card-shadow);
       transform: scale(1.007);
 
       @media (prefers-reduced-motion: reduce) {
-        box-shadow: none;
         transform: none;
       }
     }


### PR DESCRIPTION
- **Explanation:** Remove Card's shadow when hovering
- **Scope:** only card's shadow
- **Issue:** rdar://128943066
- **Risk:** Low, only card's shadow
- **Testing:** Manually verified
- **Reviewer:** @mportiz08 @SamLanier 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/851