### PR TITLE
[6.4] Support overviewCard block content

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -31,6 +31,7 @@ import TaskList from './ContentNode/TaskList.vue';
 import LinksBlock from './ContentNode/LinksBlock.vue';
 import DeviceFrame from './ContentNode/DeviceFrame.vue';
 import ThematicBreak from './ContentNode/ThematicBreak.vue';
+import OverviewCard from './ContentNode/OverviewCard.vue';
 
 const { CaptionPosition, CaptionTag } = Caption.constants;
 
@@ -51,6 +52,7 @@ export const BlockType = {
   tabNavigator: 'tabNavigator',
   links: 'links',
   thematicBreak: 'thematicBreak',
+  overviewCard: 'overviewCard',
 };
 
 const InlineType = {
@@ -428,6 +430,14 @@ function renderNode(createElement, references) {
     }
     case BlockType.thematicBreak:
       return createElement(ThematicBreak);
+    case BlockType.overviewCard:
+      return createElement(OverviewCard, {}, ([
+        ...renderChildren(node.head ?? []).map(vnode => ({
+          ...vnode,
+          data: { ...vnode.data, slot: 'head' },
+        })),
+        ...renderChildren(node.content),
+      ]));
     case InlineType.codeVoice:
       return createElement(CodeVoice, {
         class: 'inline-code',

--- a/src/components/ContentNode/OverviewCard.vue
+++ b/src/components/ContentNode/OverviewCard.vue
@@ -1,0 +1,58 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2026 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+<template>
+  <article class="overviewcard">
+    <header v-if="$slots.head" class="overviewcard-head">
+      <slot name="head" />
+    </header>
+    <div class="overviewcard-content">
+      <slot />
+    </div>
+  </article>
+</template>
+
+<script>
+export default {
+  name: 'OverviewCard',
+};
+</script>
+
+<style scoped lang="scss">
+@import 'docc-render/styles/_core.scss';
+
+.overviewcard {
+  --overviewcard-border-radius: #{$border-radius};
+  --overviewcard-border-style: solid;
+  --overviewcard-border-width: 1px;
+  --overviewcard-color-border: var(--color-fill);
+  --overviewcard-color-content: var(--color-fill-secondary);
+  --overviewcard-color-head: var(--color-fill-tertiary);
+
+  background: var(--overviewcard-color-content);
+  border:
+    var(--overviewcard-border-width)
+    var(--overviewcard-border-style)
+    var(--overviewcard-color-border);
+  border-radius: var(--overviewcard-border-radius);
+
+  @include space-out-between-siblings(var(--spacing-stacked-margin-xlarge));
+
+  & > * {
+    padding: 20px;
+  }
+
+  &-head {
+    background: var(--overviewcard-color-head);
+    border-start-start-radius: inherit;
+    border-start-end-radius: inherit;
+  }
+}
+</style>

--- a/tests/unit/components/ContentNode/OverviewCard.spec.js
+++ b/tests/unit/components/ContentNode/OverviewCard.spec.js
@@ -1,0 +1,41 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2026 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import { shallowMount } from '@vue/test-utils';
+import OverviewCard from 'docc-render/components/ContentNode/OverviewCard.vue';
+
+describe('OverviewCard', () => {
+  it('renders slot content', () => {
+    const wrapper = shallowMount(OverviewCard, {
+      slots: {
+        head: '<h3>foobar</h3>',
+        default: '<p>qux</p>',
+      },
+    });
+    expect(wrapper.classes('overviewcard')).toBe(true);
+
+    const head = wrapper.find('.overviewcard-head');
+    expect(head.exists()).toBe(true);
+    expect(head.text()).toBe('foobar');
+
+    const content = wrapper.find('.overviewcard-content');
+    expect(content.exists()).toBe(true);
+    expect(content.text()).toBe('qux');
+  });
+
+  it('does not render header if no head slot is provided', () => {
+    const wrapper = shallowMount(OverviewCard, {
+      slots: {
+        default: '<p>foobar</p>',
+      },
+    });
+    expect(wrapper.find('.overviewcard-head').exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
**Explanation**: Adds support for rendering block content nodes of `overviewCard` type
**Scope**: Markdown content rendering
**Issue**: rdar://173272119
**Risk**: Low, only added code paths, no major modifications to existing code
**Testing**: Added unit tests
**Reviewer**: @marinaaisa 
**Original PR**: #1004 