### PR TITLE
Add .github/CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,4 +20,4 @@
 # overrides, and makes uncharted parts of the repository easier to pin down.
 
 # Default code owner of everything.
-* @marinaaisa @mportiz08
+* @swiftlang/swift-docc-codeowners


### PR DESCRIPTION
The Contributor Experience Workgroup is currently working on a swiftlang/swift-org-website#1269 and other initiatives that require this repository to have a .github/CODEOWNERS file.