### PR TITLE
Get the right data when the navigator has multiple top-level roots and multiple languages

### DIFF
--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -183,7 +183,7 @@ function extractRootNode(data) {
   // the URL in situations where the renderer is being hosted at some path
   // prefix
   const rootPathPattern = /(\/documentation\/[^/]+)/;
-  const rootPath = window.location.href.match(rootPathPattern)?.[1] ?? '';
+  const rootPath = window.location.pathname.match(rootPathPattern)?.[1] ?? '';
   // most of the time, it is expected that `data` always has a single item
   // that represents the top-level root node of the navigation tree
   //

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -373,7 +373,7 @@ describe('when multiple top-level children are provided', () => {
   describe('flattenNavigationIndex', () => {
     it('prefers the root child with the same url path prefix', () => {
       Object.defineProperty(window, 'location', {
-        value: { href: 'http://localhost/documentation/b/b42' },
+        value: new URL('http://localhost/documentation/b/b42?language=objc'),
       });
 
       // use first root node if only one is provided
@@ -409,7 +409,7 @@ describe('when multiple top-level children are provided', () => {
   describe('extractTechnologyProps', () => {
     it('prefers the root child with the same url path prefix', () => {
       Object.defineProperty(window, 'location', {
-        value: { href: 'http://localhost/documentation/b/b42' },
+        value: new URL('http://localhost/documentation/b/b42?language=objc'),
       });
 
       // use first root node if only one is provided


### PR DESCRIPTION
Bug/issue #158778571, if applicable: 

## Summary

In the use cases of navigators with multiple top-level root and multiple languages, we want to make sure that the URL queries that are added in different languages don't interfere with the election of the top-level root node.

Before, we were reading the `window.location.href`, which includes queries. Now, by using the `window.location.pathname` property, we ignore the queries, which makes possible to compare with the `node.path` value to find which it's the correct top-level root.

Example: URL: `http://localhost:8080/documentation/foo?language=objc`
Navigator path: `/documentation/foo`

By using `window.location.pathname` we ignore `?language=objc` and we can compare `/documentation/foo` with `/documentation/foo`

## Dependencies

NA

## Testing

Steps:
1. Run DocC Render with a `.doccarchive` that has a navigator with multiple top-level roots and multiple languages (Swift, Obj-C)
2. Assert that the navigators are rendering correctly

## Checklist

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
