### PR TITLE
[6.0] Other declaration pills should be clickable when there are changes data 

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/Declaration.vue
@@ -20,7 +20,6 @@
     <template v-else>
       <DeclarationList
         v-for="(declaration, i) in declarations"
-        :class="changeClasses"
         :key="i"
         :declaration="declaration"
         :shouldCaption="hasPlatformVariants"

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationDiff.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationDiff.vue
@@ -17,7 +17,6 @@
         :key="i"
         :declaration="declaration"
         :should-caption="currentDeclarations.length > 1"
-        :changeType="changeType"
       />
     </div>
     <div class="declaration-diff-previous">
@@ -27,7 +26,6 @@
         :key="i"
         :declaration="declaration"
         :should-caption="previousDeclarations.length > 1"
-        :changeType="changeType"
       />
     </div>
   </div>
@@ -48,14 +46,6 @@ export default {
      */
     changes: {
       type: Object,
-      required: true,
-    },
-    /**
-     * The applied change type to the diff.
-     * @type {"added"|"deprecated"|"modified"}
-     */
-    changeType: {
-      type: String,
       required: true,
     },
   },

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationGroup.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationGroup.vue
@@ -1,0 +1,164 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2024 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <div
+    class="declaration-group"
+    :class="classes"
+    ref="apiChangesDiff"
+  >
+    <p v-if="shouldCaption" class="platforms">
+      <strong>{{ caption }}</strong>
+    </p>
+    <Source
+      :tokens="declaration.tokens"
+      :language="interfaceLanguage"
+    />
+  </div>
+</template>
+
+<script>
+import DeclarationSource from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue';
+import Language from 'docc-render/constants/Language';
+import { APIChangesMultipleLines } from 'docc-render/mixins/apiChangesHelpers';
+
+/**
+ * Renders a code source with an optional caption.
+ */
+export default {
+  name: 'DeclarationGroup',
+  components: {
+    Source: DeclarationSource,
+  },
+  mixins: [APIChangesMultipleLines],
+  inject: {
+    languages: {
+      default: () => new Set(),
+    },
+    interfaceLanguage: {
+      default: () => Language.swift.key.api,
+    },
+    symbolKind: {
+      default: () => undefined,
+    },
+  },
+  props: {
+    declaration: {
+      type: Object,
+      required: true,
+    },
+    /**
+     * Whether to show the caption or not.
+     * Usually if there is more than Declaration group.
+     */
+    shouldCaption: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * The type of code change.
+     * @type {"added"|"deprecated"|"modified"}
+     */
+    changeType: {
+      type: String,
+      required: false,
+    },
+  },
+  computed: {
+    classes: ({
+      changeType,
+      multipleLinesClass,
+      displaysMultipleLinesAfterAPIChanges,
+    }) => ({
+      [`declaration-group--changed declaration-group--${changeType}`]: changeType,
+      [multipleLinesClass]: displaysMultipleLinesAfterAPIChanges,
+    }),
+    caption() {
+      return this.declaration.platforms.join(', ');
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@import 'docc-render/styles/_core.scss';
+
+.platforms {
+  @include font-styles(body-reduced);
+
+  margin-bottom: 0.45rem;
+  margin-top: var(--spacing-stacked-margin-xlarge);
+
+  .changed & {
+    padding-left: $code-source-spacing;
+  }
+
+  &:first-of-type {
+    margin-top: 1rem;
+  }
+}
+
+.source {
+  transition: margin 0.3s linear;
+
+  .platforms + & {
+    margin: 0;
+  }
+}
+
+// don't highlight tokens in initial declaration until the user has explicitly
+// expanded a list of overloaded declarations — this rule could be simplified
+// in the future if the HTML is restructured to have an expanded state class for
+// the whole list instead of having it on each declaration
+.declaration-pill:not(.declaration-pill--expanded) {
+  .source:deep(.highlighted) {
+    background: unset;
+    font-weight: normal;
+  }
+}
+
+// only applicable for when other declaration list is expanded
+.declaration-pill--expanded {
+  $docs-declaration-source-border-width: 1px;
+
+  .source {
+    border-width: $docs-declaration-source-border-width;
+
+    // ensure links are not clickable, when expanded
+    :deep(a) {
+      pointer-events: none;
+    }
+  }
+
+  &.selected-declaration {
+    .source {
+      border-color: var(--color-focus-border-color, var(--color-focus-border-color));
+    }
+  }
+
+  &:not(.selected-declaration) {
+    .source {
+      background: none;
+    }
+  }
+}
+
+@include changedStyles {
+  .source {
+    // background should also be applied over changed icon over whole pill
+    background: none;
+    border: none;
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: $change-icon-occupied-space;
+    padding-left: 0;
+  }
+}
+</style>

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationList.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationList.vue
@@ -1,7 +1,7 @@
 <!--
   This source file is part of the Swift.org open source project
 
-  Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+  Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
@@ -10,14 +10,8 @@
 
 <template>
   <div
-    class="declaration-group"
-    :class="classes"
-    ref="apiChangesDiff"
+    class="declaration-list"
   >
-    <p v-if="shouldCaption" class="platforms">
-      <strong>{{ caption }}</strong>
-    </p>
-
     <transition-expand
       v-for="declaration in declarationTokens"
       :key="declaration.identifier"
@@ -27,19 +21,17 @@
         class="declaration-pill"
         :class="{
           'declaration-pill--expanded': hasOtherDeclarations && isExpanded,
+          [changeClasses]: changeType && declaration.identifier === selectedIdentifier,
+          'selected-declaration': isSelectedDeclaration(declaration.identifier),
         }"
       >
         <component
           :is="getWrapperComponent(declaration)"
           @click="selectDeclaration(declaration.identifier)"
-          class="declaration-source-wrapper"
+          class="declaration-group-wrapper"
         >
-          <Source
-            :tokens="declaration.tokens"
-            :language="interfaceLanguage"
-            :class="{
-              'selected-declaration': isSelectedDeclaration(declaration.identifier),
-            }"
+          <DeclarationGroup
+            v-bind="getDeclProp(declaration)"
           />
         </component>
       </div>
@@ -48,10 +40,8 @@
 </template>
 
 <script>
-import DeclarationSource from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue';
-import Language from 'docc-render/constants/Language';
+import DeclarationGroup from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationGroup.vue';
 import TransitionExpand from 'docc-render/components/TransitionExpand.vue';
-import { APIChangesMultipleLines } from 'docc-render/mixins/apiChangesHelpers';
 import { waitFor } from 'docc-render/utils/loading';
 import { buildUrl } from 'docc-render/utils/url-helper';
 
@@ -59,9 +49,9 @@ import { buildUrl } from 'docc-render/utils/url-helper';
  * Renders a code source with an optional caption.
  */
 export default {
-  name: 'DeclarationGroup',
+  name: 'DeclarationList',
   components: {
-    Source: DeclarationSource,
+    DeclarationGroup,
     TransitionExpand,
   },
   data() {
@@ -69,17 +59,7 @@ export default {
       selectedIdentifier: this.identifier,
     };
   },
-  mixins: [APIChangesMultipleLines],
   inject: {
-    languages: {
-      default: () => new Set(),
-    },
-    interfaceLanguage: {
-      default: () => Language.swift.key.api,
-    },
-    symbolKind: {
-      default: () => undefined,
-    },
     store: {
       default: () => ({
         state: {
@@ -118,13 +98,14 @@ export default {
     },
   },
   computed: {
+    changeClasses: ({ changeType }) => `changed changed-${changeType}`,
     hasOtherDeclarations: ({ declaration }) => declaration.otherDeclarations || null,
     declarationTokens: ({
       declaration,
       hasOtherDeclarations,
       identifier,
     }) => {
-      if (!hasOtherDeclarations) return [declaration];
+      if (!hasOtherDeclarations) return [{ ...declaration, identifier }];
       const {
         otherDeclarations: {
           declarations,
@@ -140,14 +121,6 @@ export default {
         ...declarations.slice(displayIndex),
       ];
     },
-    classes: ({ changeType, multipleLinesClass, displaysMultipleLinesAfterAPIChanges }) => ({
-      [`declaration-group--changed declaration-group--${changeType}`]: changeType,
-      [multipleLinesClass]: displaysMultipleLinesAfterAPIChanges,
-    }),
-    caption() {
-      return this.declaration.platforms.join(', ');
-    },
-    isSwift: ({ interfaceLanguage }) => interfaceLanguage === Language.swift.key.api,
     references: ({ store }) => store.state.references,
     isExpanded: {
       get: ({ declListExpanded }) => declListExpanded,
@@ -158,7 +131,7 @@ export default {
   },
   methods: {
     async selectDeclaration(identifier) {
-      if (identifier === this.identifier) return;
+      if (identifier === this.identifier || !this.isExpanded) return;
       this.selectedIdentifier = identifier;
       await this.$nextTick(); // wait for identifier to update
       this.isExpanded = false; // collapse the list
@@ -170,6 +143,16 @@ export default {
       return (!this.isExpanded || decl.identifier === this.identifier)
         ? 'div' : 'button';
     },
+    getDeclProp(decl) {
+      return !this.hasOtherDeclarations || decl.identifier === this.identifier
+        ? {
+          declaration: decl,
+          shouldCaption: this.shouldCaption,
+          changeType: this.changeType,
+        } : {
+          declaration: decl,
+        };
+    },
     isSelectedDeclaration(identifier) {
       return identifier === this.selectedIdentifier;
     },
@@ -180,59 +163,14 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-.platforms {
-  @include font-styles(body-reduced);
-
-  margin-bottom: 0.45rem;
-  margin-top: var(--spacing-stacked-margin-xlarge);
-
-  .changed & {
-    padding-left: $code-source-spacing;
-  }
-
-  &:first-of-type {
-    margin-top: 1rem;
-  }
-}
-
-// don't highlight tokens in initial declaration until the user has explicitly
-// expanded a list of overloaded declarations — this rule could be simplified
-// in the future if the HTML is restructured to have an expanded state class for
-// the whole list instead of having it on each declaration
-.declaration-pill:not(.declaration-pill--expanded):deep(.highlighted) {
-  background: unset;
-  font-weight: normal;
-}
-
 .declaration-pill--expanded {
   transition-timing-function: linear;
   transition-property: opacity, height;
-  $docs-declaration-source-border-width: 1px;
-
-  .source {
-    border-width: $docs-declaration-source-border-width;
-
-    // ensure links are not clickable, when expanded
-    :deep(a) {
-      pointer-events: none;
-    }
-  }
+  margin: var(--declaration-code-listing-margin);
 
   > button {
     display: block;
     width: 100%;
-  }
-
-  .selected-declaration {
-    border-color: var(--color-focus-border-color, var(--color-focus-border-color));
-  }
-
-  .source:not(.selected-declaration) {
-    background: unset;
-  }
-
-  + .declaration-pill--expanded .source {
-    margin: var(--declaration-code-listing-margin);
   }
 
   &.expand-enter, &.expand-leave-to {
@@ -244,25 +182,10 @@ export default {
   }
 }
 
-.source {
-  transition: margin 0.3s linear;
-
-  .platforms + & {
-    margin: 0;
-  }
-}
-
 @include changedStyles {
-  &.declaration-group {
+  &.selected-declaration {
+    // add back unset background for pills with changes
     background: var(--background, var(--color-code-background));
-  }
-  .source {
-    background: none;
-    border: none;
-    margin-top: 0;
-    margin-bottom: 0;
-    margin-left: $change-icon-occupied-space;
-    padding-left: 0;
   }
 }
 </style>

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/Declaration.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/Declaration.spec.js
@@ -186,8 +186,6 @@ describe('Declaration', () => {
     expect(declarationDiff.exists()).toBe(true);
     expect(declarationDiff.props()).toEqual({
       changes: provide.store.state.apiChanges.foo,
-      // when `new` and `previous` are provided, change type is always `modified`
-      changeType: ChangeTypes.modified,
     });
     expect(declarationDiff.classes()).toContain('changed');
     expect(declarationDiff.classes()).toContain('changed-modified');
@@ -198,7 +196,7 @@ describe('Declaration', () => {
     expect(wrapper.find(DeclarationDiff).exists()).toBe(false);
   });
 
-  it('renders a `DeclarationList` for `added` change type', () => {
+  it('renders a `DeclarationList` with `added` change type prop', () => {
     const provide = provideFactory({
       [identifier]: {
         change: ChangeTypes.added,
@@ -218,11 +216,28 @@ describe('Declaration', () => {
     const declarationList = wrapper.find(DeclarationList);
     expect(declarationList.props('changeType')).toBe(ChangeTypes.added);
     expect(declarationList.props('declaration')).toBe(propsData.declarations[0]);
-    expect(declarationList.classes()).toContain('changed');
-    expect(declarationList.classes()).toContain('changed-added');
   });
 
-  it('renders a `DeclarationList` for `deprecated` change type', () => {
+  it('passes `added` type change prop if no declarations are present in the diff ', () => {
+    const provide = provideFactory({
+      [identifier]: {
+        change: ChangeTypes.added,
+      },
+    });
+
+    wrapper = shallowMount(Declaration, {
+      propsData,
+      provide,
+    });
+
+    expect(wrapper.find(DeclarationDiff).exists()).toBe(false);
+
+    const declarationList = wrapper.find(DeclarationList);
+    expect(declarationList.props('changeType')).toBe(ChangeTypes.added);
+    expect(declarationList.props('declaration')).toBe(propsData.declarations[0]);
+  });
+
+  it('renders a `DeclarationList` with `deprecated` change type prop', () => {
     const provide = provideFactory({
       [identifier]: {
         change: ChangeTypes.deprecated,
@@ -242,28 +257,5 @@ describe('Declaration', () => {
     const declarationList = wrapper.find(DeclarationList);
     expect(declarationList.props('changeType')).toBe(ChangeTypes.deprecated);
     expect(declarationList.props('declaration')).toBe(propsData.declarations[0]);
-    expect(declarationList.classes()).toContain('changed');
-    expect(declarationList.classes()).toContain('changed-deprecated');
-  });
-
-  it('applies only `added` type change class if no declarations are present in the diff ', () => {
-    const provide = provideFactory({
-      [identifier]: {
-        change: ChangeTypes.added,
-      },
-    });
-
-    wrapper = shallowMount(Declaration, {
-      propsData,
-      provide,
-    });
-
-    expect(wrapper.find(DeclarationDiff).exists()).toBe(false);
-
-    const declarationList = wrapper.find(DeclarationList);
-    expect(declarationList.props('changeType')).toBe(ChangeTypes.added);
-    expect(declarationList.props('declaration')).toBe(propsData.declarations[0]);
-    expect(declarationList.classes()).toContain('changed');
-    expect(declarationList.classes()).toContain('changed-added');
   });
 });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationDiff.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationDiff.spec.js
@@ -39,13 +39,11 @@ describe('DeclarationDiff', () => {
     expect(currentLists.at(0).props()).toEqual({
       declaration: propsData.changes.declaration.new[0],
       shouldCaption: true,
-      changeType: 'modified',
       declListExpanded: false,
     });
     expect(currentLists.at(1).props()).toEqual({
       declaration: propsData.changes.declaration.new[1],
       shouldCaption: true,
-      changeType: 'modified',
       declListExpanded: false,
     });
 
@@ -55,7 +53,6 @@ describe('DeclarationDiff', () => {
     expect(previousLists.at(0).props()).toEqual({
       declaration: propsData.changes.declaration.previous[0],
       shouldCaption: false, // false because we only have one declaration in the group
-      changeType: 'modified',
       declListExpanded: false,
     });
   });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationGroup.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationGroup.spec.js
@@ -1,0 +1,94 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2024 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+import DeclarationGroup from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationGroup.vue';
+import { shallowMount } from '@vue/test-utils';
+import DeclarationSource
+  from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue';
+import { multipleLinesClass } from 'docc-render/constants/multipleLines';
+
+const propsData = {
+  declaration: {
+    platforms: ['iOS', 'tvOS', 'watchOS'],
+    tokens: [
+      { type: 'text', text: 'foo' },
+    ],
+  },
+  shouldCaption: true,
+  changeType: '',
+};
+
+const store = {
+  state: {
+    references: {
+      'doc://boo': { url: 'url-boo' },
+    },
+  },
+};
+
+const provide = {
+  interfaceLanguage: 'swift',
+  languages: new Set(['swift', 'occ']),
+  store,
+};
+
+describe('DeclarationGroup', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowMount(DeclarationGroup, {
+      propsData,
+      provide,
+    });
+  });
+
+  it('renders a platforms label for each variant', () => {
+    const labels = wrapper.find('.platforms');
+    expect(labels.text()).toBe('iOS, tvOS, watchOS');
+  });
+
+  it('does not render a caption label if `shouldCaption` is false', () => {
+    wrapper = shallowMount(DeclarationGroup, {
+      propsData: {
+        ...propsData,
+        shouldCaption: false,
+      },
+      provide,
+    });
+
+    const labels = wrapper.find('.platforms');
+    expect(labels.exists()).toBe(false);
+  });
+
+  it('renders a `Source` for each variant', () => {
+    const source = wrapper.find(DeclarationSource);
+    expect(source.props('tokens')).toEqual(propsData.declaration.tokens);
+  });
+
+  it('renders the `Source`', () => {
+    const srcComponent = wrapper.find(DeclarationSource);
+    expect(srcComponent.props('language')).toEqual('swift');
+  });
+
+  it('applies the `multipleLinesClass` class if `displaysMultipleLinesAfterAPIChanges` is true', () => {
+    wrapper = shallowMount({
+      ...DeclarationGroup,
+      computed: {
+        ...DeclarationGroup.computed,
+        displaysMultipleLinesAfterAPIChanges: () => true,
+      },
+    },
+    {
+      propsData,
+      provide,
+    });
+
+    expect(wrapper.classes()).toContain(multipleLinesClass);
+  });
+});


### PR DESCRIPTION
- **Explanation:** Other declaration pills should be clickable when there are changes data 
- **Scope:** Impacts logic rendering Declaration pills
- **Issue:** rdar://127125451
- **Risk:** Medium, refactors declaration logic
- **Testing:** Updated unit tests, manually tested
- **Reviewer:** @mportiz08   
- **Original PR:** #832 