### PR TITLE
Include code and referenced text in metadata description

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -673,12 +673,17 @@ export default {
     // without any inline formatting—other block kinds like asides will be
     // ignored in the resulting plaintext representation.
     plaintext() {
+      const { references = {} } = this;
       return this.reduce((text, node) => {
         if (node.type === BlockType.paragraph) {
           return `${text}\n`;
         }
         if (node.type === InlineType.text) {
           return `${text}${node.text}`;
+        }
+        if (node.type === InlineType.reference) {
+          const title = references[node.identifier]?.title ?? '';
+          return `${text}${title}`;
         }
         return text;
       }, '').trim();

--- a/src/mixins/metadata.js
+++ b/src/mixins/metadata.js
@@ -18,9 +18,11 @@ export default {
     // Extracts the first paragraph of plaintext from the given content tree,
     // which can be used for metadata purposes.
     extractFirstParagraphText(content = []) {
+      const { references = {} } = this;
       const plaintext = ContentNode.computed.plaintext.bind({
         ...ContentNode.methods,
         content,
+        references,
       })();
       return firstParagraph(plaintext);
     },

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -2543,5 +2543,43 @@ describe('ContentNode', () => {
       });
       expect(wrapper.vm.plaintext).toBe('A\nB');
     });
+
+    it('includes text from references', () => {
+      const wrapper = shallowMount(ContentNode, {
+        propsData: {
+          content: [
+            {
+              type: ContentNode.BlockType.paragraph,
+              inlineContent: [
+                {
+                  type: ContentNode.InlineType.text,
+                  text: 'A',
+                },
+                {
+                  type: ContentNode.InlineType.text,
+                  text: ' ',
+                },
+                {
+                  type: ContentNode.InlineType.reference,
+                  identifier: 'b',
+                },
+              ],
+            },
+          ],
+        },
+        provide: {
+          store: {
+            state: {
+              references: {
+                b: {
+                  title: 'B',
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(wrapper.vm.plaintext).toBe('A B');
+    });
   });
 });

--- a/tests/unit/mixins/metadata.spec.js
+++ b/tests/unit/mixins/metadata.spec.js
@@ -45,6 +45,9 @@ const createWrapper = ({
       disableMetadata: () => disableMetadata,
       pageTitle: () => title,
       pageDescription: () => description,
+      references: () => ({
+        'ref-d': { title: 'd' },
+      }),
     },
   }, {
     mocks: {
@@ -99,7 +102,11 @@ describe('metadata', () => {
             },
             {
               type: 'text',
-              text: ' c',
+              text: ' c ',
+            },
+            {
+              type: 'reference',
+              identifier: 'ref-d',
             },
           ],
         },
@@ -114,7 +121,7 @@ describe('metadata', () => {
         },
       ];
       const wrapper = createWrapper(pageData);
-      expect(wrapper.vm.extractFirstParagraphText(content)).toBe('a b c');
+      expect(wrapper.vm.extractFirstParagraphText(content)).toBe('a b c d');
       expect(wrapper.vm.extractFirstParagraphText([])).toBe('');
     });
   });


### PR DESCRIPTION
Bug/issue #, if applicable: 129801569, #856

## Summary

Fixes a bug where the logic that populates `<meta name="description">` content doesn't include the text for any referenced items.

## Testing

Steps:
1. Use a link to a symbol in first paragraph abstract for a documentation page.
2. Verify that the text for the referenced symbol is now included in the `<meta name="description">` tag in the resulting HTML

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
