### PR TITLE
[6.0] Only indent Objective-C method declarations

### DIFF
--- a/src/utils/indentation.js
+++ b/src/utils/indentation.js
@@ -10,7 +10,18 @@
 
 import Language from 'docc-render/constants/Language';
 
+const ObjcMethodPrefix = {
+  instance: '-',
+  klass: '+',
+};
+
 function indentObjcDeclaration(codeElement) {
+  // only attempt to indent declarations for Objective-C instance/class methods
+  const txt = codeElement.textContent ?? '';
+  if (!txt.startsWith(ObjcMethodPrefix.instance) && !txt.startsWith(ObjcMethodPrefix.klass)) {
+    return;
+  }
+
   // find all param name spans (which are tokenized as "token-identifier"s)
   const params = codeElement.getElementsByClassName('token-identifier');
   if (params.length < 2) {

--- a/tests/unit/utils/indentation.spec.js
+++ b/tests/unit/utils/indentation.spec.js
@@ -59,5 +59,16 @@ describe('indentDeclaration', () => {
         expect(code.innerHTML).toEqual(originalCode);
       });
     });
+
+    describe('with a C++ function that has namespaced parameters', () => {
+      it('should not add indentation', () => {
+        const originalCode = '<a href="/documentation/mycppclass" class="type-identifier-link"><code><span>MyCPPClass</span></code></a><span class="token-identifier">operator+</span>(<span class="token-identifier">std</span>::<span class="type-identifier-link"><span>string</span></span> <span class="token-internalParam">other</span>);';
+
+        const code = prepare(originalCode);
+        indentDeclaration(code, 'occ');
+
+        expect(code.innerHTML).toEqual(originalCode);
+      });
+    });
   });
 });


### PR DESCRIPTION
- **Explanation:** Fixes issue where some declarations render with unexpected newlines
- **Scope:** Impacts the declaration rendering for any C-family symbol
- **Issue:** rdar://129590639
- **Risk:** Low, single conditional added to make formatting logic more restrictive to ObjC methods
- **Testing:** Added unit test, manually tested that C++ symbol with unexpected formatting is resolved with this change, verified that there are no regressions with the formatting of Objective-C method declarations.
- **Reviewer:** @hqhhuang 
- **Original PR:** #860 