### PR TITLE
Make build-script-helper.py use python3

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -73,7 +73,10 @@ def ensure_npm_is_installed(verbose=False):
         fatal_error('-- Error: %s' % error_msg)
     try:
         node_version = check_output(['node', '--version'], verbose=verbose)
-        if not node_version.startswith('v18.16.'):
+        # Ensure node_version is a string (decode if it's bytes)
+        if isinstance(node_version, bytes):
+            node_version = node_version.decode('utf-8')
+        if not node_version.strip().startswith('v18.16.'):
             warn_msg = "Unexpected version of 'node' installed. Swift-DocC-Render requires node 18.16.1. "\
                 "See the README.md file for more information about building Swift-DocC-Render."
             printerr('-- Warning: %s' % warn_msg)


### PR DESCRIPTION
Bug/issue #156708326, if applicable: 

## Summary

By aiming to update the Node version to 22.17.0 on Swift Docker for Swift DocC Render [1], we need to specify version 3 of python, otherwise it will try to use python 2 which it's not available in Node 22.

[1] https://github.com/swiftlang/swift-docker/pull/487

## Dependencies

This change unblocks this PR in Swift Docker: https://github.com/swiftlang/swift-docker/pull/487

## Testing

Steps:
1. Make sure that SwiftCI works.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
