### PR TITLE
It does not render the NavigatorCard if children are not ready

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -14,6 +14,7 @@
     class="navigator"
   >
     <NavigatorCard
+      v-if="flatChildren.length"
       v-show="!isFetching"
       v-bind="technologyProps"
       :type="type"

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -14,6 +14,7 @@ import NavigatorCard from '@/components/Navigator/NavigatorCard.vue';
 import { baseNavStickyAnchorId } from 'docc-render/constants/nav';
 import { TopicTypes } from '@/constants/TopicTypes';
 import { INDEX_ROOT_KEY } from '@/constants/sidebar';
+import { flattenNestedData } from 'docc-render/utils/navigatorData';
 
 jest.mock('docc-render/utils/throttle', () => jest.fn(v => v));
 
@@ -105,7 +106,7 @@ const defaultProps = {
   scrollLockID: 'foo',
   renderFilterOnTop: false,
   navigatorReferences,
-  flatChildren: [],
+  flatChildren: flattenNestedData(technology.children),
 };
 
 const fauxAnchor = document.createElement('DIV');
@@ -139,7 +140,7 @@ describe('Navigator', () => {
     expect(wrapper.find(NavigatorCard).props()).toEqual({
       activePath: [references.first.url, references.second.url, mocks.$route.path],
       // will assert in another test
-      children: [],
+      children: defaultProps.flatChildren,
       type: TopicTypes.module,
       technology: technology.title,
       technologyPath: technology.path,
@@ -151,6 +152,15 @@ describe('Navigator', () => {
       navigatorReferences,
       hideAvailableTags: false,
     });
+  });
+
+  it('does not render the NavigatorCard if children are not ready', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        flatChildren: [],
+      },
+    });
+    expect(wrapper.find(NavigatorCard).exists()).toBe(false);
   });
 
   it('renders an aria live that tells VO users when navigator is loading', () => {
@@ -201,7 +211,7 @@ describe('Navigator', () => {
     expect(wrapper.find(NavigatorCard).props()).toEqual({
       activePath: [references.first.url, references.second.url, mocks.$route.path],
       // will assert in another test
-      children: [],
+      children: defaultProps.flatChildren,
       type: TopicTypes.module,
       technology: fallbackTechnology.title,
       technologyPath: fallbackTechnology.url,


### PR DESCRIPTION
Bug/issue #130779044, if applicable: 

## Summary

It does not render the NavigatorCard if children are not ready

## Dependencies

NA

## Testing

Steps:
1. Run any doccarchive with a navigator
2. Assert that everything works as expected

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
