### PR TITLE
Added Documentation homepage

### DIFF
--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -69,7 +69,11 @@
       "view-symbol": "View symbol",
       "view-sample-code": "View sample code"
     },
-    "view-more": "View more"
+    "view-more": "View more",
+    "hero": {
+      "title": "Developer Documentation",
+      "copy": "Browse the latest API reference."
+    }
   },
   "declarations": {
     "hide-other-declarations": "Hide other declarations",

--- a/src/lang/locales/ja-JP.json
+++ b/src/lang/locales/ja-JP.json
@@ -69,7 +69,11 @@
       "view-symbol": "記号を表示",
       "view-sample-code": "サンプルコードを表示"
     },
-    "view-more": "さらに表示"
+    "view-more": "さらに表示",
+    "hero": {
+      "title": "デベロッパドキュメント",
+      "copy": "最新のAPIリファレンスを閲覧できます。"
+    }
   },
   "declarations": {
     "hide-other-declarations": "ほかの宣言を非表示",

--- a/src/lang/locales/ko-KR.json
+++ b/src/lang/locales/ko-KR.json
@@ -69,7 +69,11 @@
       "view-symbol": "기호 보기",
       "view-sample-code": "샘플 코드 보기"
     },
-    "view-more": "더 보기"
+    "view-more": "더 보기",
+    "hero": {
+      "title": "개발자 문서",
+      "copy": "최신 API 레퍼런스를 확인하세요."
+    }
   },
   "declarations": {
     "hide-other-declarations": "다른 선언 가리기",

--- a/src/lang/locales/zh-CN.json
+++ b/src/lang/locales/zh-CN.json
@@ -69,7 +69,11 @@
       "view-symbol": "查看符号",
       "view-sample-code": "查看示例代码"
     },
-    "view-more": "查看更多"
+    "view-more": "查看更多",
+    "hero": {
+      "title": "开发者文档",
+      "copy": "浏览最新的 API 参考。"
+    }
   },
   "declarations": {
     "hide-other-declarations": "隐藏其他声明",

--- a/src/mixins/indexDataFetcher.js
+++ b/src/mixins/indexDataFetcher.js
@@ -28,8 +28,10 @@ export default {
           interfaceLanguages,
           references = {},
         } = await fetchData(this.indexDataPath);
+        const topLevelNodes = Object.values(interfaceLanguages || {}).flat();
         const flatChildren = Object.freeze(flattenNavigationIndex(interfaceLanguages));
         IndexStore.setFlatChildren(flatChildren);
+        IndexStore.setTopLevelNodes(topLevelNodes);
         IndexStore.setTechnologyProps(extractTechnologyProps(interfaceLanguages));
         IndexStore.setReferences(references);
         IndexStore.setIncludedArchiveIdentifiers(includedArchiveIdentifiers);

--- a/src/routes.js
+++ b/src/routes.js
@@ -16,6 +16,14 @@ import {
 import ServerError from 'theme/views/ServerError.vue';
 import NotFound from 'theme/views/NotFound.vue';
 
+export const homeRoute = {
+  path: '/',
+  name: 'home-index',
+  component: () => import(
+    /* webpackChunkName: "home-index" */ 'theme/views/Index.vue'
+  ),
+};
+
 export const fallbackRoutes = [
   {
     path: '*',
@@ -54,6 +62,7 @@ export const pagesRoutes = [
 ];
 
 export default [
+  homeRoute,
   ...pagesRoutes,
   ...fallbackRoutes,
 ];

--- a/src/setup-utils/SwiftDocCRenderRouter.js
+++ b/src/setup-utils/SwiftDocCRenderRouter.js
@@ -14,12 +14,13 @@ import {
   restoreScrollOnReload,
   scrollBehavior,
 } from 'docc-render/utils/router-utils';
-import routes, { fallbackRoutes } from 'docc-render/routes';
+import { homeRoute, pagesRoutes, fallbackRoutes } from 'docc-render/routes';
 import { baseUrl } from 'docc-render/utils/theme-settings';
 import { addPrefixedRoutes } from 'docc-render/utils/route-utils';
 
 const defaultRoutes = [
-  ...addPrefixedRoutes(routes),
+  homeRoute,
+  ...addPrefixedRoutes(pagesRoutes),
   ...fallbackRoutes,
 ];
 

--- a/src/stores/IndexStore.js
+++ b/src/stores/IndexStore.js
@@ -11,6 +11,7 @@
 export default {
   state: {
     flatChildren: null,
+    topLevelNodes: [],
     references: {},
     apiChanges: null,
     apiChangesVersion: null,
@@ -21,6 +22,7 @@ export default {
   },
   reset() {
     this.state.flatChildren = null;
+    this.state.topLevelNodes = [];
     this.state.references = {};
     this.state.apiChanges = null;
     this.state.apiChangesVersion = null;
@@ -34,6 +36,9 @@ export default {
   },
   setReferences(references) {
     this.state.references = references;
+  },
+  setTopLevelNodes(nodes) {
+    this.state.topLevelNodes = nodes || [];
   },
   setApiChanges(diff) {
     this.state.apiChanges = diff;

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -208,9 +208,9 @@ export default {
 
 <style scoped lang="scss">
 .index-page {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 32px 24px 64px;
+  width: 100%;
+  padding: 32px 28px 56px;
+  box-sizing: border-box;
 }
 
 .index-section {
@@ -227,34 +227,44 @@ export default {
 .hero {
   background: linear-gradient(315deg, var(--color-fill-secondary), var(--color-fill-tertiary));
   color: var(--colors-header-text, var(--color-header-text));
-  padding: 48px 36px;
+  padding: 40px 32px;
   border-radius: 20px;
   box-shadow: 0 20px 60px var(--color-card-shadow);
   text-align: center;
-  position: relative;
-  overflow: hidden;
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 auto 32px;
 }
 
 .hero__title {
-  font-size: 2.6rem;
-  line-height: 1.2;
-  margin: 0 0 12px;
+  margin: 0 0 8px;
 }
 
 .hero__lede {
   margin: 0;
   color: var(--colors-text, var(--color-text));
-  font-size: 1.1rem;
 }
 
 .index-section--grid {
-  margin-top: 40px;
+  margin-top: 32px;
 }
 
 .card-grid {
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media (max-width: 1024px) {
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .feature-card {
@@ -267,7 +277,6 @@ export default {
   border-radius: 12px;
   border: 1px solid var(--color-link-block-card-border);
   text-decoration: none;
-  position: relative;
   transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
@@ -289,7 +298,6 @@ export default {
 
 .feature-card__title {
   margin: 0;
-  font-size: 1.1rem;
 }
 
 .feature-card__tag {
@@ -303,12 +311,8 @@ export default {
 
 @media (max-width: 768px) {
   .hero {
-    padding: 32px 24px;
+    padding: 28px 20px;
     text-align: left;
-  }
-
-  .hero__title {
-    font-size: 2.1rem;
   }
 }
 </style>

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -1,0 +1,360 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2024 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <DocumentationLayout
+    :enableNavigator="true"
+    :interfaceLanguage="interfaceLanguage"
+    :references="indexState.references"
+    :navigatorFixedWidth="296"
+    :quickNavNodes="topLevelIndexNodes"
+  >
+    <template #nav-title="{ className }">
+      <h2 :class="className">{{ $t('documentation.title') || 'Documentation' }}</h2>
+    </template>
+
+    <template #navigator="{
+      scrollLockID,
+      breakpoint,
+      sidenavVisibleOnMobile,
+      handleToggleSidenav,
+      enableQuickNavigation,
+      openQuickNavigationModal,
+    }">
+      <Navigator
+        key="base-navigator"
+        v-show="sidenavVisibleOnMobile || breakpoint === BreakpointName.large"
+        v-bind="topLevelNavigatorProps"
+        :parent-topic-identifiers="parentTopicIdentifiers"
+        :references="references"
+        :scrollLockID="scrollLockID"
+        :render-filter-on-top="breakpoint !== BreakpointName.large"
+        @close="handleToggleSidenav(breakpoint)"
+      >
+        <template v-if="enableQuickNavigation" #filter>
+          <QuickNavigationButton @click.native="openQuickNavigationModal" />
+        </template>
+        <template #above-navigator-head>
+          <slot name="above-navigator-head"/>
+        </template>
+        <template #navigator-head="{ className }">
+          <slot name="nav-title" :className="className" />
+        </template>
+      </Navigator>
+    </template>
+
+    <template #content>
+      <main class="index-page">
+        <section class="hero">
+          <h1 class="hero__title">{{ heroTitle }}</h1>
+          <p class="hero__lede">
+            {{ heroCopy }}
+          </p>
+        </section>
+
+        <section v-if="documentation.length" class="index-section index-section--grid">
+          <header class="index-section__header">
+            <h2>Frameworks</h2>
+          </header>
+          <p v-if="isLoading">Loading index…</p>
+          <div v-else class="card-grid">
+            <RouterLink
+              v-for="doc in documentation"
+              :key="doc.path"
+              :to="doc.path"
+              class="feature-card"
+            >
+              <div class="feature-card__icon">
+                <TopicTypeIcon
+                  :type="doc.type || 'module'"
+                  :with-colors="false"
+                  :shouldCalculateOptimalWidth="false"
+                />
+              </div>
+              <div class="feature-card__body">
+                <h3 class="feature-card__title">{{ doc.title || doc.path }}</h3>
+              </div>
+              <span v-if="doc.beta" class="feature-card__tag">Beta</span>
+            </RouterLink>
+          </div>
+        </section>
+
+        <section v-if="tutorials.length" class="index-section index-section--grid">
+          <header class="index-section__header">
+            <h2>Tutorials</h2>
+          </header>
+          <p v-if="isLoading">Loading index…</p>
+          <div v-else class="card-grid">
+            <RouterLink
+              v-for="tutorial in tutorials"
+              :key="tutorial.path"
+              :to="tutorial.path"
+              class="feature-card"
+            >
+              <div class="feature-card__icon">
+                <TopicTypeIcon
+                  :type="tutorial.type || 'tutorial'"
+                  :with-colors="false"
+                  :shouldCalculateOptimalWidth="false"
+                />
+              </div>
+              <div class="feature-card__body">
+                <h3 class="feature-card__title">{{ tutorial.title || tutorial.path }}</h3>
+              </div>
+              <span v-if="tutorial.beta" class="feature-card__tag">Beta</span>
+            </RouterLink>
+          </div>
+        </section>
+      </main>
+    </template>
+  </DocumentationLayout>
+</template>
+
+<script>
+import Language from 'docc-render/constants/Language';
+import DocumentationLayout from 'theme/components/DocumentationLayout.vue';
+import Navigator from 'docc-render/components/Navigator.vue';
+import QuickNavigationButton from 'docc-render/components/Navigator/QuickNavigationButton.vue';
+import TopicTypeIcon from 'docc-render/components/TopicTypeIcon.vue';
+import DocumentationTopicStore from 'docc-render/stores/DocumentationTopicStore';
+import { BreakpointName } from 'docc-render/utils/breakpoints';
+import { INDEX_ROOT_KEY } from 'docc-render/constants/sidebar';
+import { hashCode } from 'docc-render/utils/navigatorData';
+import communicationBridgeUtils from 'docc-render/mixins/communicationBridgeUtils';
+import indexDataFetcher from 'theme/mixins/indexDataFetcher';
+import indexDataGetter from 'theme/mixins/indexDataGetter';
+
+export default {
+  name: 'Index',
+  components: {
+    DocumentationLayout,
+    Navigator,
+    QuickNavigationButton,
+    TopicTypeIcon,
+  },
+  mixins: [indexDataFetcher, indexDataGetter, communicationBridgeUtils],
+  data: () => ({
+    // fallback interface language used by indexDataGetter
+    interfaceLanguage: Language.swift.key.url,
+    heroTitle: 'Apple Developer Documentation',
+    heroCopy: 'Browse the latest sample code, articles, tutorials, and API reference.',
+    store: DocumentationTopicStore,
+    BreakpointName,
+  }),
+  provide() {
+    return {
+      store: this.store,
+    };
+  },
+  computed: {
+    references() {
+      return this.indexState.references;
+    },
+    parentTopicIdentifiers() {
+      return [];
+    },
+    topLevelIndexNodes() {
+      const nodes = this.indexState.topLevelNodes || [];
+      const siblingsCount = nodes.length;
+      return nodes.map((node, index) => ({
+        uid: hashCode(node.path || node.title || `${index}`),
+        title: node.title,
+        path: node.path,
+        type: node.type,
+        parent: INDEX_ROOT_KEY,
+        childUIDs: [],
+        depth: 0,
+        index,
+        siblingsCount,
+      })).filter(item => item.path);
+    },
+    topLevelNavigatorProps() {
+      return {
+        ...this.navigatorProps,
+        flatChildren: this.topLevelIndexNodes,
+        // hide the technology header to avoid duplicate top entry
+        technologyProps: null,
+      };
+    },
+    documentation() {
+      const docs = this.topLevelIndexNodes
+        .filter(node => node.path?.startsWith('/documentation/'));
+      return docs;
+    },
+    tutorials() {
+      const tops = this.topLevelIndexNodes
+        .filter(node => node.path?.startsWith('/tutorials/'));
+      return tops;
+    },
+    isLoading() {
+      const { flatChildren, errorFetching } = this.indexState;
+      return !flatChildren && !errorFetching;
+    },
+  },
+  watch: {
+    indexNodes() {
+      this.$nextTick(this.newContentMounted);
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.index-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px 64px;
+}
+
+.index-section {
+  margin-top: 32px;
+}
+
+.index-section__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.index-section__count {
+  display: inline-flex;
+  min-width: 28px;
+  padding: 4px 10px;
+  border-radius: 14px;
+  background: #f1f2f6;
+  font-weight: 600;
+  color: #1d1d1f;
+  font-size: 0.9rem;
+}
+
+.index-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.index-list__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid #e5e5ea;
+}
+
+.index-list__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.index-list__link:hover {
+  text-decoration: underline;
+}
+
+.index-list__tag {
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #fde68a;
+  color: #92400e;
+}
+
+.hero {
+  background: radial-gradient(120% 120% at 20% 20%, #2c2c34 0%, #111118 55%);
+  color: #f5f5f7;
+  padding: 48px 36px;
+  border-radius: 20px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: none;
+}
+
+.hero__title {
+  font-size: 2.6rem;
+  line-height: 1.2;
+  margin: 0 0 12px;
+}
+
+.hero__lede {
+  margin: 0;
+  color: #d1d1d6;
+  font-size: 1.1rem;
+}
+
+.index-section--grid {
+  margin-top: 40px;
+}
+
+.card-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.feature-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  background: #15151c;
+  color: #f5f5f7;
+  border-radius: 12px;
+  border: 1px solid #222230;
+  text-decoration: none;
+  position: relative;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.feature-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  border-color: #2e2e3e;
+}
+
+.feature-card__icon {
+  font-size: 1.5rem;
+}
+
+.feature-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.feature-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.feature-card__tag {
+  align-self: flex-start;
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #fde68a;
+  color: #92400e;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding: 32px 24px;
+    text-align: left;
+  }
+
+  .hero__title {
+    font-size: 2.1rem;
+  }
+}
+</style>

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -224,54 +224,8 @@ export default {
   margin-bottom: 12px;
 }
 
-.index-section__count {
-  display: inline-flex;
-  min-width: 28px;
-  padding: 4px 10px;
-  border-radius: 14px;
-  background: var(--color-fill-secondary);
-  font-weight: 600;
-  color: var(--color-figure-gray);
-  font-size: 0.9rem;
-}
-
-.index-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.index-list__item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 0;
-  border-bottom: 1px solid #e5e5ea;
-}
-
-.index-list__link {
-  color: inherit;
-  text-decoration: none;
-}
-
-.index-list__link:hover {
-  text-decoration: underline;
-}
-
-.index-list__tag {
-  font-size: 0.75rem;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: var(--color-standard-yellow);
-  color: var(--color-figure-orange);
-}
-
 .hero {
-  background: linear-gradient(
-    315deg,
-    var(--color-fill-secondary),
-    var(--color-fill-tertiary)
-  );
+  background: linear-gradient(315deg, var(--color-fill-secondary), var(--color-fill-tertiary));
   color: var(--colors-header-text, var(--color-header-text));
   padding: 48px 36px;
   border-radius: 20px;
@@ -279,10 +233,6 @@ export default {
   text-align: center;
   position: relative;
   overflow: hidden;
-}
-
-.hero::after {
-  content: none;
 }
 
 .hero__title {

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -53,9 +53,9 @@
     <template #content>
       <main class="index-page">
         <section class="hero">
-          <h1 class="hero__title">{{ heroTitle }}</h1>
+          <h1 class="hero__title">{{ $t('documentation.hero.title') }}</h1>
           <p class="hero__lede">
-            {{ heroCopy }}
+            {{ $t('documentation.hero.copy') }}
           </p>
         </section>
 
@@ -143,8 +143,6 @@ export default {
   data: () => ({
     // fallback interface language used by indexDataGetter
     interfaceLanguage: Language.swift.key.url,
-    heroTitle: 'Developer Documentation',
-    heroCopy: 'Browse the latest API reference.',
     store: DocumentationTopicStore,
     BreakpointName,
   }),

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -143,8 +143,8 @@ export default {
   data: () => ({
     // fallback interface language used by indexDataGetter
     interfaceLanguage: Language.swift.key.url,
-    heroTitle: 'Apple Developer Documentation',
-    heroCopy: 'Browse the latest sample code, articles, tutorials, and API reference.',
+    heroTitle: 'Developer Documentation',
+    heroCopy: 'Browse the latest API reference.',
     store: DocumentationTopicStore,
     BreakpointName,
   }),
@@ -231,9 +231,10 @@ export default {
   border-radius: 20px;
   box-shadow: 0 20px 60px var(--color-card-shadow);
   text-align: center;
-  width: fit-content;
-  max-width: 100%;
+  width: 50%;
   margin: 0 auto 32px;
+  display: flex;
+  flex-direction: column;
 }
 
 .hero__title {
@@ -256,6 +257,10 @@ export default {
 }
 
 @media (max-width: 1024px) {
+  .hero {
+    width: unset;
+  }
+
   .card-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -309,10 +314,4 @@ export default {
   color: var(--color-figure-orange);
 }
 
-@media (max-width: 768px) {
-  .hero {
-    padding: 28px 20px;
-    text-align: left;
-  }
-}
 </style>

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -229,9 +229,9 @@ export default {
   min-width: 28px;
   padding: 4px 10px;
   border-radius: 14px;
-  background: #f1f2f6;
+  background: var(--color-fill-secondary);
   font-weight: 600;
-  color: #1d1d1f;
+  color: var(--color-figure-gray);
   font-size: 0.9rem;
 }
 
@@ -262,16 +262,20 @@ export default {
   font-size: 0.75rem;
   padding: 2px 8px;
   border-radius: 999px;
-  background: #fde68a;
-  color: #92400e;
+  background: var(--color-standard-yellow);
+  color: var(--color-figure-orange);
 }
 
 .hero {
-  background: radial-gradient(120% 120% at 20% 20%, #2c2c34 0%, #111118 55%);
-  color: #f5f5f7;
+  background: linear-gradient(
+    315deg,
+    var(--color-fill-secondary),
+    var(--color-fill-tertiary)
+  );
+  color: var(--colors-header-text, var(--color-header-text));
   padding: 48px 36px;
   border-radius: 20px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 20px 60px var(--color-card-shadow);
   text-align: center;
   position: relative;
   overflow: hidden;
@@ -289,7 +293,7 @@ export default {
 
 .hero__lede {
   margin: 0;
-  color: #d1d1d6;
+  color: var(--colors-text, var(--color-text));
   font-size: 1.1rem;
 }
 
@@ -308,10 +312,10 @@ export default {
   flex-direction: column;
   gap: 8px;
   padding: 16px;
-  background: #15151c;
-  color: #f5f5f7;
+  background: var(--color-card-background);
+  color: var(--color-card-content-text);
   border-radius: 12px;
-  border: 1px solid #222230;
+  border: 1px solid var(--color-link-block-card-border);
   text-decoration: none;
   position: relative;
   transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
@@ -319,8 +323,8 @@ export default {
 
 .feature-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
-  border-color: #2e2e3e;
+  box-shadow: 0 10px 30px var(--color-card-shadow);
+  border-color: var(--color-navigator-item-hover);
 }
 
 .feature-card__icon {
@@ -343,8 +347,8 @@ export default {
   font-size: 0.75rem;
   padding: 2px 8px;
   border-radius: 999px;
-  background: #fde68a;
-  color: #92400e;
+  background: var(--color-standard-yellow);
+  color: var(--color-figure-orange);
 }
 
 @media (max-width: 768px) {

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -54,63 +54,9 @@
       <main class="index-page">
         <section class="hero">
           <h1 class="hero__title">{{ $t('documentation.hero.title') }}</h1>
-          <p class="hero__lede">
+          <p class="hero__subtitle">
             {{ $t('documentation.hero.copy') }}
           </p>
-        </section>
-
-        <section v-if="documentation.length" class="index-section index-section--grid">
-          <header class="index-section__header">
-            <h2>Frameworks</h2>
-          </header>
-          <p v-if="isLoading">Loading index…</p>
-          <div v-else class="card-grid">
-            <RouterLink
-              v-for="doc in documentation"
-              :key="doc.path"
-              :to="doc.path"
-              class="feature-card"
-            >
-              <div class="feature-card__icon">
-                <TopicTypeIcon
-                  :type="doc.type || 'module'"
-                  :with-colors="false"
-                  :shouldCalculateOptimalWidth="false"
-                />
-              </div>
-              <div class="feature-card__body">
-                <h3 class="feature-card__title">{{ doc.title || doc.path }}</h3>
-              </div>
-              <span v-if="doc.beta" class="feature-card__tag">Beta</span>
-            </RouterLink>
-          </div>
-        </section>
-
-        <section v-if="tutorials.length" class="index-section index-section--grid">
-          <header class="index-section__header">
-            <h2>Tutorials</h2>
-          </header>
-          <p v-if="isLoading">Loading index…</p>
-          <div v-else class="card-grid">
-            <RouterLink
-              v-for="tutorial in tutorials"
-              :key="tutorial.path"
-              :to="tutorial.path"
-              class="feature-card"
-            >
-              <div class="feature-card__icon">
-                <TopicTypeIcon
-                  :type="tutorial.type || 'tutorial'"
-                  :with-colors="false"
-                  :shouldCalculateOptimalWidth="false"
-                />
-              </div>
-              <div class="feature-card__body">
-                <h3 class="feature-card__title">{{ tutorial.title || tutorial.path }}</h3>
-              </div>
-              <span v-if="tutorial.beta" class="feature-card__tag">Beta</span>
-            </RouterLink>
-          </div>
         </section>
       </main>
     </template>
@@ -122,7 +68,6 @@ import Language from 'docc-render/constants/Language';
 import DocumentationLayout from 'theme/components/DocumentationLayout.vue';
 import Navigator from 'docc-render/components/Navigator.vue';
 import QuickNavigationButton from 'docc-render/components/Navigator/QuickNavigationButton.vue';
-import TopicTypeIcon from 'docc-render/components/TopicTypeIcon.vue';
 import DocumentationTopicStore from 'docc-render/stores/DocumentationTopicStore';
 import { BreakpointName } from 'docc-render/utils/breakpoints';
 import { INDEX_ROOT_KEY } from 'docc-render/constants/sidebar';
@@ -137,7 +82,6 @@ export default {
     DocumentationLayout,
     Navigator,
     QuickNavigationButton,
-    TopicTypeIcon,
   },
   mixins: [indexDataFetcher, indexDataGetter, communicationBridgeUtils],
   data: () => ({
@@ -181,20 +125,6 @@ export default {
         technologyProps: null,
       };
     },
-    documentation() {
-      const docs = this.topLevelIndexNodes
-        .filter(node => node.path?.startsWith('/documentation/'));
-      return docs;
-    },
-    tutorials() {
-      const tops = this.topLevelIndexNodes
-        .filter(node => node.path?.startsWith('/tutorials/'));
-      return tops;
-    },
-    isLoading() {
-      const { flatChildren, errorFetching } = this.indexState;
-      return !flatChildren && !errorFetching;
-    },
   },
   watch: {
     indexNodes() {
@@ -206,110 +136,19 @@ export default {
 
 <style scoped lang="scss">
 .index-page {
-  width: 100%;
   padding: 32px 28px 56px;
   box-sizing: border-box;
-}
-
-.index-section {
-  margin-top: 32px;
-}
-
-.index-section__header {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 12px;
+  flex-direction: column;
 }
 
 .hero {
-  background: linear-gradient(315deg, var(--color-fill-secondary), var(--color-fill-tertiary));
   color: var(--colors-header-text, var(--color-header-text));
-  padding: 40px 32px;
-  border-radius: 20px;
-  box-shadow: 0 20px 60px var(--color-card-shadow);
   text-align: center;
-  width: 50%;
-  margin: 0 auto 32px;
-  display: flex;
-  flex-direction: column;
 }
 
-.hero__title {
-  margin: 0 0 8px;
-}
-
-.hero__lede {
-  margin: 0;
+.hero__subtitle {
   color: var(--colors-text, var(--color-text));
-}
-
-.index-section--grid {
-  margin-top: 32px;
-}
-
-.card-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-@media (max-width: 1024px) {
-  .hero {
-    width: unset;
-  }
-
-  .card-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 640px) {
-  .card-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-.feature-card {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 16px;
-  background: var(--color-card-background);
-  color: var(--color-card-content-text);
-  border-radius: 12px;
-  border: 1px solid var(--color-link-block-card-border);
-  text-decoration: none;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
-}
-
-.feature-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 30px var(--color-card-shadow);
-  border-color: var(--color-navigator-item-hover);
-}
-
-.feature-card__icon {
-  font-size: 1.5rem;
-}
-
-.feature-card__body {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.feature-card__title {
-  margin: 0;
-}
-
-.feature-card__tag {
-  align-self: flex-start;
-  font-size: 0.75rem;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: var(--color-standard-yellow);
-  color: var(--color-figure-orange);
 }
 
 </style>

--- a/tests/unit/mixins/indexDataFetcher.spec.js
+++ b/tests/unit/mixins/indexDataFetcher.spec.js
@@ -258,6 +258,7 @@ describe('indexDataFetcher', () => {
       errorFetching: false,
       errorFetchingDiffs: false,
       technologyProps: {},
+      topLevelNodes: [],
     });
   });
 

--- a/tests/unit/stores/IndexStore.spec.js
+++ b/tests/unit/stores/IndexStore.spec.js
@@ -57,6 +57,7 @@ describe('IndexStore', () => {
     errorFetching: false,
     errorFetchingDiffs: false,
     technologyProps: {},
+    topLevelNodes: [],
   };
 
   beforeEach(() => {

--- a/tests/unit/views/Index.spec.js
+++ b/tests/unit/views/Index.spec.js
@@ -1,0 +1,98 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2025 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import { shallowMount } from '@vue/test-utils';
+import Index from '@/views/Index.vue';
+import Navigator from 'docc-render/components/Navigator.vue';
+
+const defaultMocks = {
+  $bridge: {
+    on: jest.fn(),
+    off: jest.fn(),
+    send: jest.fn(),
+  },
+  $route: {},
+};
+
+const messages = {
+  'documentation.hero.title': 'Developer Documentation',
+  'documentation.hero.copy': 'Browse the latest API reference.',
+};
+
+const DocumentationLayoutStub = {
+  name: 'DocumentationLayout',
+  props: ['enableNavigator', 'interfaceLanguage', 'references', 'navigatorFixedWidth', 'quickNavNodes'],
+  template: '<div><slot name="navigator"></slot><slot name="content"></slot></div>',
+};
+
+const baseDataFn = (
+  Index.options && Index.options.data
+    ? Index.options.data.bind(Index)
+    : () => ({})
+);
+const baseData = baseDataFn();
+
+const mountWith = (indexStateOverrides = {}, extraOptions = {}) => shallowMount(Index, {
+  mocks: {
+    ...defaultMocks,
+    $t: key => messages[key] || key,
+    $te: key => Boolean(messages[key]),
+  },
+  stubs: {
+    DocumentationLayout: DocumentationLayoutStub,
+    Navigator: false,
+    QuickNavigationButton: true,
+    TopicTypeIcon: true,
+    RouterLink: {
+      render(h) { return h('a', {}, this.$slots.default); },
+    },
+    ...(extraOptions.stubs || {}),
+  },
+  data: () => ({
+    ...baseData,
+    indexState: {
+      ...(baseData.indexState || {}),
+      flatChildren: [],
+      topLevelNodes: [],
+      references: {},
+      ...indexStateOverrides,
+    },
+  }),
+  computed: {
+    indexNodes: () => [],
+    ...(extraOptions.computed || {}),
+  },
+});
+
+describe('Index view', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders hero text from translation keys', () => {
+    const wrapper = mountWith();
+    expect(wrapper.find('.hero__title').text()).toBe('Developer Documentation');
+    expect(wrapper.find('.hero__lede').text()).toBe('Browse the latest API reference.');
+  });
+
+  it('passes top-level nodes to navigator only', () => {
+    const topLevelNodes = [{ path: '/documentation/foo', title: 'Foo', type: 'module' }];
+    const wrapper = mountWith({ topLevelNodes });
+    const nav = wrapper.findComponent(Navigator);
+    expect(nav.exists()).toBe(true);
+    expect(nav.props('flatChildren').length).toBe(1);
+    expect(nav.props('flatChildren')[0].path).toBe('/documentation/foo');
+  });
+
+  it('hides sections when lists are empty', () => {
+    const wrapper = mountWith();
+    expect(wrapper.find('section.index-section--grid').exists()).toBe(false);
+  });
+});

--- a/tests/unit/views/Index.spec.js
+++ b/tests/unit/views/Index.spec.js
@@ -79,7 +79,7 @@ describe('Index view', () => {
   it('renders hero text from translation keys', () => {
     const wrapper = mountWith();
     expect(wrapper.find('.hero__title').text()).toBe('Developer Documentation');
-    expect(wrapper.find('.hero__lede').text()).toBe('Browse the latest API reference.');
+    expect(wrapper.find('.hero__subtitle').text()).toBe('Browse the latest API reference.');
   });
 
   it('passes top-level nodes to navigator only', () => {
@@ -89,10 +89,5 @@ describe('Index view', () => {
     expect(nav.exists()).toBe(true);
     expect(nav.props('flatChildren').length).toBe(1);
     expect(nav.props('flatChildren')[0].path).toBe('/documentation/foo');
-  });
-
-  it('hides sections when lists are empty', () => {
-    const wrapper = mountWith();
-    expect(wrapper.find('section.index-section--grid').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

### What this change addresses / expected UX
Adds a home (/ ) experience inspired by https://developer.apple.com/documentation: a centered hero plus two card grids for top-level documentation and tutorials. Users now land on a concise, styled index that matches the sidebar’s top-level navigation (only roots, with proper icons), hides empty sections, and adapts to light/dark themes.

Before

<img width="1588" height="1064" alt="Screenshot 2025-12-07 at 2 47 31 p m" src="https://github.com/user-attachments/assets/d95f608f-896f-43b4-b497-8117546b58ed" />

After

<img width="1588" height="1064" alt="Screenshot 2025-12-07 at 2 24 30 p m" src="https://github.com/user-attachments/assets/9df0dd65-65b1-4eec-bf55-708113b0e905" />

> Note: The UI/layout can be changed based on suggestions in this PR. The screenshot is just an initial implementation

### Implementation overview
- src/views/Index.vue: reuse DocumentationLayout with a filtered Navigator (top-level only); hero text now uses new i18n keys (documentation.hero.title/copy); cards use TopicTypeIcon; responsive 3/2/1 grid; hero width responsive (50% on desktop, full on smaller screens); simplified themed styling.
- Routing unchanged; home remains “/”.
- i18n: added documentation.hero.title and documentation.hero.copy to locale files (en-US, ja-JP, zh-CN, ko-KR).
- Tests: new tests/unit/views/Index.spec.js covers hero i18n, navigator top-level-only data, and hiding empty sections.
- Styles cleaned to rely on theme tokens for color/shadows and responsive spacing.

Inspiration explicitly taken from https://developer.apple.com/documentation ’s documentation landing layout.

<img width="1697" height="1094" alt="Screenshot 2025-12-06 at 12 31 22 p m" src="https://github.com/user-attachments/assets/e177ea31-ba52-45eb-8570-8d3395bef618" />



## Dependencies

None

## Testing

Steps:
1. Build the documentation archive
2. Run the renderer
3. Visit the server index (http://localhost:8080/)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
