### PR TITLE
Only indent Objective-C method declarations

### DIFF
--- a/src/utils/indentation.js
+++ b/src/utils/indentation.js
@@ -17,6 +17,19 @@ function indentObjcDeclaration(codeElement) {
     return;
   }
 
+  // since we don't yet have a way of distinguishing ObjC from C++ code yet,
+  // we should check to make sure we don't have any identifiers followed by
+  // the text "::", which will indicate that there are params using C++
+  // namespaces, and we should bail out in that scenario, since this code is
+  // tailored to ObjC declarations and is not generic enough to also work for
+  // C++ functions
+  for (let i = 0; i < params.length; i += 1) {
+    const param = params[i];
+    if (param.nextSibling?.textContent === '::') {
+      return;
+    }
+  }
+
   // use the position of the first keyword colon separator as the offset
   // to determine indentation for following lines
   const offset = codeElement.textContent.indexOf(':') + 1;

--- a/src/utils/indentation.js
+++ b/src/utils/indentation.js
@@ -10,24 +10,22 @@
 
 import Language from 'docc-render/constants/Language';
 
+const ObjcMethodPrefix = {
+  instance: '-',
+  klass: '+',
+};
+
 function indentObjcDeclaration(codeElement) {
+  // only attempt to indent declarations for Objective-C instance/class methods
+  const txt = codeElement.textContent ?? '';
+  if (!txt.startsWith(ObjcMethodPrefix.instance) && !txt.startsWith(ObjcMethodPrefix.klass)) {
+    return;
+  }
+
   // find all param name spans (which are tokenized as "token-identifier"s)
   const params = codeElement.getElementsByClassName('token-identifier');
   if (params.length < 2) {
     return;
-  }
-
-  // since we don't yet have a way of distinguishing ObjC from C++ code yet,
-  // we should check to make sure we don't have any identifiers followed by
-  // the text "::", which will indicate that there are params using C++
-  // namespaces, and we should bail out in that scenario, since this code is
-  // tailored to ObjC declarations and is not generic enough to also work for
-  // C++ functions
-  for (let i = 0; i < params.length; i += 1) {
-    const param = params[i];
-    if (param.nextSibling?.textContent === '::') {
-      return;
-    }
   }
 
   // use the position of the first keyword colon separator as the offset

--- a/tests/unit/utils/indentation.spec.js
+++ b/tests/unit/utils/indentation.spec.js
@@ -59,5 +59,16 @@ describe('indentDeclaration', () => {
         expect(code.innerHTML).toEqual(originalCode);
       });
     });
+
+    describe('with a C++ function that has namespaced parameters', () => {
+      it('should not add indentation', () => {
+        const originalCode = '<a href="/documentation/mycppclass" class="type-identifier-link"><code><span>MyCPPClass</span></code></a><span class="token-identifier">operator+</span>(<span class="token-identifier">std</span>::<span class="type-identifier-link"><span>string</span></span> <span class="token-internalParam">other</span>);';
+
+        const code = prepare(originalCode);
+        indentDeclaration(code, 'occ');
+
+        expect(code.innerHTML).toEqual(originalCode);
+      });
+    });
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 129590639

## Summary

This prevents bugs where the indentation formatting code is mistakenly executed with declarations that are not Objective-C methods.

Since this formatting code was designed for only those kinds of method declarations, this added check will enforce this requirement more strictly, preventing bugs where this code may currently execute with other kinds of Objective-C (or other C family) symbols.

## Testing

Steps:
1. Verify that there are no regressions with the way that Objective-C instance/class methods are formatted—the colon character is aligned across multiple lines when methods have multiple parameters.
2. Verify that there are no unexpected newlines introduced for other kinds of C-family declarations that may have parameters but aren't Objective-C instance/class methods (specific example: C++ functions with namespaced parameters)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
