### PR TITLE
Add smooth scroll

### DIFF
--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -31,6 +31,11 @@
 
 html {
   --scale-inline: 1;
+  scroll-behavior: smooth;
+
+  @media (prefers-reduced-motion: reduce) {
+    scroll-behavior: auto;
+  }
 }
 
 html[dir="rtl"] {


### PR DESCRIPTION
Bug/issue #985 

## Summary
Added CSS in `html` to enable the smooth scroll.  Disable the smooth scroll if the user has a setting that enables `prefers-reduced-motion`

## Dependencies
None

## Testing
All done

Steps:
- Navigate to a page with multiple headings / anchors
- Click on an anchor
- User should see a smooth scroll to the anchor

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary

Tests are not needed for this and documentation shouldn't be updated for this.
