### PR TITLE
[AX] Add keyboard navigation wrap-around tests to QuickNavigationModal

### DIFF
--- a/tests/unit/components/Navigator/QuickNavigationModal.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationModal.spec.js
@@ -470,14 +470,12 @@ describe('QuickNavigationModal', () => {
     it('pressing Down on the last item wraps focus back to the first item', async () => {
       await wrapper.setData({ focusedIndex: wrapper.vm.totalItemsToNavigate - 1 });
       wrapper.vm.focusNext({});
-      await wrapper.vm.$nextTick();
       expect(wrapper.vm.focusedIndex).toBe(0);
     });
 
     it('pressing Up on the first item wraps focus to the last item', async () => {
       await wrapper.setData({ focusedIndex: 0 });
       wrapper.vm.focusPrev({});
-      await wrapper.vm.$nextTick();
       expect(wrapper.vm.focusedIndex).toBe(wrapper.vm.totalItemsToNavigate - 1);
     });
 
@@ -490,7 +488,6 @@ describe('QuickNavigationModal', () => {
     it('handleDownKeyInput focuses the first result item', async () => {
       await wrapper.setData({ focusedIndex: 2 });
       wrapper.vm.handleDownKeyInput();
-      await wrapper.vm.$nextTick();
       expect(wrapper.vm.focusedIndex).toBe(0);
     });
   });

--- a/tests/unit/components/Navigator/QuickNavigationModal.spec.js
+++ b/tests/unit/components/Navigator/QuickNavigationModal.spec.js
@@ -447,6 +447,54 @@ describe('QuickNavigationModal', () => {
     });
   });
 
+  describe('keyboard navigation', () => {
+    beforeEach(async () => {
+      await wrapper.setData({ debouncedInput: inputValue });
+      // Suppress DOM calls that require a real browser environment
+      jest.spyOn(wrapper.vm, 'scrollIntoView').mockImplementation(() => {});
+      jest.spyOn(wrapper.vm, 'focusReference').mockImplementation(() => {});
+    });
+
+    it('pressing Down moves focus to the next item', async () => {
+      await wrapper.setData({ focusedIndex: 0 });
+      wrapper.vm.focusNext({});
+      expect(wrapper.vm.focusedIndex).toBe(1);
+    });
+
+    it('pressing Up moves focus to the previous item', async () => {
+      await wrapper.setData({ focusedIndex: 1 });
+      wrapper.vm.focusPrev({});
+      expect(wrapper.vm.focusedIndex).toBe(0);
+    });
+
+    it('pressing Down on the last item wraps focus back to the first item', async () => {
+      await wrapper.setData({ focusedIndex: wrapper.vm.totalItemsToNavigate - 1 });
+      wrapper.vm.focusNext({});
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.focusedIndex).toBe(0);
+    });
+
+    it('pressing Up on the first item wraps focus to the last item', async () => {
+      await wrapper.setData({ focusedIndex: 0 });
+      wrapper.vm.focusPrev({});
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.focusedIndex).toBe(wrapper.vm.totalItemsToNavigate - 1);
+    });
+
+    it('does not move focus when metaKey and shiftKey are held', async () => {
+      await wrapper.setData({ focusedIndex: 1 });
+      wrapper.vm.focusNext({ metaKey: true, shiftKey: true });
+      expect(wrapper.vm.focusedIndex).toBe(1);
+    });
+
+    it('handleDownKeyInput focuses the first result item', async () => {
+      await wrapper.setData({ focusedIndex: 2 });
+      wrapper.vm.handleDownKeyInput();
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.focusedIndex).toBe(0);
+    });
+  });
+
   describe('initialFilterText prop', () => {
     it('seeds userInput from initialFilterText', () => {
       const w = shallowMount(QuickNavigationModal, {


### PR DESCRIPTION
## Summary

Relates to #412

The Quick Navigation modal already implements keyboard wrap-around via `startingPointHook` (Up from first → last) and `endingPointHook` (Down from last → first) in `QuickNavigationModal.vue`. However, these critical accessibility behaviors had **zero test coverage**, leaving them vulnerable to silent regression.

### Changes

- **`tests/unit/components/Navigator/QuickNavigationModal.spec.js`**: Adds a new `keyboard navigation` describe block with six tests:
  - Down moves to the next item
  - Up moves to the previous item
  - **Down on the last item wraps back to the first** (regression guard for #412)
  - **Up on the first item wraps to the last** (regression guard for #412)
  - Modifier-key guard (metaKey + shiftKey prevents movement)
  - `handleDownKeyInput` focuses the first result when called from the search input

## Test plan

- [ ] Run `npm run test:unit` — all 32 `QuickNavigationModal` tests pass
- [ ] Open the quick navigation modal (press `/`), type a query, and use arrow keys to verify wrap-around works end-to-end