### PR TITLE
Add copy-to-clipboard support to code blocks

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -274,6 +274,7 @@ function renderNode(createElement, references) {
         fileType: node.fileType,
         content: node.code,
         showLineNumbers: node.showLineNumbers,
+        copyToClipboard: node.copyToClipboard ?? false,
       };
       return createElement(CodeListing, { props });
     }

--- a/src/components/Icons/CheckmarkIcon.vue
+++ b/src/components/Icons/CheckmarkIcon.vue
@@ -1,0 +1,35 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2025 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <SVGIcon
+    class="CheckmarkIcon"
+    viewBox="0 0 24 24"
+    themeId="checkmark"
+  >
+    <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
+  </SVGIcon>
+</template>
+
+<script>
+import SVGIcon from 'docc-render/components/SVGIcon.vue';
+
+export default {
+  name: 'CheckmarkIcon',
+  components: { SVGIcon },
+};
+</script>
+
+<style scoped lang="scss">
+.CheckmarkIcon {
+  opacity: 1;
+  stroke: currentColor;
+}
+</style>

--- a/src/components/Icons/CopyIcon.vue
+++ b/src/components/Icons/CopyIcon.vue
@@ -1,0 +1,37 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2025 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <SVGIcon
+    class="CopyIcon"
+    viewBox="0 0 24 24"
+    themeId="copy"
+  >
+    <title>{{ $t('icons.copy') }}</title>
+    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2
+      .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0
+      16H8V7h11v14z"/>
+  </SVGIcon>
+</template>
+
+<script>
+import SVGIcon from 'docc-render/components/SVGIcon.vue';
+
+export default {
+  name: 'CopyIcon',
+  components: { SVGIcon },
+};
+</script>
+
+<style scoped lang="scss">
+.CopyIcon {
+  opacity: 0.8;
+}
+</style>

--- a/src/components/Icons/CrossIcon.vue
+++ b/src/components/Icons/CrossIcon.vue
@@ -1,0 +1,37 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2025 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <SVGIcon
+    class="CrossIcon"
+    viewBox="0 0 24 24"
+    themeId="cross"
+  >
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41
+         10.59 12 5 17.59 6.41 19 12 13.41
+         17.59 19 19 17.59 13.41 12z"/>
+  </SVGIcon>
+</template>
+
+<script>
+import SVGIcon from 'docc-render/components/SVGIcon.vue';
+
+export default {
+  name: 'CrossIcon',
+  components: { SVGIcon },
+};
+</script>
+
+<style scoped lang="scss">
+.CrossIcon {
+  opacity: 1;
+  stroke: currentColor;
+}
+</style>

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -207,7 +207,8 @@
   "icons": {
     "clear": "Clear",
     "web-service-endpoint": "Web Service Endpoint",
-    "search": "Search"
+    "search": "Search",
+    "copy": "Copy code to clipboard"
   },
   "formats": {
     "parenthesis": "({content})",

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -101,6 +101,7 @@ describe('ContentNode', () => {
       syntax: 'swift',
       fileType: 'swift',
       code: ['foobar'],
+      copyToClipboard: false,
     };
 
     it('renders a `CodeListing`', () => {
@@ -111,6 +112,7 @@ describe('ContentNode', () => {
       expect(codeListing.props('syntax')).toBe(listing.syntax);
       expect(codeListing.props('fileType')).toBe(listing.fileType);
       expect(codeListing.props('content')).toEqual(listing.code);
+      expect(codeListing.props('copyToClipboard')).toEqual(listing.copyToClipboard);
       expect(codeListing.isEmpty()).toBe(true);
     });
 
@@ -135,6 +137,29 @@ describe('ContentNode', () => {
       expect(caption.props('title')).toBe(metadata.title);
       expect(caption.contains('p')).toBe(true);
       expect(caption.text()).toContain('blah');
+    });
+  });
+
+  describe('with type="codeListing" and copy set', () => {
+    const listing = {
+      type: 'codeListing',
+      syntax: 'swift',
+      fileType: 'swift',
+      code: ['foobar'],
+      copyToClipboard: true,
+    };
+
+    // renders a copy button
+    it('renders a copy button', () => {
+      const wrapper = mountWithItem(listing);
+
+      const codeListing = wrapper.find('.content').find(CodeListing);
+      expect(codeListing.exists()).toBe(true);
+      expect(codeListing.props('syntax')).toBe(listing.syntax);
+      expect(codeListing.props('fileType')).toBe(listing.fileType);
+      expect(codeListing.props('content')).toEqual(listing.code);
+      expect(codeListing.props('copyToClipboard')).toEqual(listing.copyToClipboard);
+      expect(codeListing.isEmpty()).toBe(true);
     });
   });
 

--- a/tests/unit/components/ContentNode/CodeListing.spec.js
+++ b/tests/unit/components/ContentNode/CodeListing.spec.js
@@ -139,6 +139,32 @@ describe('CodeListing', () => {
     expect(wrapper.html().includes('.syntax')).toBe(false);
   });
 
+  it('does not show copy button when its disabled', async () => {
+    const wrapper = shallowMount(CodeListing, {
+      propsData: {
+        syntax: 'swift',
+        content: ['let foo = "bar"'],
+        copyToClipboard: false,
+      },
+    });
+    await flushPromises();
+
+    expect(wrapper.find('.copy-button').exists()).toBe(false);
+  });
+
+  it('shows copy button when its enabled', async () => {
+    const wrapper = shallowMount(CodeListing, {
+      propsData: {
+        syntax: 'swift',
+        content: ['let foo = "bar"'],
+        copyToClipboard: true,
+      },
+    });
+    await flushPromises();
+
+    expect(wrapper.find('.copy-button').exists()).toBe(true);
+  });
+
   it('renders code with empty spaces', async () => {
     const wrapper = shallowMount(CodeListing, {
       propsData: {


### PR DESCRIPTION
## Summary

This PR adds support for a new copy-to-clipboard button in code blocks. When this feature is enabled through the `enable-experimental-code-block` flag, a copy-to-clipboard button is rendered in the top-right corner of all code blocks, allowing users to easily copy its contents. When an author does not want the contents of a code block to be copyable, a `nocopy` option can be used to disable the copy-to-clipboard button.

### User Experience

When the `enable-experimental-code-block` flag is used, a copy button will appear in the top-right corner of all code blocks. Clicking the button copies the full contents of the code block to the clipboard and displays a checkmark to confirm success. If a code block includes the `nocopy` keyword in the language line, the copy button will not appear on that code block.

### Implementation Overview

- In `swift-docc-render`, this adds `copyToClipboard` to the properties on `BlockType.codeListing`.
- Adds a copy-to-clipboard button in `CodeListing.vue`, similar to swift.org’s copy-to-clipboard button on its code blocks, when `copyToClipboard` is set to true from the feature flag `enable-experimental-code-block`. Includes a function, `copyCodeToClipboard`, to copy the contents of a code block to clipboard. 
- Adding ` ```nocopy ` disables the copy button on that code block.
- This flag is forwarded from `swift-docc`. The accompanying branch/PR is here: https://github.com/swiftlang/swift-docc/pull/1273

## Dependencies

This PR depends on associated changes in `swift-docc` to pass the parameter for the copy button.

## Testing

### Setup
1. Use the codeblock-copy branches for `swift-docc` and `swift-docc-render` with the copy-to-clipboard changes.
2. Rebuild documentation using `swift-docc` with the feature flag `enable-experimental-code-block` and serve it using a local build of `swift-docc-render`.

### How to Test
1. In all code listings with the `enable-experimental-code-block` flag, a copy button will appear in the top-right corner.
2. Click the copy icon. The code should be copied to your clipboard and the icon should update to a checkmark briefly. Paste to verify the copy functionality works.

To disable the copy icon with the feature flag enabled:
1. In any code listing using ` ``` ` or by adding a code listing, add the `nocopy` option like this:

``````
﻿```swift, nocopy
﻿print(“Hello, world!”)
﻿```
``````
﻿or like this:
``````
﻿```nocopy
﻿print(“Hello, world!”)
﻿```
``````
﻿
2. Verify the copy button does not appear on this code block.
<img width="1575" height="887" alt="Screenshot 2025-08-11 at 5 47 54 PM" src="https://github.com/user-attachments/assets/8086a90d-d0cf-4430-8e3f-1601cffba73e" />

## Checklist

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary – On my DocC PR, I updated `RenderNode.spec.json` to include `copyToClipboard` as a property on `CodeListing`. Please let me know if there's any other documentation I should update here.

![show on hover](https://github.com/user-attachments/assets/ac2d0305-ee3a-4f6c-ab76-0448ea19d7e1)
<img width="400" alt="always show copy button mobile" src="https://github.com/user-attachments/assets/74c1a2e1-7b59-438e-8a2a-f3e91a9a546d" />