### PR TITLE
Derive the default locale from locales.json instead of hardcoding it

### DIFF
--- a/src/lang/index.js
+++ b/src/lang/index.js
@@ -14,9 +14,11 @@ import en_US from './locales/en-US.json';
 import zh_CN from './locales/zh-CN.json';
 import ja_JP from './locales/ja-JP.json';
 import ko_KR from './locales/ko-KR.json';
+import locales from './locales.json';
 
 // default locale
-export const defaultLocale = process.env.VUE_APP_DEFAULT_LOCALE ?? 'en-US';
+export const defaultLocale = process.env.VUE_APP_DEFAULT_LOCALE
+ ?? locales.find(locale => locale.default).slug;
 // translated locales
 export const messages = {
   ar,

--- a/src/lang/locales.json
+++ b/src/lang/locales.json
@@ -7,7 +7,8 @@
   {
     "code": "en-US",
     "name": "English",
-    "slug": "en-US"
+    "slug": "en-US",
+    "default": true
   },
   {
     "code": "zh-CN",


### PR DESCRIPTION
Bug/issue #172843245, if applicable: 

## Summary

The default locale was hardcoded as the string literal 'en-US' in the fallback of the nullish coalescing operator [1]. This meant the fallback value was disconnected from the locale definitions in locales.json, creating a single source of truth violation: if the default locale ever changed in the data file, the code would still silently fall back to 'en-US'.

A "default": true property is added to the en-US entry in locales.json, marking it as the canonical default locale. The fallback in index.js now imports locales.json and uses Array.prototype.find() [2] to look up whichever locale has "default": true, using its slug as the fallback value.

This keeps locales.json as the single source of truth for all locale metadata, including which locale is the default.

[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing
[2] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find

## Dependencies

NA

## Testing

Steps:
1. This is a refactor, so nothing should change.
2. Make sure that everything works as expected.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
