### PR TITLE
Add support for optional alignment property on row columns

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -399,7 +399,9 @@ function renderNode(createElement, references) {
       return createElement(
         Row, { props: { columns } }, node.columns.map(col => (
           createElement(
-            Column, { props: { span: col.size } }, renderChildren(col.content),
+            Column,
+            { props: { span: col.size, alignment: col.alignment } },
+            renderChildren(col.content),
           )
         )),
       );

--- a/src/components/ContentNode/Column.vue
+++ b/src/components/ContentNode/Column.vue
@@ -30,6 +30,7 @@ export default {
     alignment: {
       type: String,
       default: null,
+      validator: v => Object.hasOwn(AlignmentMap, v) || v === null,
     },
   },
   computed: {

--- a/src/components/ContentNode/Column.vue
+++ b/src/components/ContentNode/Column.vue
@@ -14,6 +14,12 @@
 </template>
 
 <script>
+const AlignmentMap = {
+  leading: 'flex-start',
+  center: 'center',
+  trailing: 'flex-end',
+};
+
 export default {
   name: 'Column',
   props: {
@@ -21,9 +27,16 @@ export default {
       type: Number,
       default: null,
     },
+    alignment: {
+      type: String,
+      default: null,
+    },
   },
   computed: {
-    style: ({ span }) => ({ '--col-span': span }),
+    style: ({ span, alignment }) => ({
+      '--col-span': span,
+      '--col-alignment': AlignmentMap[alignment] || null,
+    }),
   },
 };
 </script>
@@ -32,6 +45,9 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .column {
+  display: flex;
+  flex-direction: column;
+  align-items: var(--col-alignment, flex-start);
   grid-column: span var(--col-span);
   min-width: 0;
   @include breakpoint(small) {

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -514,9 +514,9 @@ describe('ContentNode', () => {
       });
       const columns = grid.findAllComponents(Column);
       expect(columns).toHaveLength(2);
-      expect(columns.at(0).props()).toEqual({ span: 2 });
+      expect(columns.at(0).props()).toEqual({ span: 2, alignment: null });
       expect(columns.at(0).find('p').text()).toBe('foo');
-      expect(columns.at(1).props()).toEqual({ span: null });
+      expect(columns.at(1).props()).toEqual({ span: null, alignment: null });
       expect(columns.at(1).find('p').text()).toBe('bar');
     });
     it('renders a `<Row>` without column count specified', () => {
@@ -558,10 +558,40 @@ describe('ContentNode', () => {
       });
       const columns = grid.findAllComponents(Column);
       expect(columns).toHaveLength(2);
-      expect(columns.at(0).props()).toEqual({ span: 2 });
+      expect(columns.at(0).props()).toEqual({ span: 2, alignment: null });
       expect(columns.at(0).find('p').text()).toBe('foo');
-      expect(columns.at(1).props()).toEqual({ span: null });
+      expect(columns.at(1).props()).toEqual({ span: null, alignment: null });
       expect(columns.at(1).find('p').text()).toBe('bar');
+    });
+
+    it('renders columns with alignment', () => {
+      const col = (size, alignment, text) => ({
+        size,
+        alignment,
+        content: [
+          {
+            type: 'paragraph',
+            inlineContent: [{ type: 'text', text }],
+          },
+        ],
+      });
+      const wrapper = mountWithItem({
+        type: 'row',
+        numberOfColumns: 4,
+        columns: [
+          col(1, null, 'foo'),
+          col(1, 'leading', 'bar'),
+          col(1, 'center', 'baz'),
+          col(1, 'trailing', 'qux'),
+        ],
+      });
+      const grid = wrapper.findComponent(Row);
+      const columns = grid.findAllComponents(Column);
+      expect(columns).toHaveLength(4);
+      expect(columns.at(0).props()).toEqual({ span: 1, alignment: null });
+      expect(columns.at(1).props()).toEqual({ span: 1, alignment: 'leading' });
+      expect(columns.at(2).props()).toEqual({ span: 1, alignment: 'center' });
+      expect(columns.at(3).props()).toEqual({ span: 1, alignment: 'trailing' });
     });
   });
 

--- a/tests/unit/components/ContentNode/Column.spec.js
+++ b/tests/unit/components/ContentNode/Column.spec.js
@@ -37,17 +37,20 @@ describe('Column', () => {
     });
 
     it('applies leading alignment', async () => {
-      const wrapper = createWrapper({ props: { alignment: 'leading' } });
+      const wrapper = createWrapper();
+      await wrapper.setProps({ alignment: 'leading' });
       expect(wrapper.vm.style).toHaveProperty('--col-alignment', 'flex-start');
     });
 
     it('applies center alignment', async () => {
-      const wrapper = createWrapper({ props: { alignment: 'center' } });
+      const wrapper = createWrapper();
+      await wrapper.setProps({ alignment: 'center' });
       expect(wrapper.vm.style).toHaveProperty('--col-alignment', 'center');
     });
 
     it('applies trailing alignment', async () => {
-      const wrapper = createWrapper({ props: { alignment: 'trailing' } });
+      const wrapper = createWrapper();
+      await wrapper.setProps({ alignment: 'trailing' });
       expect(wrapper.vm.style).toHaveProperty('--col-alignment', 'flex-end');
     });
   });

--- a/tests/unit/components/ContentNode/Column.spec.js
+++ b/tests/unit/components/ContentNode/Column.spec.js
@@ -29,4 +29,26 @@ describe('Column', () => {
     });
     expect(wrapper.vm.style).toHaveProperty('--col-span', 5);
   });
+
+  describe('alignment', () => {
+    it('defaults to null when no alignment is set', () => {
+      const wrapper = createWrapper();
+      expect(wrapper.vm.style).toHaveProperty('--col-alignment', null);
+    });
+
+    it('applies leading alignment', async () => {
+      const wrapper = createWrapper({ props: { alignment: 'leading' } });
+      expect(wrapper.vm.style).toHaveProperty('--col-alignment', 'flex-start');
+    });
+
+    it('applies center alignment', async () => {
+      const wrapper = createWrapper({ props: { alignment: 'center' } });
+      expect(wrapper.vm.style).toHaveProperty('--col-alignment', 'center');
+    });
+
+    it('applies trailing alignment', async () => {
+      const wrapper = createWrapper({ props: { alignment: 'trailing' } });
+      expect(wrapper.vm.style).toHaveProperty('--col-alignment', 'flex-end');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

This PR implements alignment rendering for the `@Column` directive in swift-docc-render, enabling documentation authors to control how content aligns within columns.

The feature adds support for the optional `alignment` parameter on columns, accepting `leading`, `center`, or `trailing` values. These values are mapped to CSS flex alignment properties (`flex-start`, `center`, `flex-end`).

### Implementation Overview

- Updates `ContentNode.vue` to pass the `alignment` property from the semantic model to the `Column` component
- Introduces `AlignmentMap` in `Column.vue` to convert Swift alignment values to CSS flex equivalents:
  - `leading` → `flex-start` (default behavior)
  - `center` → `center`
  - `trailing` → `flex-end`
- Modifies the column layout to use flexbox with `display: flex` and `flex-direction: column` to enable alignment via `align-items`
- Applies alignment through CSS custom property `--col-alignment` with a fallback to `flex-start`

## Dependencies

This PR depends on the corresponding swift-docc changes that parse and expose the alignment parameter (https://github.com/swiftlang/swift-docc/pull/1530).

## Testing

Follow testing instructions in the linked swift-docc PR.

## Checklist

- [x] Added tests (5 new test cases for alignment behavior)
- [x] Ran `npm test`, and it succeeded
- [n/a] Updated documentation if necessary (alignment support is documented in swift-docc semantic layer)