### PR TITLE
Identify the root module of the navigator out of nested modules

### DIFF
--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -183,7 +183,7 @@ export function getSiblings(uid, childrenMap, children) {
  * @param {Object[]} modules - Array of module objects with optional children
  * @return {Object[]} Flattened array containing all modules and their nested module children
  */
-function flattenModules(modules) {
+export function flattenModules(modules) {
   return modules.flatMap(module => [
     module, ...flattenModules((module.children || []).filter(child => child.type === 'module')),
   ]);


### PR DESCRIPTION
Bug/issue #163125305, if applicable: 

## Summary

In some cases, our navigator can have nested modules within the top level modules. We want to extract all of them to be able to identify which it's the root module that the navigator should use.
This change introduces a recursively function that flatten a nested module structure into a single array.

It's confusing to use `landData` and `data` when we are referring to `modules` in the navigator. So this PR also renames:
- `landData` -> `modules`
- `data` -> `modules`
- `node` -> `module`

## Dependencies

NA

## Testing

Steps:
1. Run DocC Render with a navigator that has nested modules
2. Assert that it picks the right module

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
