### PR TITLE
[6.0] Inactivate known external links 

### DIFF
--- a/src/components/ContentNode/Reference.vue
+++ b/src/components/ContentNode/Reference.vue
@@ -54,6 +54,9 @@ export default {
   name: 'Reference',
   computed: {
     isInternal({ url }) {
+      if (!url) {
+        return false;
+      }
       if (!url.startsWith('/') && !url.startsWith('#')) {
         // If the URL has a scheme, it's not an internal link.
         return false;
@@ -92,7 +95,7 @@ export default {
   props: {
     url: {
       type: String,
-      required: true,
+      required: false,
     },
     kind: {
       type: String,

--- a/src/components/ContentNode/ReferenceExternal.vue
+++ b/src/components/ContentNode/ReferenceExternal.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <a v-if="isActive" :href="url"><slot /></a>
+  <a v-if="url && isActive" :href="url"><slot /></a>
   <span v-else><slot /></span>
 </template>
 
@@ -19,7 +19,7 @@ export default {
   props: {
     url: {
       type: String,
-      required: true,
+      required: false,
     },
     isActive: {
       type: Boolean,

--- a/src/components/ContentNode/ReferenceInternal.vue
+++ b/src/components/ContentNode/ReferenceInternal.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <router-link v-if="isActive" :to="url"><slot /></router-link>
+  <router-link v-if="url && isActive" :to="url"><slot /></router-link>
   <span v-else><slot/></span>
 </template>
 
@@ -19,7 +19,7 @@ export default {
   props: {
     url: {
       type: String,
-      required: true,
+      required: false,
     },
     isActive: {
       type: Boolean,

--- a/src/components/Navigator/NavigatorDataProvider.vue
+++ b/src/components/Navigator/NavigatorDataProvider.vue
@@ -11,6 +11,7 @@
 <script>
 import { fetchIndexPathsData } from 'docc-render/utils/data';
 import { flattenNestedData } from 'docc-render/utils/navigatorData';
+import AppStore from 'docc-render/stores/AppStore';
 import Language from 'docc-render/constants/Language';
 
 /**
@@ -88,11 +89,16 @@ export default {
     async fetchIndexData() {
       try {
         this.isFetching = true;
-        const { interfaceLanguages, references } = await fetchIndexPathsData(
+        const {
+          includedArchiveIdentifiers = [],
+          interfaceLanguages,
+          references,
+        } = await fetchIndexPathsData(
           { slug: this.$route.params.locale || '' },
         );
         this.navigationIndex = Object.freeze(interfaceLanguages);
         this.navigationReferences = Object.freeze(references);
+        AppStore.setIncludedArchiveIdentifiers(includedArchiveIdentifiers);
       } catch (e) {
         this.errorFetching = true;
       } finally {

--- a/src/mixins/referencesProvider.js
+++ b/src/mixins/referencesProvider.js
@@ -7,6 +7,7 @@
  * See https://swift.org/LICENSE.txt for license information
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
+import AppStore from 'docc-render/stores/AppStore';
 
 export default {
   // inject the `store`
@@ -21,8 +22,39 @@ export default {
       }),
     },
   },
+  data: () => ({ appState: AppStore.state }),
   computed: {
     // exposes the references for the current page
-    references: ({ store }) => store.state.references,
+    references() {
+      const {
+        isFromIncludedArchive,
+        store: {
+          state: { references: originalRefs = {} },
+        },
+      } = this;
+      // strip the `url` key from refs if their identifier comes from an
+      // archive that hasn't been included by DocC
+      return Object.keys(originalRefs).reduce((newRefs, id) => {
+        const { url, ...refWithoutUrl } = originalRefs[id];
+        return {
+          ...newRefs,
+          [id]: isFromIncludedArchive(id) ? originalRefs[id] : refWithoutUrl,
+        };
+      }, {});
+    },
+  },
+  methods: {
+    isFromIncludedArchive(id) {
+      const { includedArchiveIdentifiers = [] } = this.appState;
+      // for backwards compatibility purposes, treat all references as being
+      // from included archives if there is no data for it
+      if (!includedArchiveIdentifiers.length) {
+        return true;
+      }
+
+      return includedArchiveIdentifiers.some(archiveId => (
+        id?.startsWith(`doc://${archiveId}/`)
+      ));
+    },
   },
 };

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -30,6 +30,7 @@ export default {
     supportsAutoColorScheme,
     systemColorScheme: ColorScheme.light,
     availableLocales: [],
+    includedArchiveIdentifiers: [],
   },
   reset() {
     this.state.imageLoadingStrategy = process.env.VUE_APP_TARGET === 'ide'
@@ -37,6 +38,7 @@ export default {
     this.state.preferredColorScheme = Settings.preferredColorScheme || defaultColorScheme;
     this.state.supportsAutoColorScheme = supportsAutoColorScheme;
     this.state.systemColorScheme = ColorScheme.light;
+    this.state.includedArchiveIdentifiers = [];
   },
   setImageLoadingStrategy(strategy) {
     this.state.imageLoadingStrategy = strategy;
@@ -58,6 +60,9 @@ export default {
   },
   setSystemColorScheme(value) {
     this.state.systemColorScheme = value;
+  },
+  setIncludedArchiveIdentifiers(value) {
+    this.state.includedArchiveIdentifiers = value;
   },
   syncPreferredColorScheme() {
     if (!!Settings.preferredColorScheme

--- a/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
+++ b/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
@@ -10,6 +10,7 @@
 
 import NavigatorDataProvider from '@/components/Navigator/NavigatorDataProvider.vue';
 import { shallowMount } from '@vue/test-utils';
+import AppStore from 'docc-render/stores/AppStore';
 import Language from 'docc-render/constants/Language';
 import { TopicTypes } from '@/constants/TopicTypes';
 import { fetchIndexPathsData } from '@/utils/data';
@@ -127,7 +128,13 @@ const references = {
   foo: { bar: 'bar' },
 };
 
+const includedArchiveIdentifiers = [
+  'foo',
+  'bar',
+];
+
 const response = {
+  includedArchiveIdentifiers,
   interfaceLanguages: {
     [Language.swift.key.url]: [
       swiftIndexOne,
@@ -172,6 +179,10 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(NavigatorD
 describe('NavigatorDataProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    AppStore.reset();
   });
 
   it('fetches data when mounting NavigatorDataProvider', async () => {
@@ -551,5 +562,13 @@ describe('NavigatorDataProvider', () => {
         uid: -827353283,
       },
     ]);
+  });
+
+  it('sets `includedArchiveIdentifiers` state in the app store', async () => {
+    expect(AppStore.state.includedArchiveIdentifiers).toEqual([]);
+    fetchIndexPathsData.mockResolvedValue(response);
+    createWrapper();
+    await flushPromises();
+    expect(AppStore.state.includedArchiveIdentifiers).toEqual(includedArchiveIdentifiers);
   });
 });

--- a/tests/unit/mixins/referencesProvider.spec.js
+++ b/tests/unit/mixins/referencesProvider.spec.js
@@ -1,0 +1,121 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2024 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+import { shallowMount } from '@vue/test-utils';
+import referencesProvider from 'docc-render/mixins/referencesProvider';
+
+const FakeComponentInner = {
+  name: 'FakeComponentInner',
+  props: ['references'],
+  render() {
+    return null;
+  },
+};
+
+const FakeComponentOuter = {
+  name: 'FakeComponentOuter',
+  mixins: [referencesProvider],
+  render(createElement) {
+    return createElement(FakeComponentInner, {
+      props: {
+        references: this.references,
+      },
+    });
+  },
+};
+
+const aa = {
+  identifier: 'doc://A/documentation/A/a',
+  url: '/documentation/A/a',
+  title: 'A.A',
+};
+const ab = {
+  identifier: 'doc://A/documentation/A/b',
+  url: '/documentation/A/b',
+  title: 'A.B',
+};
+const bb = {
+  identifier: 'doc://B/documentation/B/b',
+  url: '/documentation/B/b',
+  title: 'B.B',
+};
+const bbb = {
+  identifier: 'doc://BB/documentation/BB/b',
+  url: '/documentation/BB/b',
+  title: 'BB.B',
+};
+
+const references = {
+  [aa.identifier]: aa,
+  [ab.identifier]: ab,
+  [bb.identifier]: bb,
+  [bbb.identifier]: bbb,
+};
+
+const provide = {
+  store: {
+    state: { references },
+  },
+};
+
+const createOuter = (opts = { provide }) => shallowMount(FakeComponentOuter, opts);
+
+describe('referencesProvider', () => {
+  it('provides a store with a default state', () => {
+    const outer = createOuter({});
+    const inner = outer.find(FakeComponentInner);
+    expect(inner.exists()).toBe(true);
+    expect(inner.props('references')).toEqual({});
+  });
+
+  it('provides references from a store', () => {
+    const outer = createOuter();
+    const inner = outer.find(FakeComponentInner);
+    expect(inner.exists()).toBe(true);
+    expect(inner.props('references')).toEqual(references);
+  });
+
+  it('removes `url` data for refs with non-empty `includedArchiveIdentifiers` app state', () => {
+    // empty `includedArchiveIdentifiers` — no changes to refs
+    const outer = createOuter();
+    let inner = outer.find(FakeComponentInner);
+    expect(inner.exists()).toBe(true);
+    expect(inner.props('references')).toEqual(references);
+
+    // `includedArchiveIdentifiers` contains all refs - no changes to refs
+    outer.setData({
+      appState: {
+        includedArchiveIdentifiers: ['A', 'B', 'BB'],
+      },
+    });
+    inner = outer.find(FakeComponentInner);
+    expect(inner.exists()).toBe(true);
+    expect(inner.props('references')).toEqual(references);
+
+    // `includedArchiveIdentifiers` only contains archive B — remove `url` field
+    // from all non-B refs
+    outer.setData({
+      appState: {
+        includedArchiveIdentifiers: ['B'],
+      },
+    });
+    inner = outer.find(FakeComponentInner);
+    expect(inner.exists()).toBe(true);
+    const refs3 = inner.props('references');
+    expect(refs3).not.toEqual(references);
+    expect(refs3[aa.identifier].title).toBe(aa.title);
+    expect(refs3[aa.identifier].url).toBeFalsy(); // aa `url` is gone now
+    expect(refs3[ab.identifier].title).toBe(ab.title);
+    expect(refs3[ab.identifier].url).toBeFalsy(); // ab `url` is gone now
+    expect(refs3[bb.identifier].title).toBe(bb.title);
+    expect(refs3[bb.identifier].url).toBe(bb.url); // bb still has `url`
+    expect(refs3[bbb.identifier].title).toBe(bbb.title);
+    expect(refs3[bbb.identifier].url).toBeFalsy(); // bbb `url` is gone now
+  });
+});

--- a/tests/unit/stores/AppStore.spec.js
+++ b/tests/unit/stores/AppStore.spec.js
@@ -22,6 +22,7 @@ describe('AppStore', () => {
       systemColorScheme: ColorScheme.light,
       preferredLocale: null,
       availableLocales: [],
+      includedArchiveIdentifiers: [],
     });
   });
 
@@ -37,6 +38,7 @@ describe('AppStore', () => {
       systemColorScheme: ColorScheme.light,
       preferredLocale: null,
       availableLocales: [],
+      includedArchiveIdentifiers: [],
     });
 
     // restore target
@@ -72,11 +74,20 @@ describe('AppStore', () => {
     });
   });
 
+  describe('setIncludedArchiveIdentifiers', () => {
+    it('sets the included archive identifiers', () => {
+      const includedArchiveIdentifiers = ['foo', 'bar'];
+      AppStore.setIncludedArchiveIdentifiers(includedArchiveIdentifiers);
+      expect(AppStore.state.includedArchiveIdentifiers).toEqual(includedArchiveIdentifiers);
+    });
+  });
+
   it('resets the state', () => {
     AppStore.setImageLoadingStrategy(ImageLoadingStrategy.eager);
     AppStore.setPreferredColorScheme(ColorScheme.auto);
     AppStore.setSystemColorScheme(ColorScheme.dark);
     AppStore.syncPreferredColorScheme();
+    AppStore.setIncludedArchiveIdentifiers(['a']);
     AppStore.reset();
 
     expect(AppStore.state).toEqual({
@@ -86,6 +97,7 @@ describe('AppStore', () => {
       systemColorScheme: ColorScheme.light,
       preferredLocale: null,
       availableLocales: [],
+      includedArchiveIdentifiers: [],
     });
   });
 });


### PR DESCRIPTION
On behalf of @mportiz08 
- **Explanation:** Inactive links to pages from other targets unless they have been included in the same combined archive
- **Scope:** Impacts all links in the renderer 
- **Issue:** rdar://118834404
- **Risk:** Small
- **Testing:** Updated unit tests, manually test
- **Reviewer:** @hqhhuang  
- **Original PR:** https://github.com/swiftlang/swift-docc-render/pull/878
