### PR TITLE
[6.0] Add bottom margin under the declaration list when no content after

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -952,7 +952,7 @@ $space-size: 15px;
     min-width: 0;
     width: 100%;
 
-    // only render border on declaration list menu
+    // only render border and bottom margin on declaration list menu
     // when there are no content sections afterwards at all
     .container:only-child {
       .declaration-list-menu:last-child::before {
@@ -961,6 +961,7 @@ $space-size: 15px;
         border-top-width: var(--content-table-title-border-width, 1px);
         content: '';
         display: block;
+        margin-bottom: $section-spacing-single-side;
       }
     }
 


### PR DESCRIPTION
- **Explanation:** Add a bottom margin under the declaration list button when there's no content after it, to prevent overlapping with footer
- **Scope:** S, only minor CSS change
- **Issue:** rdar://129563985
- **Risk:** Low
- **Testing:** Manually verified
- **Reviewer:** @mportiz08
- **Original PR:** https://github.com/apple/swift-docc-render/pull/857