### PR TITLE
Add locale fallback with redirect for 404 pages

### DIFF
--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -13,6 +13,7 @@ import {
   queryStringForParams, areEquivalentLocations, getAbsoluteUrl,
 } from 'docc-render/utils/url-helper';
 import emitWarningForSchemaVersionMismatch from 'docc-render/utils/schema-version-check';
+import { defaultLocale } from 'theme/lang/index';
 import RedirectError from 'docc-render/errors/RedirectError';
 import FetchError from 'docc-render/errors/FetchError';
 
@@ -95,6 +96,19 @@ export async function fetchDataForRouteEnter(to, from, next) {
     }
 
     if (error.status && error.status === 404) {
+      // If the current locale is not the default, try fetching the default
+      // locale version as a fallback and redirect to it.
+      const locale = to.params && to.params.locale;
+      if (locale && locale !== defaultLocale) {
+        const fallbackPath = to.path.replace(`/${locale}`, '');
+        try {
+          await fetchData(createDataPath(fallbackPath), to.query);
+          next(fallbackPath);
+          return null;
+        } catch (fallbackError) {
+          console.error(`Fallback fetch failed for locale "${locale}":`, fallbackError);
+        }
+      }
       // route to 404 page if missing data, but not in IDE build
       next({
         name: 'not-found',

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -13,6 +13,8 @@ import {
   queryStringForParams, areEquivalentLocations, getAbsoluteUrl,
 } from 'docc-render/utils/url-helper';
 import emitWarningForSchemaVersionMismatch from 'docc-render/utils/schema-version-check';
+import { defaultLocale } from 'theme/lang/index';
+import { localeIsValid } from 'docc-render/utils/i18n-utils';
 import RedirectError from 'docc-render/errors/RedirectError';
 import FetchError from 'docc-render/errors/FetchError';
 
@@ -95,6 +97,14 @@ export async function fetchDataForRouteEnter(to, from, next) {
     }
 
     if (error.status && error.status === 404) {
+      // Destructure the locale out of the route params, leaving the rest.
+      const { locale, ...paramsWithoutLocale } = to.params ?? {};
+      if (locale && locale !== defaultLocale && localeIsValid(locale)) {
+        // Call `next` with the same route but without the locale param,
+        // redirecting to the non-localized version of the route.
+        next({ ...to, params: paramsWithoutLocale });
+        return null;
+      }
       // route to 404 page if missing data, but not in IDE build
       next({
         name: 'not-found',

--- a/tests/unit/utils/data.spec.js
+++ b/tests/unit/utils/data.spec.js
@@ -34,7 +34,7 @@ const goodFetchResponse = {
   ok: true,
   json: () => Promise.resolve({ foobar: 'foobar' }),
 };
-const notFoundFetchResposne = {
+const notFoundFetchResponse = {
   ok: false,
   status: 404,
 };
@@ -218,7 +218,7 @@ describe('fetchDataForRouteEnter', () => {
   });
 
   it('calls the `next` fn with a not-found route for 404s', async () => {
-    window.fetch = jest.fn().mockImplementation(() => notFoundFetchResposne);
+    window.fetch = jest.fn().mockImplementation(() => notFoundFetchResponse);
 
     await fetchDataForRouteEnter(to, from, next);
     await expect(next).toHaveBeenCalledWith({
@@ -231,7 +231,7 @@ describe('fetchDataForRouteEnter', () => {
 
   it('redirects to the default locale path when a localized page returns 404', async () => {
     window.fetch = jest.fn()
-      .mockImplementationOnce(() => notFoundFetchResposne)
+      .mockImplementationOnce(() => notFoundFetchResponse)
       .mockImplementationOnce(() => goodFetchResponse);
 
     await fetchDataForRouteEnter(localizedTo, from, next);
@@ -247,13 +247,13 @@ describe('fetchDataForRouteEnter', () => {
 
   it('shows 404 when both localized and English fallback return 404', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockReturnValue('');
-    window.fetch = jest.fn().mockImplementation(() => notFoundFetchResposne);
+    window.fetch = jest.fn().mockImplementation(() => notFoundFetchResponse);
 
     await fetchDataForRouteEnter(localizedTo, from, next);
     expect(window.fetch).toHaveBeenCalledTimes(2);
     expect(errorSpy).toHaveBeenCalledWith(
       'Fallback fetch failed for locale "zh-CN":',
-      notFoundFetchResposne,
+      notFoundFetchResponse,
     );
     expect(next).toHaveBeenCalledWith({
       name: 'not-found',

--- a/tests/unit/utils/data.spec.js
+++ b/tests/unit/utils/data.spec.js
@@ -155,6 +155,11 @@ describe('fetchDataForRouteEnter', () => {
     path: '/tutorials/augmented-reality/tutorials',
     params: { locale: defaultLocale },
   };
+  const localizedTo = {
+    name: 'technology-tutorials-locale',
+    path: '/zh-CN/tutorials/augmented-reality/tutorials',
+    params: { locale: 'zh-CN' },
+  };
   const from = {};
   const next = jest.fn();
 
@@ -221,6 +226,41 @@ describe('fetchDataForRouteEnter', () => {
       params: ['/tutorials/augmented-reality/tutorials'],
     });
 
+    window.fetch.mockRestore();
+  });
+
+  it('redirects to the default locale path when a localized page returns 404', async () => {
+    window.fetch = jest.fn()
+      .mockImplementationOnce(() => notFoundFetchResposne)
+      .mockImplementationOnce(() => goodFetchResponse);
+
+    await fetchDataForRouteEnter(localizedTo, from, next);
+    expect(window.fetch).toHaveBeenCalledTimes(2);
+    expect(window.fetch.mock.calls[1][0]).toEqual(new URL(
+      '/data/tutorials/augmented-reality/tutorials.json',
+      window.location.href,
+    ).href);
+    expect(next).toHaveBeenCalledWith('/tutorials/augmented-reality/tutorials');
+
+    window.fetch.mockRestore();
+  });
+
+  it('shows 404 when both localized and English fallback return 404', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockReturnValue('');
+    window.fetch = jest.fn().mockImplementation(() => notFoundFetchResposne);
+
+    await fetchDataForRouteEnter(localizedTo, from, next);
+    expect(window.fetch).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Fallback fetch failed for locale "zh-CN":',
+      notFoundFetchResposne,
+    );
+    expect(next).toHaveBeenCalledWith({
+      name: 'not-found',
+      params: ['/zh-CN/tutorials/augmented-reality/tutorials'],
+    });
+
+    errorSpy.mockRestore();
     window.fetch.mockRestore();
   });
 

--- a/tests/unit/utils/data.spec.js
+++ b/tests/unit/utils/data.spec.js
@@ -155,6 +155,11 @@ describe('fetchDataForRouteEnter', () => {
     path: '/tutorials/augmented-reality/tutorials',
     params: { locale: defaultLocale },
   };
+  const localizedTo = {
+    name: 'technology-tutorials-locale',
+    path: '/zh-CN/tutorials/augmented-reality/tutorials',
+    params: { locale: 'zh-CN' },
+  };
   const from = {};
   const next = jest.fn();
 
@@ -219,6 +224,33 @@ describe('fetchDataForRouteEnter', () => {
     await expect(next).toHaveBeenCalledWith({
       name: 'not-found',
       params: ['/tutorials/augmented-reality/tutorials'],
+    });
+
+    window.fetch.mockRestore();
+  });
+
+  it('redirects to the default locale path when a localized page returns 404', async () => {
+    window.fetch = jest.fn().mockImplementationOnce(() => notFoundFetchResposne);
+
+    await fetchDataForRouteEnter(localizedTo, from, next);
+    expect(window.fetch).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith({ ...localizedTo, params: {} });
+
+    window.fetch.mockRestore();
+  });
+
+  it('routes to 404 page when a page with an unsupported locale param returns 404', async () => {
+    window.fetch = jest.fn().mockImplementationOnce(() => notFoundFetchResponse);
+
+    const fakeLocaleTo = {
+      name: 'technology-tutorials-locale',
+      path: '/fakelocale/tutorials/augmented-reality/tutorials',
+      params: { locale: 'fakelocale' },
+    };
+    await fetchDataForRouteEnter(fakeLocaleTo, from, next);
+    expect(next).toHaveBeenCalledWith({
+      name: 'not-found',
+      params: [fakeLocaleTo.path],
     });
 
     window.fetch.mockRestore();

--- a/tests/unit/utils/data.spec.js
+++ b/tests/unit/utils/data.spec.js
@@ -34,7 +34,7 @@ const goodFetchResponse = {
   ok: true,
   json: () => Promise.resolve({ foobar: 'foobar' }),
 };
-const notFoundFetchResposne = {
+const notFoundFetchResponse = {
   ok: false,
   status: 404,
 };
@@ -218,7 +218,7 @@ describe('fetchDataForRouteEnter', () => {
   });
 
   it('calls the `next` fn with a not-found route for 404s', async () => {
-    window.fetch = jest.fn().mockImplementation(() => notFoundFetchResposne);
+    window.fetch = jest.fn().mockImplementation(() => notFoundFetchResponse);
 
     await fetchDataForRouteEnter(to, from, next);
     await expect(next).toHaveBeenCalledWith({
@@ -230,7 +230,7 @@ describe('fetchDataForRouteEnter', () => {
   });
 
   it('redirects to the default locale path when a localized page returns 404', async () => {
-    window.fetch = jest.fn().mockImplementationOnce(() => notFoundFetchResposne);
+    window.fetch = jest.fn().mockImplementationOnce(() => notFoundFetchResponse);
 
     await fetchDataForRouteEnter(localizedTo, from, next);
     expect(window.fetch).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Bug/issue #172836734, if applicable: 

## Summary

When a localized page (e.g. /zh-CN/documentation/...) returned a 404, the app would immediately show the not-found page without attempting to check if the content existed in the default locale.

Users navigating to a localized URL for untranslated content would see a 404 instead of being redirected to the available default locale version.

The fix adds a fallback step inside the 404 handler in fetchDataForRouteEnter. When the current locale differs from the default, it attempts to fetch the equivalent page with the locale prefix stripped from the path. If that fetch succeeds, it calls next() [1] with the fallback path to trigger a Vue Router navigation to the default locale page. If the fallback also fails, the error is logged to the console for debugging and the 404 page is shown as before.

The fallback path is derived by removing the locale segment from to.path (e.g. /zh-CN/documentation/foo becomes /documentation/foo), and the data path is verified via fetchData(createDataPath(fallbackPath)) before redirecting.

[1] https://v3.router.vuejs.org/guide/advanced/navigation-guards.html#global-before-guards

## Dependencies

NA

## Testing

Steps:
1. Download [SlothCreator.doccarchive.zip](https://github.com/user-attachments/files/26756075/SlothCreator.doccarchive.zip)
2. Run `VUE_APP_DEV_SERVER_PROXY=[path-to-doccarchive-file] npm run serve`
3. Go to http://localhost:8080/zh-CN/documentation/links and assert that it redirects to http://localhost:8080/documentation/links, since the JSON file only exists in English.
5. Go to http://localhost:8080/zh-CN/documentation/slothcreator and asserts that it shows "SlothCreator in Chinese" in the title, since the JSON file exists in English and Chinese.
6. Go to http://localhost:8080/zh-CN/documentation/nonexistingpage and asserts that it goes to the 404 page, since none of the JSON files exist.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
