### PR TITLE
Update locale in all view routing hooks

### DIFF
--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -15,6 +15,7 @@
 </template>
 
 <script>
+import { updateLocale } from 'theme/utils/i18n-utils';
 import GenericError from 'theme/components/GenericError.vue';
 import AppStore from 'docc-render/stores/AppStore';
 
@@ -23,6 +24,14 @@ export default {
   components: { GenericError },
   created() {
     AppStore.setAllLocalesAreAvailable();
+  },
+  beforeRouteEnter(to, from, next) {
+    next((vm) => {
+      updateLocale(to.params.locale, vm);
+    });
+  },
+  beforeRouteUpdate(to) {
+    updateLocale(to.params.locale, this);
   },
 };
 </script>

--- a/src/views/ServerError.vue
+++ b/src/views/ServerError.vue
@@ -13,6 +13,7 @@
 </template>
 
 <script>
+import { updateLocale } from 'theme/utils/i18n-utils';
 import GenericError from 'theme/components/GenericError.vue';
 import AppStore from 'docc-render/stores/AppStore';
 
@@ -21,6 +22,14 @@ export default {
   components: { GenericError },
   created() {
     AppStore.setAllLocalesAreAvailable();
+  },
+  beforeRouteEnter(to, from, next) {
+    next((vm) => {
+      updateLocale(to.params.locale, vm);
+    });
+  },
+  beforeRouteUpdate(to) {
+    updateLocale(to.params.locale, this);
   },
 };
 </script>

--- a/src/views/Topic.vue
+++ b/src/views/Topic.vue
@@ -21,6 +21,7 @@
 </template>
 
 <script>
+import { updateLocale } from 'theme/utils/i18n-utils';
 import {
   fetchDataForRouteEnter,
   shouldFetchDataForRouteUpdate,
@@ -80,6 +81,7 @@ export default {
       return;
     }
     fetchDataForRouteEnter(to, from, next).then(data => next((vm) => {
+      updateLocale(to.params.locale, vm);
       vm.topicData = data; // eslint-disable-line no-param-reassign
     })).catch(next);
   },
@@ -87,6 +89,7 @@ export default {
     if (shouldFetchDataForRouteUpdate(to, from)) {
       fetchDataForRouteEnter(to, from, next).then((data) => {
         this.topicData = data;
+        updateLocale(to.params.locale, this);
         next();
       }).catch(next);
     } else {

--- a/src/views/TutorialsOverview.vue
+++ b/src/views/TutorialsOverview.vue
@@ -13,6 +13,7 @@
 </template>
 
 <script>
+import { updateLocale } from 'theme/utils/i18n-utils';
 import {
   fetchDataForRouteEnter,
   shouldFetchDataForRouteUpdate,
@@ -54,6 +55,7 @@ export default {
     }
 
     fetchDataForRouteEnter(to, from, next).then(data => next((vm) => {
+      updateLocale(to.params.locale, vm);
       vm.topicData = data; // eslint-disable-line no-param-reassign
     })).catch(next);
   },
@@ -61,6 +63,7 @@ export default {
     if (shouldFetchDataForRouteUpdate(to, from)) {
       fetchDataForRouteEnter(to, from, next).then((data) => {
         this.topicData = data;
+        updateLocale(to.params.locale, this);
         next();
       }).catch(next);
     } else {

--- a/tests/unit/setup-utils/SwiftDocCRenderRouter.spec.js
+++ b/tests/unit/setup-utils/SwiftDocCRenderRouter.spec.js
@@ -15,6 +15,7 @@ import FetchError from 'docc-render/errors/FetchError';
 
 jest.mock('docc-render/utils/theme-settings', () => ({
   baseUrl: '/',
+  getSetting: jest.fn(),
 }));
 
 const mockInstance = {


### PR DESCRIPTION
Bug/issue #, if applicable: 160500944

## Summary

Previously, the locale was only being updated in routing hooks for documentation pages. This should be done for all view components to ensure that the appropriate locale metadata is updated and tracked, regardless of how a page is entered (directly loading a URL or clicking through links between pages).

## Testing

Steps:
1. Try to open a URL containing localized tutorial content (or other non-doc pages), like http://localhost:8080/ja-JP/tutorials/example
2. Verify that hardcoded UI strings are presented in the appropriate language

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
