### PR TITLE
[AX] Announce code block changes to screen readers in tutorial steps

### DIFF
--- a/src/components/Tutorial/SectionSteps.vue
+++ b/src/components/Tutorial/SectionSteps.vue
@@ -10,6 +10,11 @@
 
 <template>
   <div class="steps">
+    <div
+      aria-live="polite"
+      aria-atomic="true"
+      class="visuallyhidden"
+    >{{ stepAnnouncement }}</div>
     <div class="content-container">
       <component
         v-for="(node, index) in contentNodes"
@@ -107,6 +112,7 @@ export default {
         runtimePreview,
       },
       activeStep: firstStepIndex,
+      stepAnnouncement: '',
     };
   },
   computed: {
@@ -196,6 +202,17 @@ export default {
         media,
         runtimePreview,
       };
+
+      if (code) {
+        const stepNode = this.stepNodes.find(({ props }) => props.index === key);
+        if (stepNode) {
+          const { stepNumber } = stepNode.props;
+          this.stepAnnouncement = this.$t('tutorials.steps.code-updated', {
+            number: stepNumber,
+            total: this.numberOfSteps,
+          });
+        }
+      }
     },
     onRuntimePreviewToggle(value) {
       this.$emit('runtime-preview-toggle', value);

--- a/src/components/Tutorial/SectionSteps.vue
+++ b/src/components/Tutorial/SectionSteps.vue
@@ -157,6 +157,9 @@ export default {
       return this.tutorialState.breakpoint === BreakpointName.small;
     },
     stepNodes: ({ contentNodes, isStepNode }) => contentNodes.filter(isStepNode),
+    activeStepNode({ stepNodes, activeStep }) {
+      return stepNodes.find(({ props }) => props.index === activeStep);
+    },
     intersectionRootMargin: () => IntersectionMargins,
   },
   async mounted() {
@@ -203,15 +206,11 @@ export default {
         runtimePreview,
       };
 
-      if (code) {
-        const stepNode = this.stepNodes.find(({ props }) => props.index === key);
-        if (stepNode) {
-          const { stepNumber } = stepNode.props;
-          this.stepAnnouncement = this.$t('tutorials.steps.code-updated', {
-            number: stepNumber,
-            total: this.numberOfSteps,
-          });
-        }
+      if (code && this.activeStepNode) {
+        this.stepAnnouncement = this.$t('tutorials.code-updated', {
+          number: this.activeStepNode.props.stepNumber,
+          total: this.numberOfSteps,
+        });
       }
     },
     onRuntimePreviewToggle(value) {

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -41,9 +41,7 @@
     "question-of": "Question {index} of {total}",
     "section-of": "{number} of {total}",
     "overriding-title": "{newTitle} with {title}",
-    "steps": {
-      "code-updated": "Code updated for step {number} of {total}"
-    },
+    "code-updated": "Code updated for step {number} of {total}",
     "time": {
       "format": "{number} {minutes}",
       "minutes": {

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -41,6 +41,9 @@
     "question-of": "Question {index} of {total}",
     "section-of": "{number} of {total}",
     "overriding-title": "{newTitle} with {title}",
+    "steps": {
+      "code-updated": "Code updated for step {number} of {total}"
+    },
     "time": {
       "format": "{number} {minutes}",
       "minutes": {

--- a/src/lang/locales/ja-JP.json
+++ b/src/lang/locales/ja-JP.json
@@ -41,6 +41,9 @@
     "question-of": "{total}問中の{index}問",
     "section-of": "{total}件中の{number}件",
     "overriding-title": "{title}の{newTitle}",
+    "steps": {
+      "code-updated": "ステップ {number}/{total} のコードが更新されました"
+    },
     "time": {
       "format": "{number} {minutes}",
       "minutes": {

--- a/src/lang/locales/ja-JP.json
+++ b/src/lang/locales/ja-JP.json
@@ -41,9 +41,7 @@
     "question-of": "{total}問中の{index}問",
     "section-of": "{total}件中の{number}件",
     "overriding-title": "{title}の{newTitle}",
-    "steps": {
-      "code-updated": "ステップ {number}/{total} のコードが更新されました"
-    },
+    "code-updated": "ステップ {number}/{total} のコードが更新されました",
     "time": {
       "format": "{number} {minutes}",
       "minutes": {

--- a/src/lang/locales/ko-KR.json
+++ b/src/lang/locales/ko-KR.json
@@ -41,6 +41,9 @@
     "question-of": "총 {total}개 중 {index}번째 질문",
     "section-of": "{total} 중 {number}",
     "overriding-title": "{title}의 {newTitle}",
+    "steps": {
+      "code-updated": "총 {total}단계 중 {number}단계의 코드가 업데이트되었습니다"
+    },
     "time": {
       "format": "{number}{minutes}",
       "minutes": {

--- a/src/lang/locales/ko-KR.json
+++ b/src/lang/locales/ko-KR.json
@@ -41,9 +41,7 @@
     "question-of": "총 {total}개 중 {index}번째 질문",
     "section-of": "{total} 중 {number}",
     "overriding-title": "{title}의 {newTitle}",
-    "steps": {
-      "code-updated": "총 {total}단계 중 {number}단계의 코드가 업데이트되었습니다"
-    },
+    "code-updated": "총 {total}단계 중 {number}단계의 코드가 업데이트되었습니다",
     "time": {
       "format": "{number}{minutes}",
       "minutes": {

--- a/src/lang/locales/zh-CN.json
+++ b/src/lang/locales/zh-CN.json
@@ -41,6 +41,9 @@
     "question-of": "第 {index} 个问题（共 {total} 个）",
     "section-of": "{number}/{total}",
     "overriding-title": "{newTitle}{title}",
+    "steps": {
+      "code-updated": "步骤 {number}（共 {total} 步）的代码已更新"
+    },
     "time": {
       "format": "{number} {minutes}",
       "minutes": {

--- a/src/lang/locales/zh-CN.json
+++ b/src/lang/locales/zh-CN.json
@@ -41,9 +41,7 @@
     "question-of": "第 {index} 个问题（共 {total} 个）",
     "section-of": "{number}/{total}",
     "overriding-title": "{newTitle}{title}",
-    "steps": {
-      "code-updated": "步骤 {number}（共 {total} 步）的代码已更新"
-    },
+    "code-updated": "步骤 {number}（共 {total} 步）的代码已更新",
     "time": {
       "format": "{number} {minutes}",
       "minutes": {

--- a/tests/unit/components/Tutorial/SectionSteps.spec.js
+++ b/tests/unit/components/Tutorial/SectionSteps.spec.js
@@ -336,10 +336,8 @@ describe('SectionSteps', () => {
       wrapper.vm.onIntersect({ target: target(2), isIntersecting: true });
       await wrapper.vm.$nextTick();
 
-      const liveRegion = wrapper.find('[aria-live="polite"]');
-      expect(liveRegion.exists()).toBe(true);
       // $t mock returns 'key number total'
-      expect(wrapper.vm.stepAnnouncement).toBe('tutorials.steps.code-updated 2 5');
+      expect(wrapper.find('[aria-live="polite"]').text()).toBe('tutorials.code-updated 2 5');
     });
 
     it('does not announce when a step with only media becomes active', async () => {
@@ -347,7 +345,7 @@ describe('SectionSteps', () => {
       wrapper.vm.onIntersect({ target: target(1), isIntersecting: true });
       await wrapper.vm.$nextTick();
 
-      expect(wrapper.vm.stepAnnouncement).toBe('');
+      expect(wrapper.find('[aria-live="polite"]').text()).toBe('');
     });
   });
 

--- a/tests/unit/components/Tutorial/SectionSteps.spec.js
+++ b/tests/unit/components/Tutorial/SectionSteps.spec.js
@@ -330,6 +330,27 @@ describe('SectionSteps', () => {
     });
   });
 
+  describe('aria-live announcements', () => {
+    it('announces code block updates when a step with code becomes active', async () => {
+      // step at index 2 has code (exampleStepWithCode, stepNumber 2 of 5)
+      wrapper.vm.onIntersect({ target: target(2), isIntersecting: true });
+      await wrapper.vm.$nextTick();
+
+      const liveRegion = wrapper.find('[aria-live="polite"]');
+      expect(liveRegion.exists()).toBe(true);
+      // $t mock returns 'key number total'
+      expect(wrapper.vm.stepAnnouncement).toBe('tutorials.steps.code-updated 2 5');
+    });
+
+    it('does not announce when a step with only media becomes active', async () => {
+      // step at index 1 has media only (exampleStepWithMedia)
+      wrapper.vm.onIntersect({ target: target(1), isIntersecting: true });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.stepAnnouncement).toBe('');
+    });
+  });
+
   describe('when a code step is active', () => {
     const key = 2;
 


### PR DESCRIPTION
## Summary

Closes #949

When a tutorial step with a code block scrolls into view, screen readers were not notified of the change. This made it difficult or impossible for assistive technology users to follow tutorial code along as they scrolled through steps.

### Changes

- **`src/components/Tutorial/SectionSteps.vue`**: Adds a visually-hidden `aria-live="polite" aria-atomic="true"` region. When `onFocus(key)` is called for a step that has a code block, the region is updated with an announcement string ("Code updated for step N of M"), which is immediately read aloud by screen readers.
- **`src/lang/locales/en-US.json`** (and ja-JP, ko-KR, zh-CN): Adds the `tutorials.steps.code-updated` i18n key used by the announcement.
- **`tests/unit/components/Tutorial/SectionSteps.spec.js`**: Adds two tests — one verifying the announcement fires for code steps, one verifying it does not fire for media-only steps.

## Test plan

- [ ] Run `npm run test:unit` — all 20 `SectionSteps` tests pass
- [ ] Navigate a tutorial page using VoiceOver/NVDA — confirm "Code updated for step N of M" is announced when scrolling to a step with a code block
- [ ] Confirm media-only steps produce no announcement