### PR TITLE
Update scroll lock logic to lock everything but disabled targets

### DIFF
--- a/src/components/Filter/FilterInput.vue
+++ b/src/components/Filter/FilterInput.vue
@@ -37,6 +37,7 @@
         </button>
         <div
           :class="['filter__input-box-wrapper', { 'scrolling': isScrolling }]"
+          v-bind="{[SCROLL_LOCK_DISABLE_ATTR]: true}"
           @scroll="handleScroll"
         >
           <TagList
@@ -106,7 +107,7 @@
         </div>
       </div>
       <TagList
-        v-if="displaySuggestedTags"
+        v-show="displaySuggestedTags"
         :id="SuggestedTagsId"
         ref="suggestedTags"
         :ariaLabel="$tc('filter.suggested-tags', suggestedTags.length)"
@@ -128,6 +129,7 @@
 import ClearRoundedIcon from 'theme/components/Icons/ClearRoundedIcon.vue';
 import multipleSelection from 'docc-render/mixins/multipleSelection';
 import handleScrollbar from 'docc-render/mixins/handleScrollbar';
+import { SCROLL_LOCK_DISABLE_ATTR } from 'docc-render/utils/scroll-lock';
 import FilterIcon from 'theme/components/Icons/FilterIcon.vue';
 import TagList from './TagList.vue';
 
@@ -225,6 +227,7 @@ export default {
       SuggestedTagsId,
       AXinputProperties,
       showSuggestedTags: false,
+      SCROLL_LOCK_DISABLE_ATTR,
     };
   },
   computed: {

--- a/src/components/Filter/TagList.vue
+++ b/src/components/Filter/TagList.vue
@@ -24,6 +24,7 @@
         role="listbox"
         :aria-multiselectable="areTagsRemovable ? 'true' : 'false'"
         aria-orientation="horizontal"
+        v-bind="{[SCROLL_LOCK_DISABLE_ATTR]: true}"
         @keydown.left.capture.prevent="focusPrev"
         @keydown.right.capture.prevent="focusNext"
         @keydown.up.capture.prevent="focusPrev"
@@ -61,6 +62,7 @@
 import { isSingleCharacter } from 'docc-render/utils/input-helper';
 import handleScrollbar from 'docc-render/mixins/handleScrollbar';
 import keyboardNavigation from 'docc-render/mixins/keyboardNavigation';
+import { SCROLL_LOCK_DISABLE_ATTR } from 'docc-render/utils/scroll-lock';
 import Tag from './Tag.vue';
 
 export default {
@@ -69,6 +71,11 @@ export default {
     handleScrollbar,
     keyboardNavigation,
   ],
+  data() {
+    return {
+      SCROLL_LOCK_DISABLE_ATTR,
+    };
+  },
   props: {
     tags: {
       type: Array,

--- a/tests/unit/components/Filter/FilterInput.spec.js
+++ b/tests/unit/components/Filter/FilterInput.spec.js
@@ -378,7 +378,7 @@ describe('FilterInput', () => {
       });
       expect(selectedTags.props('activeTags')).toEqual(tags);
       // assert we tried to ficus first item
-      expect(spy).toHaveBeenCalledWith(0);
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it('on paste, handles clipboard in HTML format, when copying and pasting from search directly', () => {
@@ -563,7 +563,7 @@ describe('FilterInput', () => {
       await wrapper.vm.$nextTick();
       // first time was `true`, from `focus`, then `blur` made it `false`
       expect(wrapper.emitted('show-suggested-tags')).toEqual([[true], [false]]);
-      expect(suggestedTags.exists()).toBe(false);
+      expect(suggestedTags.attributes('style')).toContain('display: none');
     });
 
     it('deletes `suggestedTags` component when `deleteButton` looses its focus on an external component', async () => {
@@ -576,7 +576,7 @@ describe('FilterInput', () => {
       });
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted('show-suggested-tags')).toEqual([[true], [false]]);
-      expect(suggestedTags.exists()).toBe(false);
+      expect(suggestedTags.attributes('style')).toContain('display: none');
     });
 
     it('does not hide the tags, if the new focus target matches `input, button`, inside the main component', async () => {
@@ -598,7 +598,7 @@ describe('FilterInput', () => {
 
       await flushPromises();
 
-      expect(suggestedTags.exists()).toBe(false);
+      expect(suggestedTags.attributes('style')).toContain('display: none');
       expect(wrapper.emitted('show-suggested-tags')).toEqual([[true], [false]]);
     });
 
@@ -613,7 +613,7 @@ describe('FilterInput', () => {
       });
 
       await wrapper.vm.$nextTick();
-      expect(suggestedTags.exists()).toBe(false);
+      expect(suggestedTags.attributes('style')).toContain('display: none');
       expect(wrapper.emitted('show-suggested-tags')).toEqual([[true], [false]]);
       expect(wrapper.emitted('blur')).toBeTruthy();
     });
@@ -637,7 +637,7 @@ describe('FilterInput', () => {
       });
 
       it('deletes `suggestedTags` component when no tags available', () => {
-        expect(suggestedTags.exists()).toBe(false);
+        expect(suggestedTags.attributes('style')).toContain('display: none');
       });
 
       it('does not render `deleteButton` when there are no tags and `input` is empty', () => {


### PR DESCRIPTION
Bug/issue #129588759, if applicable: 

## Summary

Update scroll lock logic to lock everything but disabled targets

## Dependencies

NA

## Testing

Steps:

1. Open Safari iOS in Simulator or use any iOS device
2. Go to any documentation page
3. Open the navigator
4. Assert that you can scroll tags in the navigator

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
