### PR TITLE
Allow configurable colors for overviewcard

### DIFF
--- a/src/components/ContentNode/OverviewCard.vue
+++ b/src/components/ContentNode/OverviewCard.vue
@@ -32,9 +32,9 @@ export default {
   --overviewcard-border-radius: #{$border-radius};
   --overviewcard-border-style: solid;
   --overviewcard-border-width: 1px;
-  --overviewcard-color-border: var(--color-fill);
-  --overviewcard-color-content: var(--color-fill-secondary);
-  --overviewcard-color-head: var(--color-fill-tertiary);
+  --overviewcard-color-border: var(--color-overviewcard-border);
+  --overviewcard-color-content: var(--color-overviewcard-fill);
+  --overviewcard-color-head: var(--color-overviewcard-fill-secondary);
 
   background: var(--overviewcard-color-content);
   border:

--- a/src/styles/core/colors/_light.scss
+++ b/src/styles/core/colors/_light.scss
@@ -136,6 +136,9 @@
   --color-nav-dark-uiblur-stuck: #{change-color(dark-color(fill-tertiary), $alpha: 0.7)};
   --color-nav-dark-root-subhead: #{dark-color(tutorials-teal)};
   --color-other-decl-button: var(--color-text-background);
+  --color-overviewcard-border: var(--color-fill);
+  --color-overviewcard-fill: var(--color-fill-secondary);
+  --color-overviewcard-fill-secondary: var(--color-fill-tertiary);
   --color-runtime-preview-background: var(--color-fill-tertiary);
   --color-runtime-preview-disabled-text: #{change-color(light-color(figure-gray-secondary), $alpha: 0.6)};
   --color-runtime-preview-text: var(--color-figure-gray-secondary);


### PR DESCRIPTION
Bug/issue #, if applicable: 176285129

## Summary

This adds 3 global color variables that can be used to more easily configure colors for the overviewcard component.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS-only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
