### PR TITLE
[6.3] Render ReferenceExternal when linking to an asset

### DIFF
--- a/src/components/ButtonLink.vue
+++ b/src/components/ButtonLink.vue
@@ -36,10 +36,14 @@ export default {
       type: Boolean,
       default: false,
     },
+    linksToAsset: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     resolvedComponent: ({ url }) => (url ? Reference : 'button'),
-    componentProps: ({ url }) => (url ? { url } : {}),
+    componentProps: ({ url, linksToAsset }) => (url ? { url, linksToAsset } : { linksToAsset }),
   },
 };
 </script>

--- a/src/components/CallToActionButton.vue
+++ b/src/components/CallToActionButton.vue
@@ -13,6 +13,7 @@
     <ButtonLink
       :url="normalizeUrl(url)"
       :isDark="isDark"
+      :linksToAsset="linksToAsset"
     >
       {{ title }}
     </ButtonLink>

--- a/src/components/ContentNode/Reference.vue
+++ b/src/components/ContentNode/Reference.vue
@@ -53,7 +53,7 @@ import ReferenceInternal from './ReferenceInternal.vue';
 export default {
   name: 'Reference',
   computed: {
-    isInternal({ url }) {
+    isInternal({ url, linksToAsset }) {
       if (!url) {
         return false;
       }
@@ -61,6 +61,8 @@ export default {
         // If the URL has a scheme, it's not an internal link.
         return false;
       }
+
+      if (linksToAsset) return false;
 
       // Resolve the URL using the router.
       const {
@@ -119,6 +121,10 @@ export default {
       required: false,
     },
     hasInlineFormatting: {
+      type: Boolean,
+      default: false,
+    },
+    linksToAsset: {
       type: Boolean,
       default: false,
     },

--- a/tests/unit/components/ButtonLink.spec.js
+++ b/tests/unit/components/ButtonLink.spec.js
@@ -63,4 +63,17 @@ describe('ButtonLink', () => {
     });
     expect(wrapper.classes()).toContain('is-dark');
   });
+
+  it('passes the `linksToAsset` prop to `Reference`', () => {
+    const wrapper = shallowMount(ButtonLink, {
+      propsData: {
+        ...propsData,
+        linksToAsset: true,
+      },
+    });
+
+    const ref = wrapper.findComponent(Reference);
+    expect(ref.exists()).toBe(true);
+    expect(ref.props('linksToAsset')).toBe(true);
+  });
 });

--- a/tests/unit/components/CallToActionButton.spec.js
+++ b/tests/unit/components/CallToActionButton.spec.js
@@ -105,4 +105,10 @@ describe('CallToActionButton', () => {
     expect(provider.exists()).toBe(true);
     expect(provider.props('destination')).toBe(propsData.action);
   });
+
+  it('passes the `linksToAsset` prop to `ButtonLink`', () => {
+    wrapper = createWrapper();
+    const btn = wrapper.findComponent(ButtonLink);
+    expect(btn.props('linksToAsset')).toBe(propsData.linksToAsset);
+  });
 });

--- a/tests/unit/components/ContentNode/Reference.spec.js
+++ b/tests/unit/components/ContentNode/Reference.spec.js
@@ -278,4 +278,21 @@ describe('Reference', () => {
     expect(ref.props('url')).toBe('/downloads/foo.zip');
     expect(ref.text()).toBe('Foo');
   });
+
+  it('renders a `ReferenceExternal` when linksToAsset is true', () => {
+    const wrapper = shallowMount(Reference, {
+      localVue,
+      router,
+      propsData: {
+        url: '/asset/link/path.zip',
+        linksToAsset: true,
+      },
+      slots: { default: 'Asset Link' },
+    });
+    const ref = wrapper.findComponent(ReferenceExternal);
+    expect(ref.exists()).toBe(true);
+    expect(ref.props('url')).toBe('/asset/link/path.zip');
+    expect(ref.text()).toBe('Asset Link');
+    expect(wrapper.findComponent(ReferenceInternal).exists()).toBe(false);
+  });
 });


### PR DESCRIPTION
**Explanation**: We want to make sure that when we render a link that links to an asset instead of a router path, we render the ReferenceExternal component, which it's meant to render links outside the router.

**Scope**: Links to assets, for example, the "Download" button at sample codes
**Issue**: rdar://166301939.
**Risk**: Low
**Testing**: added new unit test.
**Reviewer**: @mportiz08 
**Original PR**: https://github.com/swiftlang/swift-docc-render/pull/989