### PR TITLE
Add bottom margin under the declaration list when no content after

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -952,7 +952,7 @@ $space-size: 15px;
     min-width: 0;
     width: 100%;
 
-    // only render border on declaration list menu
+    // only render border and bottom margin on declaration list menu
     // when there are no content sections afterwards at all
     .container:only-child {
       .declaration-list-menu:last-child::before {
@@ -961,6 +961,7 @@ $space-size: 15px;
         border-top-width: var(--content-table-title-border-width, 1px);
         content: '';
         display: block;
+        margin-bottom: $section-spacing-single-side;
       }
     }
 


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://129563985

## Summary
Add bottom margin under the declaration list even when there is no content after it in the `doc-content` div. 
Doing this because we sometimes also render `BetaLegalText` afterwards, but it's not part of the `doc-content` div. 

## Dependencies
NA

## Testing
Steps:
1. Ensure no regression is introduced for regular documentation pages, and symbol pages with other declarations
2. Test to see the margin is added properly 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
