### PR TITLE
Inactivate known external links [alternate approach]

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -470,7 +470,7 @@ function renderNode(createElement, references) {
           url: reference.url,
           kind: reference.kind,
           role: reference.role,
-          isActive: node.isActive,
+          isActive: reference.isFromIncludedArchive && node.isActive,
           ideTitle: reference.ideTitle,
           titleStyle: reference.titleStyle,
           hasInlineFormatting: !!titleInlineContent,

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue
@@ -19,7 +19,7 @@ export default {
   render(createElement) {
     const reference = this.references[this.identifier];
     // internal and external link
-    if (reference && reference.url) {
+    if (reference && reference.isFromIncludedArchive && reference.url) {
       return createElement(Reference, {
         props: {
           url: reference.url,

--- a/src/components/DocumentationTopic/RelationshipsList.vue
+++ b/src/components/DocumentationTopic/RelationshipsList.vue
@@ -21,6 +21,7 @@
         :role="symbol.role"
         :kind="symbol.kind"
         :url="symbol.url"
+        :isActive="symbol.isFromIncludedArchive"
       >{{symbol.title}}</Reference>
       <WordBreak v-else tag="code">{{symbol.title}}</WordBreak>
       <ConditionalConstraints

--- a/src/components/Navigator/NavigatorDataProvider.vue
+++ b/src/components/Navigator/NavigatorDataProvider.vue
@@ -11,6 +11,7 @@
 <script>
 import { fetchIndexPathsData } from 'docc-render/utils/data';
 import { flattenNestedData } from 'docc-render/utils/navigatorData';
+import AppStore from 'docc-render/stores/AppStore';
 import Language from 'docc-render/constants/Language';
 
 /**
@@ -88,11 +89,16 @@ export default {
     async fetchIndexData() {
       try {
         this.isFetching = true;
-        const { interfaceLanguages, references } = await fetchIndexPathsData(
+        const {
+          includedArchiveIdentifiers = [],
+          interfaceLanguages,
+          references,
+        } = await fetchIndexPathsData(
           { slug: this.$route.params.locale || '' },
         );
         this.navigationIndex = Object.freeze(interfaceLanguages);
         this.navigationReferences = Object.freeze(references);
+        AppStore.setIncludedArchiveIdentifiers(includedArchiveIdentifiers);
       } catch (e) {
         this.errorFetching = true;
       } finally {

--- a/src/mixins/referencesProvider.js
+++ b/src/mixins/referencesProvider.js
@@ -7,6 +7,7 @@
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
+import AppStore from 'docc-render/stores/AppStore';
 
 export default {
   // inject the `store`
@@ -21,8 +22,37 @@ export default {
       }),
     },
   },
+  data: () => ({ appState: AppStore.state }),
   computed: {
     // exposes the references for the current page
-    references: ({ store }) => store.state.references,
+    references() {
+      const {
+        isFromIncludedArchive,
+        store: {
+          state: { references: originalRefs = {} },
+        },
+      } = this;
+      // if present, use `includedArchiveIdentifiers` data to determine which
+      // references should still be considered active or not
+      return Object.keys(originalRefs).reduce((newRefs, id) => ({
+        ...newRefs,
+        [id]: {
+          ...originalRefs[id],
+          isFromIncludedArchive: isFromIncludedArchive(id),
+        },
+      }), {});
+    },
+  },
+  methods: {
+    isFromIncludedArchive(id) {
+      const { includedArchiveIdentifiers = [] } = this.appState;
+      if (!includedArchiveIdentifiers.length) {
+        return true;
+      }
+
+      return includedArchiveIdentifiers.some(archiveId => (
+        id?.startsWith(`doc://${archiveId}`)
+      ));
+    },
   },
 };

--- a/src/mixins/referencesProvider.js
+++ b/src/mixins/referencesProvider.js
@@ -46,6 +46,8 @@ export default {
   methods: {
     isFromIncludedArchive(id) {
       const { includedArchiveIdentifiers = [] } = this.appState;
+      // for backwards compatibility purposes, treat all references as being
+      // from included archives if there is no data for it
       if (!includedArchiveIdentifiers.length) {
         return true;
       }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -30,6 +30,7 @@ export default {
     supportsAutoColorScheme,
     systemColorScheme: ColorScheme.light,
     availableLocales: [],
+    includedArchiveIdentifiers: [],
   },
   reset() {
     this.state.imageLoadingStrategy = process.env.VUE_APP_TARGET === 'ide'
@@ -37,6 +38,7 @@ export default {
     this.state.preferredColorScheme = Settings.preferredColorScheme || defaultColorScheme;
     this.state.supportsAutoColorScheme = supportsAutoColorScheme;
     this.state.systemColorScheme = ColorScheme.light;
+    this.state.includedArchiveIdentifiers = [];
   },
   setImageLoadingStrategy(strategy) {
     this.state.imageLoadingStrategy = strategy;
@@ -58,6 +60,9 @@ export default {
   },
   setSystemColorScheme(value) {
     this.state.systemColorScheme = value;
+  },
+  setIncludedArchiveIdentifiers(value) {
+    this.state.includedArchiveIdentifiers = value;
   },
   syncPreferredColorScheme() {
     if (!!Settings.preferredColorScheme

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -9,6 +9,7 @@
 */
 
 import { shallowMount, mount } from '@vue/test-utils';
+import AppStore from 'docc-render/stores/AppStore';
 import Aside from 'docc-render/components/ContentNode/Aside.vue';
 import CodeListing from 'docc-render/components/ContentNode/CodeListing.vue';
 import CodeVoice from 'docc-render/components/ContentNode/CodeVoice.vue';
@@ -1296,6 +1297,43 @@ describe('ContentNode', () => {
 
       const reference = wrapper.find('.content');
       expect(reference.isEmpty()).toBe(true);
+    });
+
+    it('sets `isActive` for included archive content', () => {
+      const foo = {
+        identifier: 'doc://Foo/documentation/foo',
+        title: 'Foo',
+        url: '/documentation/foo',
+      };
+      const mountRef = (props = {}) => mountWithItem({
+        type: 'reference',
+        identifier: foo.identifier,
+        ...props,
+      }, {
+        [foo.identifier]: foo,
+      });
+
+      const wrapper1 = mountRef();
+      const ref1 = wrapper1.find('.content').find(Reference);
+      expect(ref1.exists()).toBe(true);
+      expect(ref1.props('isActive')).toBe(true);
+
+      AppStore.setIncludedArchiveIdentifiers(['Bar']);
+      const wrapper2 = mountRef();
+      const ref2 = wrapper2.find('.content').find(Reference);
+      expect(ref2.exists()).toBe(true);
+      expect(ref2.props('isActive')).toBe(false);
+
+      AppStore.setIncludedArchiveIdentifiers(['Bar', 'Foo']);
+      const wrapper3 = mountRef();
+      const ref3 = wrapper3.find('.content').find(Reference);
+      expect(ref3.exists()).toBe(true);
+      expect(ref3.props('isActive')).toBe(true);
+
+      const wrapper4 = mountRef({ isActive: false });
+      const ref4 = wrapper4.find('.content').find(Reference);
+      expect(ref4.exists()).toBe(true);
+      expect(ref4.props('isActive')).toBe(false);
     });
   });
 

--- a/tests/unit/components/ContentNode/LinksBlock.spec.js
+++ b/tests/unit/components/ContentNode/LinksBlock.spec.js
@@ -41,7 +41,7 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(LinksBlock
 describe('LinksBlock', () => {
   it('renders the LinksBlock', () => {
     const wrapper = createWrapper();
-    expect(wrapper.find(TopicsLinkCardGrid).props()).toEqual({
+    expect(wrapper.find(TopicsLinkCardGrid).props()).toMatchObject({
       items: [references.foo, references.bar],
       topicStyle: defaultProps.blockStyle,
       usePager: false,
@@ -60,7 +60,7 @@ describe('LinksBlock', () => {
     // they are two, because one does not have a reference object
     const linkBlocks = wrapper.findAll(TopicsLinkBlock);
     expect(linkBlocks).toHaveLength(2);
-    expect(linkBlocks.at(0).props('topic')).toEqual(references.foo);
-    expect(linkBlocks.at(1).props('topic')).toEqual(references.bar);
+    expect(linkBlocks.at(0).props('topic')).toMatchObject(references.foo);
+    expect(linkBlocks.at(1).props('topic')).toMatchObject(references.bar);
   });
 });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.spec.js
@@ -9,13 +9,14 @@
 */
 
 import { shallowMount } from '@vue/test-utils';
+import AppStore from 'docc-render/stores/AppStore';
 import LinkableToken
   from 'docc-render/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
 
 describe('LinkableToken', () => {
   const foo = {
-    identifier: 'foo',
+    identifier: 'doc://Foo/documentation/foo',
     title: 'Foo',
     url: '/documentation/foo',
   };
@@ -69,5 +70,45 @@ describe('LinkableToken', () => {
     expect(link.exists()).toBe(true);
     expect(link.props('url')).toBe(foo.url);
     expect(link.text()).toBe(foo.title);
+  });
+
+  it('renders a link for references to included archive content', () => {
+    AppStore.setIncludedArchiveIdentifiers(['Foo']);
+    const wrapper = shallowMount(LinkableToken, {
+      ...defaultOpts,
+      provide: {
+        store: {
+          state: {
+            references: {
+              [foo.identifier]: foo,
+            },
+          },
+        },
+      },
+    });
+
+    const link = wrapper.find(Reference);
+    expect(link.exists()).toBe(true);
+    expect(link.props('url')).toBe(foo.url);
+    expect(link.text()).toBe(foo.title);
+  });
+
+  it('renders a span for references to non-included archive content', () => {
+    AppStore.setIncludedArchiveIdentifiers(['Bar']);
+    const wrapper = shallowMount(LinkableToken, {
+      ...defaultOpts,
+      provide: {
+        store: {
+          state: {
+            references: {
+              [foo.identifier]: foo,
+            },
+          },
+        },
+      },
+    });
+
+    expect(wrapper.is('span')).toBe(true);
+    expect(wrapper.text()).toBe(foo.title);
   });
 });

--- a/tests/unit/components/DocumentationTopic/Relationships.spec.js
+++ b/tests/unit/components/DocumentationTopic/Relationships.spec.js
@@ -91,10 +91,8 @@ describe('Relationships', () => {
     expect(firstSection.props('anchor')).toBe(propsData.sections[0].anchor);
     const firstList = firstSection.find(List);
     expect(firstList.exists()).toBe(true);
-    expect(firstList.props('symbols')).toEqual([
-      foo,
-      bar,
-    ]);
+    expect(firstList.props('symbols')[0]).toMatchObject(foo);
+    expect(firstList.props('symbols')[1]).toMatchObject(bar);
     expect(firstList.props('type')).toEqual('inheritsFrom');
 
     const lastSection = sections.at(1);
@@ -102,7 +100,7 @@ describe('Relationships', () => {
     expect(lastSection.props('anchor')).toBe(null);
     const lastList = lastSection.find(List);
     expect(lastList.exists()).toBe(true);
-    expect(lastList.props('symbols')).toEqual([baz]);
+    expect(lastList.props('symbols')[0]).toMatchObject(baz);
     expect(firstList.props('type')).toEqual('inheritsFrom');
   });
 });

--- a/tests/unit/components/DocumentationTopic/TopicsLinkCardGridItem.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsLinkCardGridItem.spec.js
@@ -124,7 +124,7 @@ describe('TopicsLinkCardGridItem', () => {
         },
       },
     });
-    expect(wrapper.find(TopicTypeIcon).props('imageOverride')).toEqual(iconRef);
+    expect(wrapper.find(TopicTypeIcon).props('imageOverride')).toMatchObject(iconRef);
   });
 
   it('renders a TopicsLinkCardGridItem, in a none compact variant', async () => {

--- a/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/TopicsTable.spec.js
@@ -116,7 +116,7 @@ describe('TopicsTable', () => {
     const firstSectionBlocks = sections.at(0).findAll(TopicsLinkBlock);
     expect(firstSectionBlocks.length).toBe(1);
     expect(firstSectionBlocks.at(0).classes('topic')).toBe(true);
-    expect(firstSectionBlocks.at(0).props()).toEqual({
+    expect(firstSectionBlocks.at(0).props()).toMatchObject({
       topic: foo,
       isSymbolDeprecated: false,
       isSymbolBeta: false,
@@ -125,7 +125,7 @@ describe('TopicsTable', () => {
     const lastSectionBlocks = sections.at(1).findAll(TopicsLinkBlock);
     expect(lastSectionBlocks.length).toBe(1);
     expect(lastSectionBlocks.at(0).classes('topic')).toBe(true);
-    expect(lastSectionBlocks.at(0).props()).toEqual({
+    expect(lastSectionBlocks.at(0).props()).toMatchObject({
       topic: baz,
       isSymbolDeprecated: false,
       isSymbolBeta: false,
@@ -139,7 +139,7 @@ describe('TopicsTable', () => {
 
     const firstGrid = sections.at(0).find(TopicsLinkCardGrid);
     expect(firstGrid.classes('topic')).toBe(true);
-    expect(firstGrid.props()).toEqual({
+    expect(firstGrid.props()).toMatchObject({
       topicStyle: TopicSectionsStyle.compactGrid,
       items: [foo],
       usePager: false,
@@ -147,7 +147,7 @@ describe('TopicsTable', () => {
 
     const secondGrid = sections.at(1).find(TopicsLinkCardGrid);
     expect(secondGrid.classes('topic')).toBe(true);
-    expect(secondGrid.props()).toEqual({
+    expect(secondGrid.props()).toMatchObject({
       topicStyle: TopicSectionsStyle.compactGrid,
       items: [baz],
       usePager: false,

--- a/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
+++ b/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
@@ -10,6 +10,7 @@
 
 import NavigatorDataProvider from '@/components/Navigator/NavigatorDataProvider.vue';
 import { shallowMount } from '@vue/test-utils';
+import AppStore from 'docc-render/stores/AppStore';
 import Language from 'docc-render/constants/Language';
 import { TopicTypes } from '@/constants/TopicTypes';
 import { fetchIndexPathsData } from '@/utils/data';
@@ -127,7 +128,13 @@ const references = {
   foo: { bar: 'bar' },
 };
 
+const includedArchiveIdentifiers = [
+  'foo',
+  'bar',
+];
+
 const response = {
+  includedArchiveIdentifiers,
   interfaceLanguages: {
     [Language.swift.key.url]: [
       swiftIndexOne,
@@ -172,6 +179,10 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(NavigatorD
 describe('NavigatorDataProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    AppStore.reset();
   });
 
   it('fetches data when mounting NavigatorDataProvider', async () => {
@@ -551,5 +562,13 @@ describe('NavigatorDataProvider', () => {
         uid: -827353283,
       },
     ]);
+  });
+
+  it('sets `includedArchiveIdentifiers` state in the app store', async () => {
+    expect(AppStore.state.includedArchiveIdentifiers).toEqual([]);
+    fetchIndexPathsData.mockResolvedValue(response);
+    createWrapper();
+    await flushPromises();
+    expect(AppStore.state.includedArchiveIdentifiers).toEqual(includedArchiveIdentifiers);
   });
 });

--- a/tests/unit/components/ReferenceUrlProvider.spec.js
+++ b/tests/unit/components/ReferenceUrlProvider.spec.js
@@ -53,7 +53,7 @@ describe('ReferenceUrlProvider', () => {
 
     const reference = references['doc://com.example.Test/tutorials/TechnologyX/Getting-Started'];
 
-    expect(assertProps).toEqual({
+    expect(assertProps).toMatchObject({
       title: reference.title,
       url: reference.url,
       urlWithParams: `${reference.url}?context=foo`,

--- a/tests/unit/components/Tutorial/Hero.spec.js
+++ b/tests/unit/components/Tutorial/Hero.spec.js
@@ -112,7 +112,7 @@ describe('Hero', () => {
     const metadata = wrapper.find(HeroMetadata);
     expect(metadata.props('estimatedTimeInMinutes')).toBe(estimatedTimeInMinutes);
     expect(metadata.props('projectFilesUrl')).toBe(projectFilesUrl);
-    expect(metadata.props('xcodeRequirement')).toEqual(xcodeRequirementReference);
+    expect(metadata.props('xcodeRequirement')).toMatchObject(xcodeRequirementReference);
   });
 
   it('renders a div for the background and selects the light variant', () => {

--- a/tests/unit/stores/AppStore.spec.js
+++ b/tests/unit/stores/AppStore.spec.js
@@ -22,6 +22,7 @@ describe('AppStore', () => {
       systemColorScheme: ColorScheme.light,
       preferredLocale: null,
       availableLocales: [],
+      includedArchiveIdentifiers: [],
     });
   });
 
@@ -37,6 +38,7 @@ describe('AppStore', () => {
       systemColorScheme: ColorScheme.light,
       preferredLocale: null,
       availableLocales: [],
+      includedArchiveIdentifiers: [],
     });
 
     // restore target
@@ -72,11 +74,20 @@ describe('AppStore', () => {
     });
   });
 
+  describe('setIncludedArchiveIdentifiers', () => {
+    it('sets the included archive identifiers', () => {
+      const includedArchiveIdentifiers = ['foo', 'bar'];
+      AppStore.setIncludedArchiveIdentifiers(includedArchiveIdentifiers);
+      expect(AppStore.state.includedArchiveIdentifiers).toEqual(includedArchiveIdentifiers);
+    });
+  });
+
   it('resets the state', () => {
     AppStore.setImageLoadingStrategy(ImageLoadingStrategy.eager);
     AppStore.setPreferredColorScheme(ColorScheme.auto);
     AppStore.setSystemColorScheme(ColorScheme.dark);
     AppStore.syncPreferredColorScheme();
+    AppStore.setIncludedArchiveIdentifiers(['a']);
     AppStore.reset();
 
     expect(AppStore.state).toEqual({
@@ -86,6 +97,7 @@ describe('AppStore', () => {
       systemColorScheme: ColorScheme.light,
       preferredLocale: null,
       availableLocales: [],
+      includedArchiveIdentifiers: [],
     });
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 118834404

## Summary

This adds logic to inactivate links to pages from other targets unless they have been included in the same combined archive.

## Dependencies

https://github.com/apple/swift-docc-plugin/pull/84

## Testing

You can use the archives from this fixture for the convenience of testing purposes:
[archives.zip](https://github.com/user-attachments/files/15996968/archives.zip)

Steps:
1. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/Combined\ ExternalLinks\ Documentation.doccarchive npm run serve` and open http://localhost:8080/documentation/outer/outerclass/dosomething(with:)
2. Verify that all the links to "Inner" pages work, including in the declaration
3. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/Outer.doccarchive npm run serve` and open http://localhost:8080/documentation/outer/outerclass/dosomething(with:)
4. Verify that all the links to "Inner" pages are no longer linked
5. Check for any other regressions with links and linked declaration types using other fixture content.

Known issues:
Due to the way that the Render JSON and Navigator JSON are loaded independently by the renderer, it's possible that the links in step 4 may be initially linked for a very brief moment until the navigator has finished loading. I've discussed this with @d-ronnqvist, and this limitation is acceptable for now given the way that things are structured.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
