### PR TITLE
Allow for configurable video border-radius

### DIFF
--- a/src/components/VideoAsset.vue
+++ b/src/components/VideoAsset.vue
@@ -204,3 +204,9 @@ export default {
   },
 };
 </script>
+
+<style scoped lang="scss">
+video {
+  border-radius: var(--video-border-radius, 0px);
+}
+</style>


### PR DESCRIPTION
Bug/issue #, if applicable: 126292441

## Summary

Allows for the border-radius to be controlled with a custom CSS property called `--video-border-radius`. The default is none (`0px`).

## Testing

Steps:
1. Browse any content with video and verify that the border is unchanged by default
2. Use the inspector to configure a value for `--video-border-radius` and verify that the video corners are more rounded.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS-only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
