### PR TITLE
Fix xlarge breakpoint

### DIFF
--- a/src/components/DocumentationTopic/TopicsLinkCardGrid.vue
+++ b/src/components/DocumentationTopic/TopicsLinkCardGrid.vue
@@ -81,11 +81,13 @@ export default {
       usePager,
     }) => (usePager ? {
       [TopicSectionsStyle.compactGrid]: {
+        [BreakpointName.xlarge]: 8,
         [BreakpointName.large]: 6,
         [BreakpointName.medium]: 6,
         [BreakpointName.small]: 1,
       },
       [TopicSectionsStyle.detailedGrid]: {
+        [BreakpointName.xlarge]: 6,
         [BreakpointName.large]: 4,
         [BreakpointName.medium]: 2,
         [BreakpointName.small]: 1,

--- a/src/utils/breakpoints.js
+++ b/src/utils/breakpoints.js
@@ -28,6 +28,7 @@ export const BreakpointAttributes = {
     },
     [BreakpointName.large]: {
       minWidth: 1251,
+      maxWidth: 1536,
       contentWidth: 980,
     },
     [BreakpointName.medium]: {

--- a/tests/unit/components/DocumentationTopic/TopicsLinkCardGrid.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkCardGrid.spec.js
@@ -17,7 +17,7 @@ import { TopicSectionsStyle } from '@/constants/TopicSectionsStyle';
 const ref = n => ({ identifier: `ref${n}` });
 
 const defaultProps = {
-  items: [...Array(10).keys()].map(n => ref(n)),
+  items: [...Array(8).keys()].map(n => ref(n)),
 };
 
 const createWrapper = ({ propsData, ...others } = {}) => shallowMount(TopicsLinkCardGrid, {
@@ -51,22 +51,28 @@ describe('TopicsLinkCardGrid', () => {
         },
       });
 
-      // 10 items => 2 pages at large breakpoint (6 links per page)
+      // 8 items => 2 pages at large breakpoint (6 links per page)
       let pager = wrapper.find(Pager);
       expect(pager.exists()).toBe(true);
       expect(pager.props('pages').length).toBe(2);
 
-      // 10 items => 2 pages at medium breakpoint (6 links per page)
+      // 8 items => 1 pages at xlarge breakpoint (8 links per page)
+      wrapper.setData({ breakpoint: BreakpointName.xlarge });
+      pager = wrapper.find(Pager);
+      expect(pager.exists()).toBe(true);
+      expect(pager.props('pages').length).toBe(1);
+
+      // 8 items => 2 pages at medium breakpoint (6 links per page)
       wrapper.setData({ breakpoint: BreakpointName.medium });
       pager = wrapper.find(Pager);
       expect(pager.exists()).toBe(true);
       expect(pager.props('pages').length).toBe(2);
 
-      // 10 items => 10 pages at small breakpoint (1 links per page)
+      // 8 items => 8 pages at small breakpoint (1 links per page)
       wrapper.setData({ breakpoint: BreakpointName.small });
       pager = wrapper.find(Pager);
       expect(pager.exists()).toBe(true);
-      expect(pager.props('pages').length).toBe(10);
+      expect(pager.props('pages').length).toBe(8);
     });
   });
 
@@ -79,23 +85,23 @@ describe('TopicsLinkCardGrid', () => {
         },
       });
 
-      // 10 items => 3 pages at large breakpoint (4 links per page)
+      // 8 items => 2 pages at large breakpoint (4 links per page)
       let pager = wrapper.find(Pager);
       expect(pager.classes('detailedGrid')).toBe(true);
       expect(pager.exists()).toBe(true);
-      expect(pager.props('pages').length).toBe(3);
+      expect(pager.props('pages').length).toBe(2);
 
-      // 10 items => 5 pages at medium breakpoint (2 links per page)
+      // 8 items => 4 pages at medium breakpoint (2 links per page)
       wrapper.setData({ breakpoint: BreakpointName.medium });
       pager = wrapper.find(Pager);
       expect(pager.exists()).toBe(true);
-      expect(pager.props('pages').length).toBe(5);
+      expect(pager.props('pages').length).toBe(4);
 
-      // 10 items => 10 pages at small breakpoint (1 links per page)
+      // 8 items => 8 pages at small breakpoint (1 links per page)
       wrapper.setData({ breakpoint: BreakpointName.small });
       pager = wrapper.find(Pager);
       expect(pager.exists()).toBe(true);
-      expect(pager.props('pages').length).toBe(10);
+      expect(pager.props('pages').length).toBe(8);
     });
   });
 });


### PR DESCRIPTION
Bug/issue #128869276, if applicable: 

## Summary

- Fix breakpoints, adding a maxWidth to the large one
- Add xlarge breakpoint to TopicsLinkCardGrid

## Dependencies

NA

## Testing

Steps:
1. Run a doccarchive with a TopicsLinkCardGrid component on it
2. Test it in a xlarge viewport and assert that it shows a pager of 8 items per row
3. Assert that when resizing from xlarge viewport to large viewport, it shows a pager of 6 items per row

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
