### PR TITLE
[6.3] Get the right data when the navigator has multiple top-level roots and multiple languages

### DIFF
--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -183,7 +183,7 @@ function extractRootNode(data) {
   // the URL in situations where the renderer is being hosted at some path
   // prefix
   const rootPathPattern = /(\/documentation\/[^/]+)/;
-  const rootPath = window.location.href.match(rootPathPattern)?.[1] ?? '';
+  const rootPath = window.location.pathname.match(rootPathPattern)?.[1] ?? '';
   // most of the time, it is expected that `data` always has a single item
   // that represents the top-level root node of the navigation tree
   //

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -373,7 +373,7 @@ describe('when multiple top-level children are provided', () => {
   describe('flattenNavigationIndex', () => {
     it('prefers the root child with the same url path prefix', () => {
       Object.defineProperty(window, 'location', {
-        value: { href: 'http://localhost/documentation/b/b42' },
+        value: new URL('http://localhost/documentation/b/b42?language=objc'),
       });
 
       // use first root node if only one is provided
@@ -409,7 +409,7 @@ describe('when multiple top-level children are provided', () => {
   describe('extractTechnologyProps', () => {
     it('prefers the root child with the same url path prefix', () => {
       Object.defineProperty(window, 'location', {
-        value: { href: 'http://localhost/documentation/b/b42' },
+        value: new URL('http://localhost/documentation/b/b42?language=objc'),
       });
 
       // use first root node if only one is provided


### PR DESCRIPTION
**Explanation**: In the use cases of navigators with multiple top-level root and multiple languages, we want to make sure that the URL queries that are added in different languages don't interfere with the election of the top-level root node.

**Scope**: Updates the navigator
**Issue**: rdar://158778571.
**Risk**: Low. It only affects the navigator.
**Testing**: added new unit test.
**Reviewer**: @mportiz08 
**Original PR**: https://github.com/swiftlang/swift-docc-render/pull/980