### PR TITLE
Make Aside label customisable via a named slot

### DIFF
--- a/src/components/ContentNode/Aside.vue
+++ b/src/components/ContentNode/Aside.vue
@@ -10,7 +10,9 @@
 
 <template>
   <aside :class="kind" :aria-label="kind">
-    <p class="label">{{ name || $t(label) }}</p>
+    <slot name="label">
+      <p class="label">{{ name || $t(label) }}</p>
+    </slot>
     <slot />
   </aside>
 </template>

--- a/tests/unit/components/ContentNode/Aside.spec.js
+++ b/tests/unit/components/ContentNode/Aside.spec.js
@@ -59,6 +59,20 @@ describe('Aside', () => {
     expect(label.text()).toBe('Custom Name');
   });
 
+  it('renders a default label slot that can be overridden with custom content', () => {
+    const wrapper = shallowMount(Aside, {
+      propsData: {
+        kind: 'note',
+      },
+      slots: {
+        label: '<span class="custom-label">My Label</span>',
+        default: '<p>content</p>',
+      },
+    });
+    expect(wrapper.find('.label').exists()).toBe(false);
+    expect(wrapper.find('.custom-label').text()).toBe('My Label');
+  });
+
   it('renders slot content', () => {
     const wrapper = shallowMount(Aside, {
       propsData: {


### PR DESCRIPTION
Bug/issue #176906827, if applicable: 

## Summary

The label rendered inside the Aside component was hardcoded as a plain `<p class="label">` element with no extension point. Any consuming component that needed a different label presentation, or no label at all, had no way to achieve that without adding a new special-cased prop or a new kind value just to toggle the element off.

Vue's named slots with fallback content [1] are the best solution here: the slot renders its default content when the parent provides nothing, preserving all existing behaviour exactly as before, while still giving any consumer the freedom to supply its own label markup or suppress the label entirely by providing a non-rendering element (e.g. `<span />`) in the `#label` slot.

The `<p class="label">` is now wrapped in `<slot name="label">…</slot>` so that it continues to act as the default for every current usage of `<Aside>` (ContentNode, DocumentationTopic, etc.), and a new test documents and verifies the override path.

## Dependencies

NA

## Testing

Steps:
1. Assert that the Aside component renders as expected.
2. Create a new component on top of this Aside component with a `label` slot and assert that it overwrites the slot.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
