### PR TITLE
update build-script-helper.py to use python 3 explicitly

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
  This source file is part of the Swift.org open source project


### PR DESCRIPTION
Updating the build script helper to explicitly use python3 to unblock using later versions of the official `node` Docker image, which doesn't include `python` as an executable - only `python3`.