### PR TITLE
[6.0] Include code and referenced text in metadata description (#862)

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -673,12 +673,20 @@ export default {
     // without any inline formatting—other block kinds like asides will be
     // ignored in the resulting plaintext representation.
     plaintext() {
+      const { references = {} } = this;
       return this.reduce((text, node) => {
         if (node.type === BlockType.paragraph) {
           return `${text}\n`;
         }
+        if (node.type === InlineType.codeVoice) {
+          return `${text}${node.code}`;
+        }
         if (node.type === InlineType.text) {
           return `${text}${node.text}`;
+        }
+        if (node.type === InlineType.reference) {
+          const title = references[node.identifier]?.title ?? '';
+          return `${text}${title}`;
         }
         return text;
       }, '').trim();

--- a/src/mixins/metadata.js
+++ b/src/mixins/metadata.js
@@ -18,9 +18,11 @@ export default {
     // Extracts the first paragraph of plaintext from the given content tree,
     // which can be used for metadata purposes.
     extractFirstParagraphText(content = []) {
+      const { references = {} } = this;
       const plaintext = ContentNode.computed.plaintext.bind({
         ...ContentNode.methods,
         content,
+        references,
       })();
       return firstParagraph(plaintext);
     },

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -2538,10 +2538,57 @@ describe('ContentNode', () => {
                 },
               ],
             },
+            {
+              type: ContentNode.BlockType.paragraph,
+              inlineContent: [
+                {
+                  type: ContentNode.InlineType.codeVoice,
+                  code: 'C',
+                },
+              ],
+            },
           ],
         },
       });
-      expect(wrapper.vm.plaintext).toBe('A\nB');
+      expect(wrapper.vm.plaintext).toBe('A\nB\nC');
+    });
+
+    it('includes text from references', () => {
+      const wrapper = shallowMount(ContentNode, {
+        propsData: {
+          content: [
+            {
+              type: ContentNode.BlockType.paragraph,
+              inlineContent: [
+                {
+                  type: ContentNode.InlineType.text,
+                  text: 'A',
+                },
+                {
+                  type: ContentNode.InlineType.text,
+                  text: ' ',
+                },
+                {
+                  type: ContentNode.InlineType.reference,
+                  identifier: 'b',
+                },
+              ],
+            },
+          ],
+        },
+        provide: {
+          store: {
+            state: {
+              references: {
+                b: {
+                  title: 'B',
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(wrapper.vm.plaintext).toBe('A B');
     });
   });
 });

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -2582,6 +2582,7 @@ describe('ContentNode', () => {
               references: {
                 b: {
                   title: 'B',
+                  url: '/b',
                 },
               },
             },

--- a/tests/unit/mixins/metadata.spec.js
+++ b/tests/unit/mixins/metadata.spec.js
@@ -45,6 +45,9 @@ const createWrapper = ({
       disableMetadata: () => disableMetadata,
       pageTitle: () => title,
       pageDescription: () => description,
+      references: () => ({
+        'ref-d': { title: 'd' },
+      }),
     },
   }, {
     mocks: {
@@ -99,7 +102,11 @@ describe('metadata', () => {
             },
             {
               type: 'text',
-              text: ' c',
+              text: ' c ',
+            },
+            {
+              type: 'reference',
+              identifier: 'ref-d',
             },
           ],
         },
@@ -114,7 +121,7 @@ describe('metadata', () => {
         },
       ];
       const wrapper = createWrapper(pageData);
-      expect(wrapper.vm.extractFirstParagraphText(content)).toBe('a b c');
+      expect(wrapper.vm.extractFirstParagraphText(content)).toBe('a b c d');
       expect(wrapper.vm.extractFirstParagraphText([])).toBe('');
     });
   });


### PR DESCRIPTION
- **Explanation:** Fixes issue where inline references and code are not included in HTML metadata
- **Scope:** Impacts `<meta name="description">` tag for any pages with links/code in abstract paragraph
- **Issue:** rdar://129801569
- **Risk:** Low, small addition to focused logic for generating plaintext content
- **Testing:** Added unit tests, manually tested that expected inline text is now being included in metadata and there are no other regressions to metadata for other pages
- **Reviewer:** @marinaaisa 
- **Original PR:** #862 