### PR TITLE
Revert "Prevent NavigatorCard from re-render when fetching data" #865

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -14,7 +14,7 @@
     class="navigator"
   >
     <NavigatorCard
-      v-show="!isFetching"
+      v-if="!isFetching"
       v-bind="technologyProps"
       :type="type"
       :children="flatChildren"
@@ -36,7 +36,7 @@
     </NavigatorCard>
     <LoadingNavigatorCard
       @close="$emit('close')"
-      v-if="isFetching"
+      v-else
     />
     <div aria-live="polite" class="visuallyhidden">
       {{ $t('navigator.navigator-is', {

--- a/tests/unit/components/Navigator.spec.js
+++ b/tests/unit/components/Navigator.spec.js
@@ -126,15 +126,6 @@ describe('Navigator', () => {
     expect(wrapper.find(LoadingNavigatorCard).exists()).toBe(false);
   });
 
-  it('adds display:none to NavigatorCard when navigator is loading', () => {
-    const wrapper = createWrapper({
-      propsData: {
-        isFetching: true,
-      },
-    });
-    expect(wrapper.find(NavigatorCard).attributes('style')).toContain('display: none');
-  });
-
   it('renders an aria live that tells VO users when navigator is ready', () => {
     const wrapper = createWrapper();
     expect(wrapper.find('[aria-live="polite"]').exists()).toBe(true);


### PR DESCRIPTION
Bug/issue #, if applicable: 130779044

## Summary
Revert "Prevent NavigatorCard from re-render when fetching data" #865

## Testing
Steps:
1. unit test
2. Manual testing to ensure no regressions

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
