### PR TITLE
Add below-abstract slot to DocumentationTopic for content injection

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -61,6 +61,7 @@
           :class="{ 'minimized-abstract': enableMinimized }"
           :content="abstract"
         />
+        <slot name="below-abstract" />
         <div v-if="sampleCodeDownload">
           <DownloadButton
             class="sample-download"

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -1121,6 +1121,19 @@ describe('DocumentationTopic', () => {
     expect(wrapper.find('.above-hero-content').exists()).toBe(true);
   });
 
+  it('renders content in the `below-abstract` slot', () => {
+    wrapper = shallowMount(DocumentationTopic, {
+      propsData,
+      slots: {
+        'below-abstract': '<div class="below-abstract">Below Abstract Content</div>',
+      },
+      provide: {
+        store: mockStore,
+      },
+    });
+    expect(wrapper.findComponent(DocumentationHero).find('.below-abstract').exists()).toBe(true);
+  });
+
   it('renders `OnThisPageNav` component, if enabled via prop', async () => {
     expect(wrapper.findComponent(OnThisPageNav).exists()).toBe(false);
     expect(wrapper.findComponent(OnThisPageStickyContainer).exists()).toBe(false);


### PR DESCRIPTION
Bug/issue #176906827, if applicable: 

## Summary

Without a slot between the Abstract and the elements that follow it, consumers of DocumentationTopic have no way to inject custom content immediately after the page description. The only option would be to override or fork the entire component, which is fragile and breaks on upstream updates.

A new named slot `below-abstract` [1] is added directly after the `Abstract` component and before the `v-if="sampleCodeDownload"` div. This placement means content projected into the slot appears below the page description but above the download button, availability badges, and declarations, keeping it logically grouped within the introductory part of the hero without interfering with any of the surrounding conditionally rendered elements.

A test is added to verify that content projected into the slot is rendered inside the DocumentationHero component at the expected location.

[1] https://vuejs.org/guide/components/slots#named-slots

## Dependencies

NA

## Testing

Steps:
1. Extend the DocumentationTopic.vue component adding a slot with name `below-abstract`
2. Assert that it renders as expected

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
