### PR TITLE
[6.0] Prevent NavigatorCard from re-render when fetching data

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -14,7 +14,7 @@
     class="navigator"
   >
     <NavigatorCard
-      v-if="!isFetching"
+      v-show="!isFetching"
       v-bind="technologyProps"
       :type="type"
       :children="flatChildren"
@@ -33,7 +33,7 @@
     </NavigatorCard>
     <LoadingNavigatorCard
       @close="$emit('close')"
-      v-else
+      v-if="isFetching"
     />
     <div aria-live="polite" class="visuallyhidden">
       {{ $t('navigator.navigator-is', {

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -17,6 +17,8 @@ import { INDEX_ROOT_KEY } from '@/constants/sidebar';
 
 jest.mock('docc-render/utils/throttle', () => jest.fn(v => v));
 
+const { LoadingNavigatorCard } = Navigator.components;
+
 const technology = {
   title: 'FooTechnology',
   children: [
@@ -159,6 +161,29 @@ describe('Navigator', () => {
     });
     expect(wrapper.find('[aria-live="polite"]').exists()).toBe(true);
     expect(wrapper.find('[aria-live="polite"]').text()).toBe('navigator.navigator-is navigator.state.loading');
+  });
+
+  it('renders a LoadingNavigatorCard when navigator is loading', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        isFetching: true,
+      },
+    });
+    expect(wrapper.find(LoadingNavigatorCard).exists()).toBe(true);
+  });
+
+  it('does not render a LoadingNavigatorCard when navigator is not loading', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find(LoadingNavigatorCard).exists()).toBe(false);
+  });
+
+  it('adds display:none to NavigatorCard when navigator is loading', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        isFetching: true,
+      },
+    });
+    expect(wrapper.find(NavigatorCard).attributes('style')).toContain('display: none');
   });
 
   it('renders an aria live that tells VO users when navigator is ready', () => {


### PR DESCRIPTION
- **Explanation:** Prevent NavigatorCard from re-render when fetching data
- **Scope:** Impacts Navigator
- **Issue:** rdar://130012107
- **Risk:** Medium, affects loading of Navigator
- **Testing:** Added unit tests, manually tested
- **Reviewer:** @hqhhuang 
- **Original PR:** https://github.com/apple/swift-docc-render/pull/865